### PR TITLE
new task type to extract values from other variables

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -19,43 +19,52 @@ jobs:
 
     steps:
     - name: setup python
+      id: setup
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: checkout
+      id: checkout
       uses: actions/checkout@v2
 
     - name: setup environment
+      id: env
       run: |
         sudo ln -fs /usr/share/zoneinfo/Europe/Stockholm /etc/localtime
         sudo ln -fs /usr/share/zoneinfo/Europe/Stockholm /etc/timezone
         echo $HOME/.local/bin >> $GITHUB_PATH
 
     - name: cache python environment
+      id: cache
       uses: actions/cache@v2
       with:
         path: ${{ env.pythonLocation }}
         key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt')}}
 
     - name: install python dependencies
+      id: pip
       run: |
         pip install --upgrade wheel
         pip install --upgrade --upgrade-strategy eager -r <(cat requirements.txt requirements-dev.txt)
 
     - name: run pytest
+      id: pytest
       run: |
         pytest
 
     - name: run coverage
+      id: coverage
       run: |
         coverage report --omit=**/*messagequeue* --fail-under=95
 
     - name: run pylint
+      id: pylint
       run: |
         pylint --jobs=0 --fail-under=10 grizzly/ grizzly_extras/ tests/ example/
 
     - name: run mypy
+      id: mypy
       run: |
         arguments="$(sed '/^[ \t]*\/\/.*/d;/^$/d' .devcontainer/devcontainer.json | jq '.settings["python.linting.mypyArgs"] | join(" ")' | awk -F\" '{print $2}')"
         mypy ${arguments} grizzly/ grizzly_extras/ tests/ example/

--- a/grizzly/context.py
+++ b/grizzly/context.py
@@ -10,6 +10,7 @@ import yaml
 
 from behave.model import Scenario
 from locust.user.sequential_taskset import SequentialTaskSet
+from locust.env import Environment
 
 from .types import GrizzlyDict
 
@@ -77,6 +78,7 @@ class GrizzlyContextState:
     configuration: Dict[str, Any] = field(init=False, default_factory=load_configuration_file)
     alias: Dict[str, str] = field(init=False, default_factory=dict)
     verbose: bool = field(default=False)
+    environment: Environment = field(init=False, repr=False)
 
 
 @dataclass

