### PR TITLE
handle Getitem nodes when parsing templates for variables

### DIFF
--- a/grizzly/testdata/ast.py
+++ b/grizzly/testdata/ast.py
@@ -4,7 +4,7 @@ from typing import Set, Optional, List, Dict, Tuple, Union, cast
 
 import jinja2 as j2
 
-from jinja2.nodes import Getattr, Name
+from jinja2.nodes import Getattr, Getitem, Name
 
 from ..context import RequestContext
 
@@ -101,6 +101,9 @@ def _parse_templates(requests: RequestSourceMapping) -> Dict[str, Set[str]]:
 
                         if isinstance(node, Getattr):
                             attributes = walk_attr(node)
+                        elif isinstance(node, Getitem):
+                            child_node = getattr(node, 'node')
+                            attributes = [getattr(child_node, 'name')]
                         elif isinstance(node, Name):
                             attributes = [getattr(node, 'name')]
 

--- a/tests/test_grizzly/testdata/test_ast.py
+++ b/tests/test_grizzly/testdata/test_ast.py
@@ -26,6 +26,8 @@ def test__parse_template(request_context: Tuple[str, str, RequestContext]) -> No
     source['result']['CsvRowValue1'] = '{{ AtomicCsvRow.test.header1 }}'
     source['result']['CsvRowValue2'] = '{{ AtomicCsvRow.test.header2 }}'
     source['result']['File'] = '{{ AtomicDirectoryContents.test }}'
+    source['result']['TestSubString'] = '{{ a_sub_string[:3] }}'
+    source['result']['TestString'] = '{{ a_string }}'
 
     request.source = jsondumps(source)
     request.template = Template(request.source)
@@ -37,13 +39,15 @@ def test__parse_template(request_context: Tuple[str, str, RequestContext]) -> No
     variables = _parse_templates(templates)
 
     assert 'TestScenario' in variables
-    assert len(variables['TestScenario']) == 6
+    assert len(variables['TestScenario']) == 8
     assert 'messageID' in variables['TestScenario']
     assert 'AtomicIntegerIncrementer.messageID' in variables['TestScenario']
     assert 'AtomicDate.now' in variables['TestScenario']
     assert 'AtomicCsvRow.test.header1' in variables['TestScenario']
     assert 'AtomicCsvRow.test.header2' in variables['TestScenario']
     assert 'AtomicDirectoryContents.test' in variables['TestScenario']
+    assert 'a_sub_string' in variables['TestScenario']
+    assert 'a_string' in variables['TestScenario']
 
 
 @pytest.mark.usefixtures('request_context_syntax_error')


### PR DESCRIPTION
an example, {{ variable[0:3] }}. before this fix variable was not added as a
variable to the scenario unless it was used elsewhere without "Getitem".