### PR TITLE
fixing empty changelog in workflow@github

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,6 +54,9 @@ jobs:
 
     - name: checkout
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        ref: main
 
     - name: get last released version
       if: github.event.inputs.version == '0.0.0'

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ coverage.xml
 *.kdb
 *.rdb
 *.sth
-event.json
+*.event
 .env/
 .venv/
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ astunparse==1.6.3
 mkdocs==1.2.3
 mkdocs-material==7.3.4
 mypy==0.910
-pip-licenses==3.5.2
+pip-licenses==3.5.3
 pydoc-markdown==4.3.2
 pylint==2.11.1
 pytablewriter==0.63.0

--- a/script/docs-generate-changelog.py
+++ b/script/docs-generate-changelog.py
@@ -11,11 +11,15 @@ def main() -> int:
     tags = output.split('\n')
     tags.sort(reverse=True)
 
+    print(f'{tags=}')
+
     with open(path.join(base_directory, 'changelog.md'), 'w') as fd:
         fd.write('# Changelog\n\n')
 
         for index, previous_tag in enumerate(tags[1:], start=1):
             current_tag = tags[index-1]
+            print(f'generating changelog for {current_tag} <- {previous_tag}')
+
             output = subprocess.check_output([
                 'git',
                 'log',


### PR DESCRIPTION
action checkout@v2 does a shallow checkout by default, so no tags will be fetched.

this resulted in "autobump version" and scripts/docs-generate-changelog.py not working, since both depends on having information about existing tags.