--- a/grizzly/locust.py
+++ b/grizzly/locust.py
@@ -181,6 +181,8 @@ def setup_environment_listeners(context: Context, environment: Environment, requ
     if grizzly.setup.statistics_url is not None:
         environment.events.init.add_listener(init_statistics_listener(grizzly.setup.statistics_url))
 
+    grizzly.state.environment = environment
+
     return external_dependencies
 
 

--- a/grizzly/types.py
+++ b/grizzly/types.py
@@ -283,7 +283,7 @@ class GrizzlyDict(dict):
                 if casted_value[0] == casted_value[-1]:
                     casted_value = casted_value[1:-1]
             elif casted_value[-1] in ['"', "'"] and casted_value[-1] != casted_value[0] and casted_value.count(casted_value[-1]) % 2 != 0:
-                    raise ValueError(f'{value} is incorrectly quoted')
+                raise ValueError(f'{value} is incorrectly quoted')
 
         return casted_value
 

--- a/grizzly/types.py
+++ b/grizzly/types.py
@@ -77,6 +77,10 @@ GrizzlyDictValueType = Union[str, float, int, bool]
 
 WrappedFunc = TypeVar('WrappedFunc', bound=Callable[..., Any])
 
+T = TypeVar('T')
+
+U = TypeVar('U')
+
 
 def bool_typed(value: str) -> bool:
     if value in ['True', 'False']:
@@ -98,10 +102,6 @@ def str_response_content_type(value: str) -> ResponseContentType:
         return ResponseContentType.PLAIN
     else:
         raise ValueError(f'"{value}" is an unknown response content type')
-
-
-T = TypeVar('T')
-U = TypeVar('U')
 
 
 class AbstractAtomicClass:

--- a/tests/test_grizzly/fixtures.py
+++ b/tests/test_grizzly/fixtures.py
@@ -256,7 +256,7 @@ def behave_runner() -> Runner:
 
 
 @pytest.fixture
-def behave_context() -> Generator[Context, None, None]:
+def behave_context(locust_environment: Environment) -> Generator[Context, None, None]:
     runner = Runner(
         config=Configuration(
             command_args=[],
@@ -271,7 +271,9 @@ def behave_context() -> Generator[Context, None, None]:
     context.scenario.steps = [context.step]
     context.scenario.background = Background(filename=None, line=None, keyword='', steps=[context.step], name='')
     context._runner.step_registry = step_registry
-    setattr(context, 'grizzly', GrizzlyContext())
+    grizzly = GrizzlyContext()
+    grizzly.state.environment = locust_environment
+    setattr(context, 'grizzly', grizzly)
 
     yield context
 

--- a/tests/test_grizzly/helpers.py
+++ b/tests/test_grizzly/helpers.py
@@ -4,11 +4,11 @@ from typing import Any, Dict, Optional, Tuple, List, Set
 from types import MethodType
 
 from locust import task
-from locust.user.task import TaskSet
 
 from grizzly.users.meta import ContextVariables
 from grizzly.types import RequestMethod
 from grizzly.task import RequestTask
+from grizzly.tasks import GrizzlyTasks
 
 
 def clone_request(method: str, this: RequestTask) -> RequestTask:
@@ -56,7 +56,7 @@ class TestUser(ContextVariables):
         raise RequestCalled(request)
 
 
-class TestTaskSet(TaskSet):
+class TestTaskSet(GrizzlyTasks):
     __test__ = False
 
     @task

--- a/tests/test_grizzly/steps/background/test_setup.py
+++ b/tests/test_grizzly/steps/background/test_setup.py
@@ -8,7 +8,7 @@ from behave.runner import Context
 from grizzly.steps import *  # pylint: disable=unused-wildcard-import
 from grizzly.context import GrizzlyContext
 
-from ...fixtures import behave_context  # pylint: disable=unused-import
+from ...fixtures import behave_context, locust_environment  # pylint: disable=unused-import
 
 
 @pytest.mark.usefixtures('behave_context')

--- a/tests/test_grizzly/steps/background/test_shapes.py
+++ b/tests/test_grizzly/steps/background/test_shapes.py
@@ -5,7 +5,7 @@ from behave.runner import Context
 
 from grizzly.steps import *  # pylint: disable=unused-wildcard-import
 
-from ...fixtures import behave_context  # pylint: disable=unused-import
+from ...fixtures import behave_context, locust_environment  # pylint: disable=unused-import
 
 
 def test_parse_user_gramatical_number() -> None:

--- a/tests/test_grizzly/steps/scenario/test_response.py
+++ b/tests/test_grizzly/steps/scenario/test_response.py
@@ -10,7 +10,7 @@ from grizzly.types import RequestMethod, str_response_content_type
 from grizzly.task import RequestTask, SleepTask
 from grizzly.steps import *  # pylint: disable=unused-wildcard-import
 
-from ...fixtures import behave_context  # pylint: disable=unused-import
+from ...fixtures import behave_context, locust_environment  # pylint: disable=unused-import
 
 @pytest.fixture
 def request_task_context(behave_context: Context) -> Generator[Context, None, None]:

--- a/tests/test_grizzly/steps/scenario/test_results.py
+++ b/tests/test_grizzly/steps/scenario/test_results.py
@@ -4,7 +4,7 @@ from behave.runner import Context
 
 from grizzly.steps import *  # pylint: disable=unused-wildcard-import
 
-from ...fixtures import behave_context  # pylint: disable=unused-import
+from ...fixtures import behave_context, locust_environment  # pylint: disable=unused-import
 
 
 @pytest.mark.usefixtures('behave_context')

--- a/tests/test_grizzly/steps/scenario/test_setup.py
+++ b/tests/test_grizzly/steps/scenario/test_setup.py
@@ -10,7 +10,7 @@ from pytest_mock.plugin import MockerFixture
 from grizzly.steps import *  # pylint: disable=unused-wildcard-import
 from grizzly.types import GrizzlyDictValueType, GrizzlyDict
 
-from ...fixtures import behave_context  # pylint: disable=unused-import
+from ...fixtures import behave_context, locust_environment  # pylint: disable=unused-import
 
 
 def test_parse_iteration_gramatical_number() -> None:

--- a/tests/test_grizzly/steps/scenario/test_user.py
+++ b/tests/test_grizzly/steps/scenario/test_user.py
@@ -8,7 +8,7 @@ from behave.runner import Context
 from grizzly.steps import *  # pylint: disable=unused-wildcard-import
 from grizzly.context import GrizzlyContext
 
-from ...fixtures import behave_context  # pylint: disable=unused-import
+from ...fixtures import behave_context, locust_environment  # pylint: disable=unused-import
 
 
 @pytest.mark.usefixtures('behave_context')

--- a/tests/test_grizzly/steps/test_setup.py
+++ b/tests/test_grizzly/steps/test_setup.py
@@ -7,7 +7,7 @@ from behave.runner import Context
 from grizzly.context import GrizzlyContext
 from grizzly.steps import *  # pylint: disable=unused-wildcard-import
 
-from ..fixtures import behave_context  # pylint: disable=unused-import
+from ..fixtures import behave_context, locust_environment  # pylint: disable=unused-import
 
 
 @pytest.mark.usefixtures('behave_context')

--- a/tests/test_grizzly/steps/test_utils.py
+++ b/tests/test_grizzly/steps/test_utils.py
@@ -4,7 +4,7 @@ from behave.runner import Context
 
 from grizzly.steps.utils import step_utils_fail
 
-from ..fixtures import behave_context  # pylint: disable=unused-import
+from ..fixtures import behave_context, locust_environment  # pylint: disable=unused-import
 
 
 @pytest.mark.usefixtures('behave_context')

--- a/tests/test_grizzly/test_context.py
+++ b/tests/test_grizzly/test_context.py
@@ -26,7 +26,7 @@ from grizzly.task import PrintTask, RequestTask, SleepTask
 
 
 from .helpers import get_property_decorated_attributes
-from .fixtures import request_task, grizzly_context, behave_context  # pylint: disable=unused-import
+from .fixtures import request_task, grizzly_context, behave_context, locust_environment  # pylint: disable=unused-import
 
 
 def test_load_configuration_file(tmpdir_factory: TempdirFactory) -> None:

--- a/tests/test_grizzly/test_environment.py
+++ b/tests/test_grizzly/test_environment.py
@@ -17,7 +17,7 @@ from grizzly.steps.setup import step_setup_variable_value_ask as step_both
 from grizzly.steps.background.setup import step_setup_save_statistics as step_background
 from grizzly.steps.scenario.setup import step_setup_iterations as step_scenario
 
-from .fixtures import behave_context  # pylint: disable=unused-import
+from .fixtures import behave_context, locust_environment  # pylint: disable=unused-import
 
 
 def test_before_feature() -> None:

--- a/tests/test_grizzly/test_locust.py
+++ b/tests/test_grizzly/test_locust.py
@@ -30,7 +30,7 @@ try:
 except:
     from grizzly_extras import dummy_pymqi as pymqi
 
-from .fixtures import behave_context  # pylint: disable=unused-import
+from .fixtures import behave_context, locust_environment  # pylint: disable=unused-import
 
 
 def test_greenlet_exception_logger(caplog: LogCaptureFixture) -> None:
@@ -352,6 +352,7 @@ def test_setup_environment_listeners(behave_context: Context, mocker: MockerFixt
         assert len(environment.events.spawning_complete._handlers) == 1
         assert len(environment.events.quitting._handlers) == 0
         assert external_dependencies == set()
+        assert grizzly.state.environment is environment
 
 
         grizzly.setup.statistics_url = None

--- a/tests/test_grizzly/test_task.py
+++ b/tests/test_grizzly/test_task.py
@@ -1,15 +1,31 @@
-from typing import Any, Tuple, Optional
+import logging
 
+from typing import Any, Tuple, Optional, Dict, Callable, cast
+from json import dumps as jsondumps
+
+import pytest
+
+from pytest_mock import mocker  # pylint: disable=unused-import
+from pytest_mock.plugin import MockerFixture
+from _pytest.logging import LogCaptureFixture
 from locust.clients import ResponseContextManager
 from locust.user.users import User
+from behave.runner import Context
+from grizzly.context import GrizzlyContext
 
 from grizzly.task import (
     RequestTask,
+    SleepTask,
+    PrintTask,
+    TransformerTask,
     RequestTaskHandlers,
     RequestTaskResponse,
 )
 
 from grizzly.types import ResponseContentType, RequestMethod
+from grizzly.transformer import transformer
+
+from .fixtures import grizzly_context, request_task, behave_context, locust_environment  # pylint: disable=unused-import
 
 class TestRequestTaskHandlers:
     def tests(self) -> None:
@@ -56,14 +72,158 @@ class TestRequestTaskResponse:
 
 
 class TestRequestTask:
-    def test(self) -> None:
-        request_task = RequestTask(RequestMethod.from_string('POST'), 'test-name', '/api/test')
+    @pytest.mark.usefixtures('grizzly_context')
+    def test(self, grizzly_context: Callable, mocker: MockerFixture) -> None:
+        task = RequestTask(RequestMethod.from_string('POST'), 'test-name', '/api/test')
 
-        assert request_task.method == RequestMethod.POST
-        assert request_task.name == 'test-name'
-        assert request_task.endpoint == '/api/test'
+        assert task.method == RequestMethod.POST
+        assert task.name == 'test-name'
+        assert task.endpoint == '/api/test'
 
-        assert not hasattr(request_task, 'scenario')
+        assert not hasattr(task, 'scenario')
 
-        assert request_task.template is None
-        assert request_task.source is None
+        assert task.template is None
+        assert task.source is None
+
+        implementation = task.implementation()
+        assert callable(implementation)
+
+        _, _, tasks, _ = grizzly_context()
+
+        def noop(*args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> Any:
+            pass
+
+        mocker.patch.object(tasks.user, 'request', noop)
+        request_spy = mocker.spy(tasks.user, 'request')
+
+        implementation(tasks)
+
+        assert request_spy.call_count == 1
+        args, _ = request_spy.call_args_list[0]
+        assert args[0] is task
+
+
+class TestSleepTask:
+    @pytest.mark.usefixtures('grizzly_context')
+    def test(self, mocker: MockerFixture, grizzly_context: Callable) -> None:
+        task = SleepTask(sleep=1.0)
+
+        assert task.sleep == 1.0
+        implementation = task.implementation()
+
+        assert callable(implementation)
+
+        _, _, tasks, _ = grizzly_context()
+
+        def noop(*args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> Any:
+            pass
+
+        import grizzly.task
+        mocker.patch.object(grizzly.task, 'gsleep', noop)
+        gsleep_spy = mocker.spy(grizzly.task, 'gsleep')
+
+        implementation(tasks)
+
+        assert gsleep_spy.call_count == 1
+        args, _ = gsleep_spy.call_args_list[0]
+        assert args[0] == task.sleep
+
+
+class TestPrintTask:
+    @pytest.mark.usefixtures('grizzly_context')
+    def test(self, mocker: MockerFixture, grizzly_context: Callable, caplog: LogCaptureFixture) -> None:
+        task = PrintTask(message='hello world!')
+        assert task.message == 'hello world!'
+
+        implementation = task.implementation()
+
+        assert callable(implementation)
+
+        _, _, tasks, _ = grizzly_context()
+
+        with caplog.at_level(logging.INFO):
+            implementation(tasks)
+        assert 'hello world!' in caplog.text
+        caplog.clear()
+
+        task = PrintTask(message='variable={{ variable }}')
+        assert task.message == 'variable={{ variable }}'
+
+        implementation = task.implementation()
+
+        assert callable(implementation)
+
+        tasks.user._context['variables']['variable'] = 'hello world!'
+
+        with caplog.at_level(logging.INFO):
+            implementation(tasks)
+        assert 'variable=hello world!' in caplog.text
+        caplog.clear()
+
+
+class TestTransformerTask:
+    @pytest.mark.usefixtures('behave_context', 'grizzly_context')
+    def test(self, behave_context: Context, grizzly_context: Callable) -> None:
+        with pytest.raises(ValueError) as ve:
+            TransformerTask(
+                variable='test_variable', expression='$.', content_type=ResponseContentType.JSON, content='',
+            )
+        assert 'test_variable has not been initialized' in str(ve)
+
+        grizzly = cast(GrizzlyContext, behave_context.grizzly)
+        grizzly.state.variables.update({'test_variable': 'none'})
+
+        json_transformer = transformer.available[ResponseContentType.JSON]
+        del transformer.available[ResponseContentType.JSON]
+
+        with pytest.raises(ValueError) as ve:
+            TransformerTask(
+                variable='test_variable', expression='$.', content_type=ResponseContentType.JSON, content='',
+            )
+        assert 'could not find a transformer for JSON' in str(ve)
+
+        transformer.available.update({ResponseContentType.JSON: json_transformer})
+
+        with pytest.raises(ValueError) as ve:
+            TransformerTask(
+                variable='test_variable', expression='$.', content_type=ResponseContentType.JSON, content='',
+            )
+        assert '$. is not a valid expression for JSON' in str(ve)
+
+        task = TransformerTask(
+            variable='test_variable', expression='$.result.value', content_type=ResponseContentType.JSON, content='',
+        )
+
+        implementation = task.implementation()
+
+        assert callable(implementation)
+
+        _, _, tasks, _ = grizzly_context()
+
+        with pytest.raises(RuntimeError) as re:
+            implementation(tasks)
+        assert 'failed to transform JSON' in str(re)
+
+        task = TransformerTask(
+            variable='test_variable',
+            expression='$.result.value',
+            content_type=ResponseContentType.JSON,
+            content=jsondumps({
+                'result': {
+                    'value': 'hello world!',
+                },
+            })
+        )
+
+        implementation = task.implementation()
+
+        assert callable(implementation)
+
+        assert tasks.user._context['variables'].get('test_variable', None) is None
+
+        implementation(tasks)
+
+        assert tasks.user._context['variables'].get('test_variable', None) == 'hello world!'
+
+
+

--- a/tests/test_grizzly/test_transformer.py
+++ b/tests/test_grizzly/test_transformer.py
@@ -392,6 +392,26 @@ class TestXmlTransformer:
         get_values = XmlTransformer.parser('//row/level_1_1[. > 500]/text()')
         actual = get_values(input_payload)
         assert actual == ['521', '671', '2550']
+
+        example = '''<?xml version="1.0" encoding="UTF-8"?>
+        <documents>
+            <document>
+                <header>
+                    <id>DOCUMENT_1337-3</id>
+                    <type>application/docx</type>
+                    <author>Douglas Adams</author>
+                    <published>2021-11-01</published>
+                    <pages>241</pages>
+                </header>
+            </document>
+        </documents>'''
+
+        _, input_payload = XmlTransformer.transform(ResponseContentType.XML, example)
+
+        get_values = XmlTransformer.parser('/documents/document/header')
+        actual = get_values(input_payload)
+        assert actual == ['<header><id>DOCUMENT_1337-3</id><type>application/docx</type><author>Douglas Adams</author><published>2021-11-01</published><pages>241</pages></header>']
+
 class TestPlainTransformer:
     def test_transform(self) -> None:
         unwrapped = PlainTransformer.__wrapped_transform__  # type: ignore

--- a/tests/test_grizzly/testdata/test_utils.py
+++ b/tests/test_grizzly/testdata/test_utils.py
@@ -31,7 +31,7 @@ from grizzly.testdata.utils import (
 from grizzly.testdata.variables import AtomicCsvRow, AtomicIntegerIncrementer, AtomicMessageQueue
 from grizzly_extras.messagequeue import MessageQueueResponse
 
-from ..fixtures import grizzly_context, request_task, behave_context  # pylint: disable=unused-import
+from ..fixtures import grizzly_context, request_task, behave_context, locust_environment  # pylint: disable=unused-import
 from .fixtures import cleanup  # pylint: disable=unused-import
 from .variables.test_messagequeue import noop_zmq # pylint: disable=unused-import
 

--- a/tests/test_grizzly/testdata/variables/test_messagequeue.py
+++ b/tests/test_grizzly/testdata/variables/test_messagequeue.py
@@ -23,7 +23,7 @@ try:
 except:
     from grizzly_extras import dummy_pymqi as pymqi
 
-from ...fixtures import behave_context  # pylint: disable=unused-import
+from ...fixtures import behave_context, locust_environment  # pylint: disable=unused-import
 
 @pytest.fixture
 def noop_zmq(mocker: MockerFixture) -> Callable[[], None]:


### PR DESCRIPTION
new task `TransformerTask`, which takes another template and with an expression (JSON path or XPath) extracts values from the template and saves it to a variable.

especially useful togheter with `AtomicMessageQueue` variable, where you can get a complete message from a queue, save it in a variable, and then use the task to extract values from it and use in other places in the scenario.