### PR TITLE
Handle object and list matches for jsonpath expressions

### DIFF
--- a/grizzly/transformer.py
+++ b/grizzly/transformer.py
@@ -6,7 +6,7 @@ import re
 from abc import ABCMeta
 from typing import Tuple, Any, Dict, Type, List, Callable
 from functools import wraps
-from json import loads as jsonloads, JSONEncoder
+from json import loads as jsonloads, dumps as jsondumps, JSONEncoder
 
 from jsonpath_ng.ext import parse as jsonpath_parse
 from lxml import etree as XML
@@ -86,7 +86,19 @@ class JsonTransformer(Transformer):
             jsonpath = jsonpath_parse(expression)
 
             def get_values(input_payload: Any) -> List[str]:
-                return [str(m.value) for m in jsonpath.find(input_payload) if m.value is not None]
+                values: List[str] = []
+                for m in jsonpath.find(input_payload):
+                    if m.value is None:
+                        continue
+
+                    if isinstance(m.value, (dict, list, )):
+                        value = jsondumps(m.value)
+                    else:
+                        value = str(m.value)
+
+                    values.append(value)
+
+                return values
 
             return get_values
         except Exception as e:

--- a/tests/test_grizzly/test_transformer.py
+++ b/tests/test_grizzly/test_transformer.py
@@ -1,5 +1,5 @@
 from typing import List, Tuple, Any
-from json import dumps as jsondumps
+from json import dumps as jsondumps, loads as jsonloads
 from json.decoder import JSONDecodeError
 
 import pytest
@@ -184,12 +184,13 @@ class TestJsonTransformer:
         get_values = JsonTransformer.parser('$.*..title')
         actual = get_values(example)
         assert len(actual) == 2
-        assert ['example glossary', 'S']
+        assert ['example glossary', 'S'] == actual
 
         get_values = JsonTransformer.parser('$.*..GlossSeeAlso')
         actual = get_values(example)
         assert len(actual) == 1
-        assert ["['GML', 'XML']"] == actual
+        assert ['["GML", "XML"]'] == actual
+        assert jsonloads(actual[0]) == ['GML', 'XML']
 
         get_values = JsonTransformer.parser('$.*..GlossSeeAlso[*]')
         actual = get_values(example)

--- a/tests/test_grizzly/test_utils.py
+++ b/tests/test_grizzly/test_utils.py
@@ -324,6 +324,99 @@ def test_generate_save_handler(locust_environment: Environment) -> None:
     with pytest.raises(ResponseHandlerError):
         handler((ResponseContentType.JSON, {'test': [{'value': 'test'}, {'value': 'test'}]}), user, None)
 
+    # save object dict
+    handler = generate_save_handler(
+        '$.test.prop2',
+        '.*',
+        'test_object',
+    )
+
+    handler(
+        (
+            ResponseContentType.JSON,
+            {
+                'test': {
+                    'prop1': 'value1',
+                    'prop2': {
+                        'prop21': False,
+                        'prop22': 100,
+                        'prop23': {
+                            'prop231': True,
+                            'prop232': 'hello',
+                            'prop233': 'world!',
+                            'prop234': 200,
+                        },
+                    },
+                    'prop3': 'value3',
+                    'prop4': [
+                        'prop41',
+                        True,
+                        'prop42',
+                        300,
+                    ],
+                }
+            }
+        ),
+        user,
+        response_context_manager,
+    )
+
+    test_object = user.context_variables.get('test_object', None)
+    assert json.loads(test_object) == {
+        'prop21': False,
+        'prop22': 100,
+        'prop23': {
+            'prop231': True,
+            'prop232': 'hello',
+            'prop233': 'world!',
+            'prop234': 200,
+        },
+    }
+
+    # save object list
+    handler = generate_save_handler(
+        '$.test.prop4',
+        '.*',
+        'test_list',
+    )
+
+    handler(
+        (
+            ResponseContentType.JSON,
+            {
+                'test': {
+                    'prop1': 'value1',
+                    'prop2': {
+                        'prop21': False,
+                        'prop22': 100,
+                        'prop23': {
+                            'prop231': True,
+                            'prop232': 'hello',
+                            'prop233': 'world!',
+                            'prop234': 200,
+                        },
+                    },
+                    'prop3': 'value3',
+                    'prop4': [
+                        'prop41',
+                        True,
+                        'prop42',
+                        300,
+                    ],
+                }
+            }
+        ),
+        user,
+        response_context_manager,
+    )
+
+    test_list = user.context_variables.get('test_list', None)
+    assert json.loads(test_list) == [
+        'prop41',
+        True,
+        'prop42',
+        300,
+    ]
 
 
 @pytest.mark.usefixtures('locust_environment')


### PR DESCRIPTION
Return the match as a json string, instead of the python string representation.