### PR TITLE
ServiceBus support in async-messaged

### DIFF
--- a/grizzly/listeners/__init__.py
+++ b/grizzly/listeners/__init__.py
@@ -106,6 +106,7 @@ def locust_test_stop(**_kwargs: Dict[str, Any]) -> None:
 
 def spawning_complete(grizzly: GrizzlyContext) -> Callable[[KwArg(Dict[str, Any])], None]:
     def wrapper(**_kwargs: Dict[str, Any]) -> None:
+        logger.debug('spawning complete!')
         grizzly.state.spawning_complete = True
 
     return wrapper

--- a/grizzly/testdata/variables/messagequeue.py
+++ b/grizzly/testdata/variables/messagequeue.py
@@ -326,7 +326,7 @@ class AtomicMessageQueue(AtomicVariable[str]):
                 'action': 'GET',
                 'worker': self._settings[variable]['worker'],
                 'context': {
-                    'queue': queue_name,
+                    'endpoint': queue_name,
                 },
                 'payload': None
             }

--- a/grizzly/users/messagequeue.py
+++ b/grizzly/users/messagequeue.py
@@ -2,9 +2,9 @@
 
 User is based on `pymqi` for communicating with IBM MQ. However `pymqi` uses native libraries which `gevent` (used by `locust`) cannot patch,
 which causes any calls in `pymqi` to block the rest of `locust`. To get around this, the user implementation communicates with a stand-alone
-process via zmq, which then in turn communicates with IBM MQ.
+process via zmq, which in turn communicates with IBM MQ.
 
-The message queue daemon process is started automagically when a scenario contains the `MessageQueueUser` and `pymqi` dependencies are installed.
+`async-messaged` starts automagically when a scenario uses `MessageQueueUser` and `pymqi` dependencies are installed.
 
 ## Request methods
 
@@ -76,18 +76,18 @@ from typing import Dict, Any, Generator, Tuple, Optional, cast
 from urllib.parse import urlparse, parse_qs, unquote
 from contextlib import contextmanager
 from time import monotonic as time
-from grizzly_extras.async_message import AsyncMessageContext, AsyncMessageRequest, AsyncMessageResponse
 
 
 import zmq
 
 
 from gevent import sleep as gsleep
-from locust.exception import StopUser, CatchResponseError
+from locust.exception import StopUser
+from grizzly_extras.async_message import AsyncMessageContext, AsyncMessageRequest, AsyncMessageResponse, AsyncMessageError
 
-from .meta import ContextVariables, ResponseHandler, RequestLogger
 from ..task import RequestTask
 from ..utils import merge_dicts
+from .meta import ContextVariables, ResponseHandler, RequestLogger
 from . import logger
 
 
@@ -218,10 +218,10 @@ class MessageQueueUser(ResponseHandler, RequestLogger, ContextVariables):
 
                     delta = total_time - mq_response_time
                     if delta > 100:  # @TODO: what is a suitable value?
-                        logger.warning(f'{self.__class__.__name__}: comunicating with async-messaged took {delta} ms')
+                        logger.warning(f'{self.__class__.__name__}: communicating with async-messaged took {delta} ms')
 
                     if not response['success'] and exception is None:
-                        exception = CatchResponseError(response['message'])
+                        exception = AsyncMessageError(response['message'])
                 else:
                     response = {}
 
@@ -273,7 +273,7 @@ class MessageQueueUser(ResponseHandler, RequestLogger, ContextVariables):
             'action': request.method.name,
             'worker': self.worker_id,
             'context': {
-                'queue': endpoint,
+                'endpoint': endpoint,
             },
             'payload': payload,
         }

--- a/grizzly/users/meta/context_variables.py
+++ b/grizzly/users/meta/context_variables.py
@@ -7,6 +7,8 @@ from locust.exception import StopUser
 from locust.user.users import User
 from locust.env import Environment
 
+from grizzly.context import GrizzlyContextScenario
+
 from ...task import RequestTask
 from ...utils import merge_dicts
 from . import logger, FileRequests
@@ -16,6 +18,7 @@ class ContextVariables(User):
     _context: Dict[str, Any] = {
         'variables': {},
     }
+    _scenario: Optional[GrizzlyContextScenario] = None
 
     __dependencies__: Set[str] = set()
 

--- a/grizzly/users/servicebus.py
+++ b/grizzly/users/servicebus.py
@@ -1,9 +1,13 @@
 '''Send and receive messages on Azure Service Bus queues and topics.
 
-> **Warning**: An actual session towards the endpoint will not be created and connected until the request actually executes, the connection time is
-> a big portion of the request time. Caching per endpoint causes problems with `gevent` and the open `amqp` sockets will block indefinitely.
-<p></p>
 > **Note**: If `message.wait` is not set, `azure.servicebus` will wait until there is a message available, and hence block the scenario.
+
+User is based on `azure.servicebus` for communicating with Azure Service Bus. But creating a connection and session towards a queue or a topic
+is a costly operation, and caching of the session was causing problems with `gevent` due to the sockets blocking and hence locust/grizzly was
+blocking when finished. To get around this, the user implementation communicates with a stand-alone process via zmq, which in turn communicates
+with Azure Service Bus.
+
+`async-messaged` starts automagically when a scenario uses the `ServiceBusUser`.
 
 ## Request methods
 
@@ -36,20 +40,18 @@ Then receive request "queue-recv" from endpoint "queue:shared-queue"
 Then receive request "topic-recv" from endpoint "topic:shared-topic, subscription:my-subscription"
 ```
 '''
-import logging
-
-from typing import Dict, Any, Iterable, Tuple, Callable, Optional, cast
-from mypy_extensions import KwArg
+from typing import Generator, Dict, Any, Tuple, Optional, Set, cast
 from urllib.parse import urlparse, parse_qs
 from time import monotonic as time
+from contextlib import contextmanager
 
-from azure.servicebus import ServiceBusClient, ServiceBusMessage, TransportType, ServiceBusSender, ServiceBusReceiver
-from azure.servicebus.amqp import AmqpMessageBodyType
-from azure.servicebus.amqp._amqp_message import DictMixin
+import zmq
 
 from locust.exception import StopUser
+from gevent import sleep as gsleep
+from grizzly_extras.async_message import AsyncMessageContext, AsyncMessageResponse, AsyncMessageRequest, AsyncMessageError
 
-from ..types import RequestMethod
+from ..types import RequestMethod, RequestDirection
 from ..task import RequestTask
 from ..utils import merge_dicts
 from .meta import ContextVariables, ResponseHandler, RequestLogger
@@ -63,15 +65,31 @@ class ServiceBusUser(ResponseHandler, RequestLogger, ContextVariables):
         }
     }
 
-    sb_client: ServiceBusClient
+    __dependencies__ = set(['async-messaged'])
+
+    am_context: AsyncMessageContext
+    worker_id: Optional[str]
+    zmq_context = zmq.Context()
+    zmq_client: zmq.Socket
+    zmq_url = 'tcp://127.0.0.1:5554'
+    hellos: Set[str]
+
     host: str
+
+    request_name_map: Dict[str, str] = {
+        'RECEIVE': 'RECV',
+        'HELLO': 'HELO',
+    }
+
 
     def __init__(self, *args: Tuple[Any], **kwargs: Dict[str, Any]) -> None:
         super().__init__(*args, **kwargs)
 
-        conn_str = self.host
-        if conn_str.startswith('Endpoint='):
-            conn_str = conn_str[9:]
+        if not self.host.startswith('Endpoint='):
+            conn_str = self.host
+            self.host = f'Endpoint={self.host}'
+        else:
+            conn_str = self.host[9:]
 
         # Replace semicolon separators between parameters to ? and & to make it "urlparse-compliant"
         # for validation
@@ -93,187 +111,150 @@ class ServiceBusUser(ResponseHandler, RequestLogger, ContextVariables):
         if 'SharedAccessKey' not in params:
             raise ValueError(f'{self.__class__.__name__}: SharedAccessKey must be in the query string')
 
-        self.sb_client = ServiceBusClient.from_connection_string(
-            conn_str=self.host,
-            transport_type=TransportType.AmqpOverWebsocket,
-        )
-
         self._context = merge_dicts(super().context(), self.__class__._context)
 
-        # silence uamqp loggers
-        logging.getLogger('uamqp').setLevel(logging.ERROR)
+        self.am_context = {
+            'url': self.host[9:],
+            'message_wait': self._context.get('message', {}).get('wait', None)
+        }
 
-    @classmethod
-    def from_message(cls, message: Optional[ServiceBusMessage]) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
-        def to_dict(obj: Optional[DictMixin]) -> Dict[str, Any]:
-            if obj is None:
-                return {}
+        self.hellos = set()
+        self.worker_id = None
+        self.zmq_client = self.zmq_context.socket(zmq.REQ)
+        self.zmq_client.connect(self.zmq_url)
 
-            result: Dict[str, Any] = {}
+        if self._scenario is not None:
+            for task in self._scenario.tasks:
+                if not isinstance(task, RequestTask):
+                    continue
 
-            for key, value in obj.items():
-                result[key] = value
+                endpoint = task.endpoint
+                self.say_hello(task, endpoint)
 
-            return result
+    def say_hello(self, task: RequestTask, endpoint: str) -> None:
+        if ('{{' in endpoint and '}}' in endpoint) or '$conf' in endpoint or '$env' in endpoint:
+            logger.warning(f'{self.__class__.__name__}: cannot say hello for {task.name} when endpoint ({endpoint}) is a template')
+            return
 
-        if message is None:
-            return None, None
+        connection = 'sender' if task.method.direction == RequestDirection.TO else 'receiver'
+        if ',' in endpoint:
+            name = endpoint.split(',', 1)[0]
+        else:
+            name = endpoint
 
-        raw_amqp_message = message.raw_amqp_message
-        metadata = to_dict(raw_amqp_message.properties)
-        metadata.update(to_dict(raw_amqp_message.header))
+        description = f'{connection}={endpoint}'
+        name = f'{connection}={name.strip()}'
 
-        body = raw_amqp_message.body
+        if description in self.hellos:
+            return
 
-        if raw_amqp_message.body_type == AmqpMessageBodyType.DATA:
-            if isinstance(body, Iterable):
-                payload = ''
-                for buffer in body:
-                    payload += buffer.decode('utf-8')
+        context = cast(AsyncMessageContext, dict(self.am_context))
+        context.update({
+            'endpoint': endpoint,
+        })
+
+        request: AsyncMessageRequest = {
+            'worker': self.worker_id,
+            'action': 'HELLO',
+            'context': context,
+        }
+
+        with self.async_action(task, request, name, meta=True):
+            pass
+
+        self.hellos.add(description)
+
+    @contextmanager
+    def async_action(self, task: RequestTask, request: AsyncMessageRequest, name: str, meta: bool = False) -> Generator[None, None, None]:
+        request.update({'worker': self.worker_id})
+        connection = 'sender' if task.method.direction == RequestDirection.TO else 'receiver'
+        request['context'].update({'connection': connection})
+
+        response: Optional[AsyncMessageResponse] = None
+        exception: Optional[Exception] = None
+
+        try:
+            start_time = time()
+
+            yield
+
+            self.zmq_client.send_json(request)
+
+            while True:
+                try:
+                    response = cast(AsyncMessageResponse, self.zmq_client.recv_json(flags=zmq.NOBLOCK))
+                    break
+                except zmq.Again:
+                    gsleep(0.1)
+        except Exception as e:
+            exception = e
+        finally:
+            response_time = int((time() - start_time) * 1000)
+
+            if response is not None:
+                if self.worker_id is None:
+                    self.worker_id = response.get('worker', None)
+
+                assert self.worker_id == response.get('worker', '')
+
+                if not response.get('success', False) and exception is None:
+                    exception = AsyncMessageError(response['message'])
             else:
-                payload = body.encode('utf-8')
-        elif raw_amqp_message.body_type == AmqpMessageBodyType.SEQUENCE:
-            payload = ''.join([v.encode('utf-8') for v in body])
-        else:
-            payload = str(body)
+                response = {}
 
-        return metadata, payload
+            try:
+                if not meta:
+                    self.response_event.fire(
+                        name=f'{task.scenario.identifier} {task.name}',
+                        request=task,
+                        context=(
+                            response.get('metadata', None),
+                            response.get('payload', None),
+                        ),
+                        user=self,
+                        exception=exception,
+                    )
+            except Exception as e:
+                if exception is None:
+                    exception = e
+            finally:
+                action = self.request_name_map.get(request['action'], request['action'][:4])
+                self.environment.events.request.fire(
+                    request_type=f'sb:{action}',
+                    name=name,
+                    response_time=response_time,
+                    response_length=(response or {}).get('response_length', None) or 0,
+                    context=self._context,
+                    exception=exception,
+                )
 
-    def get_sender_instance(self, request: RequestTask, endpoint: str) -> ServiceBusSender:
-        arguments: Dict[str, Any] = {}
-        endpoint_type, endpoint_name, _ = self.get_endpoint_details(request, endpoint)
+        if exception is not None and not meta and task.scenario.stop_on_failure:
+            try:
+                self.zmq_client.disconnect(self.zmq_url)
+            except:
+                pass
 
-        sender_type: Callable[[KwArg(Any)], ServiceBusSender]
-
-        if endpoint_type == 'queue':
-            arguments.update({'queue_name': endpoint_name})
-            sender_type = cast(
-                Callable[[KwArg(Any)], ServiceBusSender],
-                self.sb_client.get_queue_sender,
-            )
-        else:
-            arguments.update({'topic_name': endpoint_name})
-            sender_type = cast(
-                Callable[[KwArg(Any)], ServiceBusSender],
-                self.sb_client.get_topic_sender,
-            )
-
-        return sender_type(**arguments)
-
-    def get_receiver_instance(self, request: RequestTask, endpoint: str) -> ServiceBusReceiver:
-        arguments: Dict[str, Any] = {}
-        endpoint_type, endpoint_name, subscription_name = self.get_endpoint_details(request, endpoint)
-
-        receiver_type: Callable[[KwArg(Any)], ServiceBusReceiver]
-
-        max_wait_time = self._context.get('message', {}).get('wait', None)
-        if max_wait_time is not None:
-            arguments.update({'max_wait_time': max_wait_time})
-
-        if endpoint_type == 'queue':
-            receiver_type = cast(Callable[[KwArg(Any)], ServiceBusReceiver], self.sb_client.get_queue_receiver)
-            arguments.update({'queue_name': endpoint_name})
-        else:
-            receiver_type = cast(Callable[[KwArg(Any)], ServiceBusReceiver], self.sb_client.get_subscription_receiver)
-            arguments.update({
-                'topic_name': endpoint_name,
-                'subscription_name': subscription_name,
-            })
-
-        return receiver_type(**arguments)
-
-    @classmethod
-    def get_endpoint_details(cls, request: RequestTask, endpoint: str) -> Tuple[str, str, Optional[str]]:
-        if ':' not in endpoint:
-            raise ValueError(f'{cls.__name__}: "{endpoint}" is not prefixed with queue: or topic:')
-
-        endpoint_type: str
-        endpoint_name: str
-        subscription_name: Optional[str] = None
-
-        endpoint_type, endpoint_details = [v.strip() for v in endpoint.split(':', 1)]
-
-        if endpoint_type not in ['queue', 'topic']:
-            raise ValueError(f'{cls.__name__}: only support endpoint types queue and topic, not {endpoint_type}')
-
-        if ',' in endpoint_details:
-            endpoint_name, endpoint_details = [v.strip() for v in endpoint_details.split(',', 1)]
-
-            if request.method not in [RequestMethod.RECEIVE]:
-                raise ValueError(f'{cls.__name__}: additional arguments in endpoint is not supported for {request.method.name}')
-
-            detail_type, detail_value = [v.strip() for v in endpoint_details.split(':', 1)]
-
-            if detail_type != 'subscription':
-                raise ValueError(f'{cls.__name__}: argument {detail_type} is not supported')
-
-            subscription_name = detail_value
-        else:
-            endpoint_name = endpoint_details
-
-        if endpoint_type == 'topic' and subscription_name is None and request.method == RequestMethod.RECEIVE:
-            raise ValueError(f'{cls.__name__}: endpoint needs to include subscription when receiving messages from a topic')
-
-        return endpoint_type, endpoint_name, subscription_name
+            raise StopUser()
 
     def request(self, request: RequestTask) -> None:
         request_name, endpoint, payload = self.render(request)
 
         name = f'{request.scenario.identifier} {request_name}'
 
-        try:
-            start_time = time()
-            response_length: int = 0
-            exception: Optional[Exception] = None
-            metadata: Optional[Dict[str, Any]] = None
-            message: ServiceBusMessage
+        self.say_hello(request, endpoint)
 
-            if request.method in [RequestMethod.SEND]:
-                message = ServiceBusMessage(payload)
-                response_length = len(payload or '')
-                with self.get_sender_instance(request, endpoint) as sender:
-                    sender.send_messages(message)
-                metadata, payload = self.from_message(message)
-            elif request.method in [RequestMethod.RECEIVE]:
-                with self.get_receiver_instance(request, endpoint) as receiver:
-                    try:
-                        message = cast(ServiceBusMessage, receiver.next())
-                        receiver.complete_message(message)
-                    except StopIteration:
-                        raise RuntimeError(f'no message on {endpoint}')
+        context = cast(AsyncMessageContext, dict(self.am_context))
+        context.update({
+            'endpoint': endpoint,
+        })
 
-                metadata, payload = self.from_message(message)
-                response_length = len(payload or '')
-            else:
-                raise NotImplementedError(f'{self.__class__.__name__} has not implemented {request.method.name}')
-        except Exception as e:
-            exception = e
-        finally:
-            total_time = int((time() - start_time) * 1000)
-            logger.debug(f'{self.__class__.__name__}: {total_time=} ms')
-            try:
-                self.response_event.fire(
-                    name=name,
-                    request=request,
-                    context=(
-                        metadata,
-                        payload,
-                    ),
-                    user=self,
-                    exception=exception
-                )
-            except Exception as e:
-                if exception is None:
-                    exception = e
-            finally:
-                self.environment.events.request.fire(
-                    request_type=f'sb:{request.method.name[:4]}',
-                    name=name,
-                    response_time=total_time,
-                    response_length=response_length,
-                    context=self._context,
-                    exception=exception,
-                )
+        am_request: AsyncMessageRequest = {
+            'action': request.method.name,
+            'context': context,
+            'payload': payload,
+        }
 
-            if exception is not None and (request.scenario.stop_on_failure or isinstance(exception, NotImplementedError)):
-                raise StopUser()
+        with self.async_action(request, am_request, name):
+            if request.method not in [RequestMethod.SEND, RequestMethod.RECEIVE]:
+                raise NotImplementedError(f'{self.__class__.__name__}: no implementation for {request.method.name} requests')
+

--- a/grizzly/utils.py
+++ b/grizzly/utils.py
@@ -121,6 +121,7 @@ def create_user_class_type(scenario: GrizzlyContextScenario, global_context: Opt
     return type(user_class_name, (base_user_class_type, ), {
         '__dependencies__': base_user_class_type.__dependencies__,
         '_context': context,
+        '_scenario': scenario,
         'weight': scenario.user.weight,
     })
 

--- a/grizzly_extras/async_message/__init__.py
+++ b/grizzly_extras/async_message/__init__.py
@@ -1,10 +1,13 @@
 import logging
+import sys
 
-from abc import ABC
+from abc import ABC, abstractmethod
 from typing import Optional, Dict, Any, TypedDict, Callable, cast
 from os import environ, path
 from platform import node as hostname
-from json import JSONEncoder
+from json import JSONEncoder, dumps as jsondumps
+from time import monotonic as time
+from io import StringIO
 
 
 __all__ = [
@@ -43,7 +46,7 @@ class AsyncMessageContext(TypedDict, total=False):
     cert_label: Optional[str]
     ssl_cipher: Optional[str]
     message_wait: Optional[int]
-    queue: str
+    endpoint: str
 
 
 class AsyncMessageRequest(TypedDict, total=False):
@@ -69,25 +72,97 @@ class AsyncMessageError(Exception):
 
 class AsyncMessageHandler(ABC):
     worker: str
+    message_wait: Optional[int]
 
     def __init__(self, worker: str) -> None:
         self.worker = worker
+        self.message_wait = None
+
+    @abstractmethod
+    def get_handler(self, action: str) -> Optional['AsyncMessageRequestHandler']:
+        raise NotImplementedError(f'{self.__class__.__name__}: get_handler is not implemented')
+
+    def handle(self, request: AsyncMessageRequest) -> AsyncMessageResponse:
+        action = request['action']
+        request_handler = self.get_handler(action)
+        logger.debug(f'handling {action}')
+        logger.debug(jsondumps(request, indent=2, cls=JsonBytesEncoder))
+
+        response: AsyncMessageResponse
+
+        start_time = time()
+
+        try:
+            if request_handler is None:
+                raise AsyncMessageError(f'no implementation for {action}')
+
+            response = request_handler(self, request)
+            response['success'] = True
+        except Exception as e:
+            response = {
+                'success': False,
+                'message': f'{action}: {e.__class__.__name__}="{str(e)}"',
+            }
+        finally:
+            total_time = int((time() - start_time) * 1000)
+            response.update({
+                'worker': self.worker,
+                'response_time': total_time,
+            })
+
+            logger.debug(f'handled {action}')
+            logger.debug(jsondumps(response, indent=2, cls=JsonBytesEncoder))
+
+            return response
+
+
+AsyncMessageRequestHandler = Callable[[AsyncMessageHandler, AsyncMessageRequest], AsyncMessageResponse]
+InferredAsyncMessageRequestHandler = Callable[[Any, AsyncMessageRequest], AsyncMessageResponse]
 
 
 LRU_READY = '\x01'
 SPLITTER_FRAME = ''.encode()
 
-log_format = '[%(asctime)s] %(levelname)-5s: %(name)s: %(message)s'
+def register(handlers: Dict[str, AsyncMessageRequestHandler], action: str, *actions: str) -> Callable[[InferredAsyncMessageRequestHandler], InferredAsyncMessageRequestHandler]:
+    def decorator(func: InferredAsyncMessageRequestHandler) -> InferredAsyncMessageRequestHandler:
+        # mypy: type AsyncServiceBus (that inherits AsyncMessageHandler) is not of type
+        # AsyncMessageHandler or Union[AsyncServiceBus, AsyncMessageQueue]
+        # this is a workaround of python/mypys, sometimes, stupid type handling...
+        typed_func = cast(AsyncMessageRequestHandler, func)
+        for a in (action, *actions):
+            if a in handlers:
+                continue
 
-logger = logging.getLogger(__name__)
-level = logging.getLevelName(environ.get('GRIZZLY_EXTRAS_LOGLEVEL', 'INFO'))
-logging.basicConfig(format=log_format, level=level)
+            handlers.update({a: typed_func})
 
-logger.info(f'level: {logging.getLevelName(level)}')
+        return func
 
-if level < logging.INFO:
+    return decorator
+
+def configure_logger(name: str) -> logging.Logger:
+    logger = logging.getLogger(name)
+    log_format = '[%(asctime)s] %(levelname)-5s: %(name)s: %(message)s'
     formatter = logging.Formatter(log_format)
-    file_name = f'async-messaged.{hostname()}.log'
-    file_handler = logging.FileHandler(path.join(environ.get('GRIZZLY_CONTEXT_ROOT', '.'), 'logs', file_name))
-    file_handler.setFormatter(formatter)
-    logger.addHandler(file_handler)
+    level = logging.getLevelName(environ.get('GRIZZLY_EXTRAS_LOGLEVEL', 'INFO'))
+    logger.setLevel(level)
+    logger.handlers = []
+    stdout_handler = logging.StreamHandler(sys.stderr)
+    stdout_handler.setFormatter(formatter)
+    logger.addHandler(stdout_handler)
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.NOTSET)  # root logger needs to have lower or equal log level
+    root_logger.handlers = []
+    root_logger.addHandler(logging.StreamHandler(StringIO()))  # disable messages from root logger
+
+    if level < logging.INFO:
+        file_name = f'async-messaged.{hostname()}.log'
+        file_handler = logging.FileHandler(path.join(environ.get('GRIZZLY_CONTEXT_ROOT', '.'), 'logs', file_name))
+        file_handler.setFormatter(formatter)
+        logger.addHandler(file_handler)
+
+    logger.info(f'level={logging.getLevelName(level)}')
+
+    return logger
+
+logger = configure_logger(__name__)

--- a/grizzly_extras/async_message/sb.py
+++ b/grizzly_extras/async_message/sb.py
@@ -1,0 +1,254 @@
+import logging
+
+from typing import Any, Callable, Dict, Optional, Union, Tuple, Iterable, cast
+from mypy_extensions import VarArg, KwArg
+
+from azure.servicebus import ServiceBusClient, ServiceBusMessage, TransportType, ServiceBusSender, ServiceBusReceiver
+from azure.servicebus.amqp import AmqpMessageBodyType
+from azure.servicebus.amqp._amqp_message import DictMixin
+
+from . import (
+    AsyncMessageHandler,
+    AsyncMessageRequestHandler,
+    AsyncMessageRequest,
+    AsyncMessageResponse,
+    AsyncMessageError,
+    register,
+)
+
+__all__ = [
+    'AsyncServiceBusHandler',
+]
+
+
+handlers: Dict[str, AsyncMessageRequestHandler] = {}
+
+GenericCacheValue = Union[ServiceBusSender, ServiceBusReceiver]
+GenericCache = Dict[str, GenericCacheValue]
+GenericInstance = Callable[[VarArg(Any)], GenericCacheValue]
+
+
+class AsyncServiceBusHandler(AsyncMessageHandler):
+    _sender_cache: Dict[str, ServiceBusSender]
+    _receiver_cache: Dict[str, ServiceBusReceiver]
+
+    client: Optional[ServiceBusClient] = None
+
+    def __init__(self, worker: str) -> None:
+        super().__init__(worker)
+
+        self._sender_cache = {}
+        self._receiver_cache = {}
+
+        # silence uamqp loggers
+        logging.getLogger('uamqp').setLevel(logging.ERROR)
+
+    @classmethod
+    def get_endpoint_details(cls, instance_type: str, endpoint: str) -> Tuple[str, str, Optional[str]]:
+        if ':' not in endpoint:
+            raise AsyncMessageError(f'"{endpoint}" is not prefixed with queue: or topic:')
+
+        endpoint_type: str
+        endpoint_name: str
+        subscription_name: Optional[str] = None
+
+        endpoint_type, endpoint_details = [v.strip() for v in endpoint.split(':', 1)]
+
+        if endpoint_type not in ['queue', 'topic']:
+            raise AsyncMessageError(f'only support for endpoint types queue and topic, not {endpoint_type}')
+
+        if ',' in endpoint_details:
+            endpoint_name, endpoint_details = [v.strip() for v in endpoint_details.split(',', 1)]
+
+            if instance_type != 'receiver':
+                raise AsyncMessageError(f'additional arguments in endpoint is not supported for {instance_type}')
+
+            detail_type, detail_value = [v.strip() for v in endpoint_details.split(':', 1)]
+
+            if detail_type != 'subscription':
+                raise AsyncMessageError(f'argument {detail_type} is not supported')
+
+            subscription_name = detail_value
+        else:
+            endpoint_name = endpoint_details
+
+        if endpoint_type == 'topic' and subscription_name is None and instance_type == 'receiver':
+            raise AsyncMessageError('endpoint needs to include subscription when receiving messages from a topic')
+
+        return endpoint_type, endpoint_name, subscription_name
+
+    @classmethod
+    def get_sender_instance(cls, client: ServiceBusClient, endpoint: str) -> ServiceBusSender:
+        arguments: Dict[str, Any] = {}
+        endpoint_type, endpoint_name, _ = cls.get_endpoint_details('sender', endpoint)
+
+        sender_type: Callable[[KwArg(Any)], ServiceBusSender]
+
+        if endpoint_type == 'queue':
+            arguments.update({'queue_name': endpoint_name})
+            sender_type = cast(
+                Callable[[KwArg(Any)], ServiceBusSender],
+                client.get_queue_sender,
+            )
+        else:
+            arguments.update({'topic_name': endpoint_name})
+            sender_type = cast(
+                Callable[[KwArg(Any)], ServiceBusSender],
+                client.get_topic_sender,
+            )
+
+        return sender_type(**arguments)
+
+    @classmethod
+    def get_receiver_instance(cls, client: ServiceBusClient, endpoint: str, message_wait: Optional[int] = None) -> ServiceBusReceiver:
+        arguments: Dict[str, Any] = {}
+        endpoint_type, endpoint_name, subscription_name = cls.get_endpoint_details('receiver', endpoint)
+
+        receiver_type: Callable[[KwArg(Any)], ServiceBusReceiver]
+
+        if message_wait is not None:
+            arguments.update({'max_wait_time': message_wait})
+
+        if endpoint_type == 'queue':
+            receiver_type = cast(Callable[[KwArg(Any)], ServiceBusReceiver], client.get_queue_receiver)
+            arguments.update({'queue_name': endpoint_name})
+        else:
+            receiver_type = cast(Callable[[KwArg(Any)], ServiceBusReceiver], client.get_subscription_receiver)
+            arguments.update({
+                'topic_name': endpoint_name,
+                'subscription_name': subscription_name,
+            })
+
+        return receiver_type(**arguments)
+
+    @classmethod
+    def from_message(cls, message: Optional[ServiceBusMessage]) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+        def to_dict(obj: Optional[DictMixin]) -> Dict[str, Any]:
+            if obj is None:
+                return {}
+
+            result: Dict[str, Any] = {}
+
+            for key, value in obj.items():
+                result[key] = value
+
+            return result
+
+        if message is None:
+            return None, None
+
+        raw_amqp_message = message.raw_amqp_message
+        metadata = to_dict(raw_amqp_message.properties)
+        metadata.update(to_dict(raw_amqp_message.header))
+
+        body = raw_amqp_message.body
+
+        if raw_amqp_message.body_type == AmqpMessageBodyType.DATA:
+            if isinstance(body, Iterable):
+                payload = ''
+                for buffer in body:
+                    payload += buffer.decode('utf-8')
+            else:
+                payload = body.encode('utf-8')
+        elif raw_amqp_message.body_type == AmqpMessageBodyType.SEQUENCE:
+            payload = ''.join([v.encode('utf-8') for v in body])
+        else:
+            payload = str(body)
+
+        return metadata, payload
+
+    @register(handlers, 'HELLO')
+    def hello(self, request: AsyncMessageRequest) -> AsyncMessageResponse:
+        context = request.get('context', None)
+        if context is None:
+            raise AsyncMessageError('no context in request')
+
+        self.message_wait = context.get('message_wait', None)
+        url = context['url']
+
+        if self.client is None:
+            if not url.startswith('Endpoint='):
+                url = f'Endpoint={url}'
+
+            self.client = ServiceBusClient.from_connection_string(
+                conn_str=url,
+                transport_type=TransportType.AmqpOverWebsocket,
+            )
+
+        instance_type = context['connection']
+
+        cache: GenericCache
+        endpoint = context['endpoint']
+        arguments: Tuple[Any, ...] = (self.client, endpoint, )
+        get_instance: GenericInstance
+
+        if instance_type == 'sender':
+            cache = cast(GenericCache, self._sender_cache)
+            get_instance = cast(GenericInstance, self.get_sender_instance)
+        elif instance_type == 'receiver':
+            cache = cast(GenericCache, self._receiver_cache)
+            arguments += (self.message_wait, )
+            get_instance = cast(GenericInstance, self.get_receiver_instance)
+        else:
+            raise AsyncMessageError(f'"{instance_type}" is not a valid value for context.connection')
+
+        if endpoint not in cache:
+            cache.update({endpoint: get_instance(*arguments).__enter__()})
+
+        return {
+            'message': 'there general kenobi',
+        }
+
+    @register(handlers, 'SEND', 'RECEIVE')
+    def request(self, request: AsyncMessageRequest) -> AsyncMessageResponse:
+        context = request.get('context', None)
+        if context is None:
+            raise AsyncMessageError('no context in request')
+
+        instance_type = context.get('connection', None)
+        endpoint = context['endpoint']
+
+        message: ServiceBusMessage
+        metadata: Optional[Dict[str, Any]] = None
+        payload = request.get('payload', None)
+
+        if instance_type == 'sender':
+            if payload is None:
+                raise AsyncMessageError('no payload')
+            sender = self._sender_cache.get(endpoint, None)
+            if sender is None:
+                raise AsyncMessageError(f'no HELLO sent for {endpoint}')
+
+            message = ServiceBusMessage(payload)
+            try:
+                sender.send_messages(message)
+            except Exception as e:
+                raise AsyncMessageError('failed to send message') from e
+        elif instance_type == 'receiver':
+            if payload is not None:
+                raise AsyncMessageError('payload not allowed')
+
+            receiver = self._receiver_cache.get(endpoint, None)
+            if receiver is None:
+                raise AsyncMessageError(f'no HELLO sent for {endpoint}')
+            try:
+                message = cast(ServiceBusMessage, receiver.next())
+                receiver.complete_message(message)
+            except StopIteration:
+                raise AsyncMessageError(f'no messages on {endpoint}')
+        else:
+            raise AsyncMessageError(f'"{instance_type}" is not a valid value for context.connection')
+
+        metadata, payload = self.from_message(message)
+        response_length = len(payload or '')
+
+        return {
+            'payload': payload,
+            'metadata': metadata,
+            'response_length': response_length,
+        }
+
+    def get_handler(self, action: str) -> Optional[AsyncMessageRequestHandler]:
+        return handlers.get(action, None)
+
+

--- a/tests/test_grizzly/fixtures.py
+++ b/tests/test_grizzly/fixtures.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import socket
 
-from typing import Generator, Tuple, Callable, Type, Optional, Any, Literal, List, Union
+from typing import Generator, Tuple, Callable, Type, Optional, Any, Literal, List, Union, Dict
 from mypy_extensions import VarArg, KwArg
 
 import pytest
@@ -41,6 +41,32 @@ REQUEST_TASK_TEMPLATE_CONTENTS = """{
         }
     }
 }"""
+
+
+@pytest.fixture
+def noop_zmq(mocker: MockerFixture) -> Callable[[str], None]:
+    def mocked_noop(*args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> None:
+        pass
+
+    def patch(prefix: str) -> None:
+        targets = [
+            'zmq.sugar.context.Context.term',
+            'zmq.sugar.context.Context.__del__',
+            'zmq.sugar.socket.Socket.bind',
+            'zmq.sugar.socket.Socket.connect',
+            'zmq.sugar.socket.Socket.send_json',
+            'zmq.sugar.socket.Socket.recv_json',
+            'zmq.sugar.socket.Socket.disconnect',
+            'gsleep',
+        ]
+
+        for target in targets:
+            mocker.patch(
+                f'{prefix}.{target}',
+                mocked_noop,
+            )
+
+    return patch
 
 
 @pytest.fixture

--- a/tests/test_grizzly/test_utils.py
+++ b/tests/test_grizzly/test_utils.py
@@ -165,6 +165,7 @@ def test_create_user_class_type(locust_environment: Environment) -> None:
     assert issubclass(user_class_type_1, (RestApiUser, User))
     assert user_class_type_1.__name__ == f'RestApiUser_{scenario.identifier}'
     assert user_class_type_1.weight == 1
+    assert user_class_type_1._scenario is scenario
     assert user_class_type_1.host == 'http://localhost:8000'
     assert user_class_type_1.__module__ == 'locust.user.users'
     assert user_class_type_1._context == {
@@ -207,6 +208,7 @@ def test_create_user_class_type(locust_environment: Environment) -> None:
             }
         }
     }
+    assert user_type_1._scenario is scenario
 
     scenario = GrizzlyContextScenario()
     scenario.name = 'TestTestTest'
@@ -232,6 +234,7 @@ def test_create_user_class_type(locust_environment: Environment) -> None:
     assert issubclass(user_class_type_2, (RestApiUser, User))
     assert user_class_type_2.__name__ == f'RestApiUser_{scenario.identifier}'
     assert user_class_type_2.weight == 1
+    assert user_class_type_2._scenario is scenario
     assert user_class_type_2.host == 'http://localhost:8001'
     assert user_class_type_2.__module__ == 'locust.user.users'
     assert user_class_type_2._context == {
@@ -281,6 +284,7 @@ def test_create_user_class_type(locust_environment: Environment) -> None:
             }
         }
     }
+    assert user_type_2._scenario is scenario
 
     scenario = GrizzlyContextScenario()
     scenario.name = 'TestTestTest2'
@@ -292,6 +296,7 @@ def test_create_user_class_type(locust_environment: Environment) -> None:
     assert issubclass(user_class_type_3, (RestApiUser, User))
     assert user_class_type_3.__name__ == f'RestApiUser_{scenario.identifier}'
     assert user_class_type_3.weight == 1
+    assert user_class_type_3._scenario is scenario
     assert user_class_type_3.host == 'http://localhost:8002'
     assert user_class_type_3.__module__ == 'locust.user.users'
     assert user_class_type_3._context == {

--- a/tests/test_grizzly/testdata/variables/test_messagequeue.py
+++ b/tests/test_grizzly/testdata/variables/test_messagequeue.py
@@ -1,7 +1,7 @@
 import subprocess
 
 from os import environ
-from typing import Dict, Any, Tuple, Optional, Callable, cast
+from typing import Dict, Any, Optional, Callable, cast
 from json import dumps as jsondumps
 
 import pytest
@@ -23,51 +23,7 @@ try:
 except:
     from grizzly_extras import dummy_pymqi as pymqi
 
-from ...fixtures import behave_context, locust_environment  # pylint: disable=unused-import
-
-@pytest.fixture
-def noop_zmq(mocker: MockerFixture) -> Callable[[], None]:
-    def mocked_noop(*args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> None:
-        pass
-
-    def mocked_recv_json(*args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> AsyncMessageResponse:
-        return {
-            'success': True,
-            'worker': '1337-aaaabbbb-beef',
-        }
-
-    def patch() -> None:
-        mocker.patch(
-            'grizzly.testdata.variables.messagequeue.zmq.sugar.context.Context.term',
-            mocked_noop,
-        )
-
-        mocker.patch(
-            'grizzly.testdata.variables.messagequeue.zmq.sugar.context.Context.__del__',
-            mocked_noop,
-        )
-
-        mocker.patch(
-            'grizzly.testdata.variables.messagequeue.zmq.sugar.socket.Socket.bind',
-            mocked_noop,
-        )
-
-        mocker.patch(
-            'grizzly.testdata.variables.messagequeue.zmq.sugar.socket.Socket.connect',
-            mocked_noop,
-        )
-
-        mocker.patch(
-            'grizzly.testdata.variables.messagequeue.zmq.sugar.socket.Socket.send_json',
-            mocked_noop,
-        )
-
-        mocker.patch(
-            'grizzly.testdata.variables.messagequeue.zmq.sugar.socket.Socket.recv_json',
-            mocked_recv_json,
-        )
-
-    return patch
+from ...fixtures import behave_context, locust_environment, noop_zmq  # pylint: disable=unused-import
 
 
 def test_atomicmessagequeue__base_type__() -> None:
@@ -210,8 +166,8 @@ class TestAtomicMessageQueue:
                 pass
 
     @pytest.mark.usefixtures('behave_context', 'noop_zmq')
-    def test_create_context(self, behave_context: Context, noop_zmq: Callable[[], None] ) -> None:
-        noop_zmq()
+    def test_create_context(self, behave_context: Context, noop_zmq: Callable[[str], None] ) -> None:
+        noop_zmq('grizzly.testdata.variables.messagequeue')
 
         grizzly = cast(GrizzlyContext, behave_context.grizzly)
         grizzly.state.configuration.update({
@@ -330,8 +286,8 @@ class TestAtomicMessageQueue:
 
 
     @pytest.mark.usefixtures('noop_zmq')
-    def test_create_client(self, mocker: MockerFixture, noop_zmq: Callable[[], None]) -> None:
-        noop_zmq()
+    def test_create_client(self, mocker: MockerFixture, noop_zmq: Callable[[str], None]) -> None:
+        noop_zmq('grizzly.testdata.variables.messagequeue')
 
         try:
             v = AtomicMessageQueue(
@@ -367,8 +323,8 @@ class TestAtomicMessageQueue:
                 pass
 
     @pytest.mark.usefixtures('noop_zmq')
-    def test_clear(self, noop_zmq: Callable[[], None]) -> None:
-        noop_zmq()
+    def test_clear(self, noop_zmq: Callable[[str], None]) -> None:
+        noop_zmq('grizzly.testdata.variables.messagequeue')
 
         try:
             v = AtomicMessageQueue(
@@ -397,8 +353,8 @@ class TestAtomicMessageQueue:
             except:
                 pass
 
-    def test___getitem__(self, mocker: MockerFixture, noop_zmq: Callable[[], None]) -> None:
-        noop_zmq()
+    def test___getitem__(self, mocker: MockerFixture, noop_zmq: Callable[[str], None]) -> None:
+        noop_zmq('grizzly.testdata.variables.messagequeue')
 
         def mock_response(response: Optional[AsyncMessageResponse], repeat: int = 1) -> None:
             mocker.patch(
@@ -561,8 +517,8 @@ class TestAtomicMessageQueue:
                 pass
 
     @pytest.mark.usefixtures('noop_zmq')
-    def test___setitem__(self, mocker: MockerFixture, noop_zmq: Callable[[], None]) -> None:
-        noop_zmq()
+    def test___setitem__(self, mocker: MockerFixture, noop_zmq: Callable[[str], None]) -> None:
+        noop_zmq('grizzly.testdata.variables.messagequeue')
 
         def mocked___getitem__(i: AtomicMessageQueue, variable: str) -> Optional[str]:
             return i._get_value(variable)
@@ -588,8 +544,8 @@ class TestAtomicMessageQueue:
                 pass
 
     @pytest.mark.usefixtures('noop_zmq')
-    def test___delitem__(self, mocker: MockerFixture, noop_zmq: Callable[[], None]) -> None:
-        noop_zmq()
+    def test___delitem__(self, mocker: MockerFixture, noop_zmq: Callable[[str], None]) -> None:
+        noop_zmq('grizzly.testdata.variables.messagequeue')
 
         def mocked___getitem__(i: AtomicMessageQueue, variable: str) -> Optional[str]:
             return i._get_value(variable)

--- a/tests/test_grizzly/users/test_messagequeue.py
+++ b/tests/test_grizzly/users/test_messagequeue.py
@@ -28,7 +28,7 @@ from grizzly.exceptions import ResponseHandlerError
 from grizzly.steps.helpers import add_save_handler
 from grizzly_extras.async_message import AsyncMessageResponse
 
-from ..fixtures import grizzly_context, request_task, locust_environment  # pylint: disable=unused-import
+from ..fixtures import grizzly_context, request_task, locust_environment, noop_zmq  # pylint: disable=unused-import
 from ..helpers import clone_request
 
 import logging
@@ -172,37 +172,16 @@ class TestMessageQueueUser:
                 }
             }
 
-    @pytest.mark.usefixtures('locust_environment')
-    def test_request__action_conn_error(self, locust_environment: Environment, mocker: MockerFixture) -> None:
+    @pytest.mark.usefixtures('locust_environment', 'noop_zmq')
+    def test_request__action_conn_error(self, locust_environment: Environment, mocker: MockerFixture, noop_zmq: Callable[[str], None]) -> None:
         def mocked_zmq_connect(*args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> Any:
             raise zmq.error.ZMQError(msg='error connecting')
 
-        def mocked_noop(*args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> None:
-            pass
-
-        mocker.patch(
-            'grizzly.users.messagequeue.zmq.sugar.context.Context.term',
-            mocked_noop,
-        )
-
-        mocker.patch(
-            'grizzly.users.messagequeue.zmq.sugar.context.Context.__del__',
-            mocked_noop,
-        )
-
-        mocker.patch(
-            'grizzly.users.messagequeue.zmq.sugar.socket.Socket.bind',
-            mocked_noop,
-        )
+        noop_zmq('grizzly.users.messagequeue')
 
         mocker.patch(
             'grizzly.users.messagequeue.zmq.sugar.socket.Socket.connect',
             mocked_zmq_connect,
-        )
-
-        mocker.patch(
-            'grizzly.users.messagequeue.zmq.sugar.socket.Socket.send_json',
-            mocked_noop,
         )
 
         def mocked_request_fire(*args: Tuple[Any, ...], **_kwargs: Dict[str, Any]) -> None:
@@ -243,7 +222,7 @@ class TestMessageQueueUser:
         process: Optional[subprocess.Popen] = None
         try:
             process = subprocess.Popen(
-                ['messagequeue-daemon'],
+                ['async-messaged'],
                 env=environ.copy(),
                 shell=False,
                 stdout=subprocess.PIPE,
@@ -300,7 +279,7 @@ class TestMessageQueueUser:
         process: Optional[subprocess.Popen] = None
         try:
             process = subprocess.Popen(
-                ['messagequeue-daemon'],
+                ['async-messaged'],
                 env=environ.copy(),
                 shell=False,
                 stdout=subprocess.PIPE,
@@ -349,36 +328,11 @@ class TestMessageQueueUser:
                 }
             }
 
-    def test_get(self, mq_user: Tuple[MessageQueueUser, GrizzlyContextScenario, Environment], mocker: MockerFixture) -> None:
+    @pytest.mark.usefixtures('noop_zmq')
+    def test_get(self, mq_user: Tuple[MessageQueueUser, GrizzlyContextScenario, Environment], mocker: MockerFixture, noop_zmq: Callable[[str], None]) -> None:
         [user, scenario, _] = mq_user
 
-        def mocked_noop(*args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> None:
-            pass
-
-        mocker.patch(
-            'grizzly.users.messagequeue.zmq.sugar.context.Context.term',
-            mocked_noop,
-        )
-
-        mocker.patch(
-            'grizzly.users.messagequeue.zmq.sugar.context.Context.__del__',
-            mocked_noop,
-        )
-
-        mocker.patch(
-            'grizzly.users.messagequeue.zmq.sugar.socket.Socket.bind',
-            mocked_noop,
-        )
-
-        mocker.patch(
-            'grizzly.users.messagequeue.zmq.sugar.socket.Socket.connect',
-            mocked_noop,
-        )
-
-        mocker.patch(
-            'grizzly.users.messagequeue.zmq.sugar.socket.Socket.send_json',
-            mocked_noop,
-        )
+        noop_zmq('grizzly.users.messagequeue')
 
         response_connected: AsyncMessageResponse = {
             'worker': '0000-1337',
@@ -592,36 +546,11 @@ class TestMessageQueueUser:
         assert kwargs['exception'] is not None
         request_event_spy.reset_mock()
 
-    def test_send(self, mq_user: Tuple[MessageQueueUser, GrizzlyContextScenario, Environment], mocker: MockerFixture) -> None:
+    @pytest.mark.usefixtures('noop_zmq')
+    def test_send(self, mq_user: Tuple[MessageQueueUser, GrizzlyContextScenario, Environment], mocker: MockerFixture, noop_zmq: Callable[[str], None]) -> None:
         [user, scenario, _] = mq_user
 
-        def mocked_noop(*args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> None:
-            pass
-
-        mocker.patch(
-            'grizzly.users.messagequeue.zmq.sugar.socket.Socket.bind',
-            mocked_noop,
-        )
-
-        mocker.patch(
-            'grizzly.users.messagequeue.zmq.sugar.socket.Socket.connect',
-            mocked_noop,
-        )
-
-        mocker.patch(
-            'grizzly.users.messagequeue.zmq.sugar.socket.Socket.send_json',
-            mocked_noop,
-        )
-
-        mocker.patch(
-            'grizzly.users.messagequeue.zmq.sugar.context.Context.term',
-            mocked_noop,
-        )
-
-        mocker.patch(
-            'grizzly.users.messagequeue.zmq.sugar.context.Context.__del__',
-            mocked_noop,
-        )
+        noop_zmq('grizzly.users.messagequeue')
 
         response_connected: AsyncMessageResponse = {
             'worker': '0000-1337',

--- a/tests/test_grizzly/users/test_servicebus.py
+++ b/tests/test_grizzly/users/test_servicebus.py
@@ -1,57 +1,62 @@
-from typing import Any, Dict, Tuple
+import logging
+
+from typing import Callable, cast
 
 import pytest
+import zmq
 
 from pytest_mock import mocker  # pylint: disable=unused-import
 from pytest_mock.plugin import MockerFixture
 from locust.env import Environment
 from locust.exception import StopUser
-from azure.servicebus import ServiceBusMessage, TransportType, ServiceBusSender, ServiceBusClient
 from jinja2 import Template
 
 from grizzly.users.meta import ContextVariables, RequestLogger, ResponseHandler
 from grizzly.users.servicebus import ServiceBusUser
 from grizzly.types import RequestMethod
-from grizzly.task import RequestTask
-from grizzly.testdata.utils import transform
+from grizzly.task import RequestTask, SleepTask
 from grizzly.context import GrizzlyContextScenario
+from grizzly_extras.async_message import AsyncMessageResponse, AsyncMessageError
 
-from ..fixtures import behave_context, request_task, locust_environment  # pylint: disable=unused-import
+from ..fixtures import behave_context, request_task, locust_environment, noop_zmq  # pylint: disable=unused-import
 
 
 class TestServiceBusUser:
-    @pytest.mark.usefixtures('locust_environment')
-    def test_create(self, locust_environment: Environment, mocker: MockerFixture) -> None:
+    @pytest.mark.usefixtures('locust_environment', 'noop_zmq')
+    def test_create(self, locust_environment: Environment, mocker: MockerFixture, noop_zmq: Callable[[str], None]) -> None:
+        noop_zmq('grizzly.users.servicebus')
+
         try:
-            servicebusclient_spy = mocker.spy(ServiceBusClient, 'from_connection_string')
+            zmq_client_connect_spy = mocker.patch('grizzly.users.servicebus.zmq.sugar.socket.Socket.connect', side_effect=[None] * 10)
+            say_hello_spy = mocker.patch('grizzly.users.servicebus.ServiceBusUser.say_hello', side_effect=[None] * 10)
 
             ServiceBusUser.host = 'Endpoint=mq://sb.example.org/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=secret='
             with pytest.raises(ValueError) as e:
                 user = ServiceBusUser(environment=locust_environment)
             assert 'ServiceBusUser: "mq" is not a supported scheme' in str(e)
 
-            assert servicebusclient_spy.call_count == 0
+            assert zmq_client_connect_spy.call_count == 0
 
             ServiceBusUser.host = 'Endpoint=sb://sb.example.org'
             with pytest.raises(ValueError) as e:
                 user = ServiceBusUser(environment=locust_environment)
             assert 'ServiceBusUser: SharedAccessKeyName and SharedAccessKey must be in the query string' in str(e)
 
-            assert servicebusclient_spy.call_count == 0
+            assert zmq_client_connect_spy.call_count == 0
 
             ServiceBusUser.host = 'Endpoint=sb://sb.example.org/;SharedAccessKey=secret='
             with pytest.raises(ValueError) as e:
                 user = ServiceBusUser(environment=locust_environment)
             assert 'ServiceBusUser: SharedAccessKeyName must be in the query string' in str(e)
 
-            assert servicebusclient_spy.call_count == 0
+            assert zmq_client_connect_spy.call_count == 0
 
             ServiceBusUser.host = 'Endpoint=sb://sb.example.org/;SharedAccessKeyName=RootManageSharedAccessKey'
             with pytest.raises(ValueError) as e:
                 user = ServiceBusUser(environment=locust_environment)
             assert 'ServiceBusUser: SharedAccessKey must be in the query string' in str(e)
 
-            assert servicebusclient_spy.call_count == 0
+            assert zmq_client_connect_spy.call_count == 0
 
             ServiceBusUser.host = 'Endpoint=sb://sb.example.org/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc123def456ghi789='
             user = ServiceBusUser(environment=locust_environment)
@@ -59,174 +64,160 @@ class TestServiceBusUser:
             assert issubclass(user.__class__, ResponseHandler)
             assert issubclass(user.__class__, RequestLogger)
 
-            assert servicebusclient_spy.call_count == 1
-            _, kwargs = servicebusclient_spy.call_args_list[0]
+            assert zmq_client_connect_spy.call_count == 1
+            args, _ = zmq_client_connect_spy.call_args_list[0]
+            assert args[0] == ServiceBusUser.zmq_url
+            assert user.zmq_client.type == zmq.REQ
+            assert say_hello_spy.call_count == 0
 
-            assert kwargs.get('conn_str', None) == 'Endpoint=sb://sb.example.org/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc123def456ghi789='
-            assert kwargs.get('transport_type', None) == TransportType.AmqpOverWebsocket
+            scenario = GrizzlyContextScenario()
+            scenario.name = 'test'
+            scenario.user.class_name = 'ServiceBusUser'
+
+            scenario.add_task(SleepTask(sleep=1.54))
+            scenario.add_task(RequestTask(RequestMethod.SEND, name='test-send', endpoint='{{ endpoint }}'))
+            scenario.add_task(RequestTask(RequestMethod.RECEIVE, name='test-receive', endpoint='queue:test-queue'))
+            scenario.add_task(RequestTask(RequestMethod.SEND, name='test-send', endpoint='topic:test-topic'))
+
+            ServiceBusUser.host = 'Endpoint=sb://sb.example.org/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc123def456ghi789='
+            ServiceBusUser._scenario = scenario
+            user = ServiceBusUser(environment=locust_environment)
+            assert say_hello_spy.call_count == 3
+
+            for index, (args, _) in enumerate(say_hello_spy.call_args_list):
+                assert args[0] is scenario.tasks[index+1]
+                assert args[1] == cast(RequestTask, scenario.tasks[index+1]).endpoint
+
         finally:
+            ServiceBusUser._scenario = None
             ServiceBusUser._context = {
                 'message': {
                     'wait': None,
                 }
             }
 
-    def test_from_message(self) -> None:
-        assert ServiceBusUser.from_message(None) == (None, None,)
+    @pytest.mark.usefixtures('noop_zmq', 'locust_environment')
+    def test_say_hello(self, noop_zmq: Callable[[str], None], locust_environment: Environment, mocker: MockerFixture, caplog: pytest.LogCaptureFixture) -> None:
+        noop_zmq('grizzly.users.servicebus')
 
-        message = ServiceBusMessage('a message')
-        message.raw_amqp_message.properties = None
-        message.raw_amqp_message.header = None
-        assert ServiceBusUser.from_message(message) == ({}, 'a message',)
-
-        message = ServiceBusMessage('a message'.encode('utf-8'))
-        metadata, payload = ServiceBusUser.from_message(message)
-        assert payload == 'a message'
-        assert isinstance(metadata, dict)
-        assert len(metadata) > 0
-
-    @pytest.mark.usefixtures('locust_environment')
-    def test_get_sender_instance(self, locust_environment: Environment, mocker: MockerFixture) -> None:
         ServiceBusUser.host = 'Endpoint=sb://sb.example.org/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc123def456ghi789='
+
         user = ServiceBusUser(environment=locust_environment)
+        assert user.hellos == set()
 
-        queue_spy = mocker.spy(user.sb_client, 'get_queue_sender')
-        topic_spy = mocker.spy(user.sb_client, 'get_topic_sender')
-        task = RequestTask(RequestMethod.SEND, name='test-send-queue', endpoint='queue:test-queue')
-        user.get_sender_instance(task, task.endpoint)
-        assert topic_spy.call_count == 0
-        assert queue_spy.call_count == 1
-        _, kwargs = queue_spy.call_args_list[0]
+        async_action_spy = mocker.patch('grizzly.users.servicebus.ServiceBusUser.async_action', autospec=True)
+
+        user.hellos = set(['sender=queue:test-queue'])
+
+        task = RequestTask(RequestMethod.SEND, name='test-send', endpoint='queue:{{ queue_name }}')
+
+        with caplog.at_level(logging.WARNING):
+            user.say_hello(task, task.endpoint)
+        assert 'ServiceBusUser: cannot say hello for test-send when endpoint (queue:{{ queue_name }}) is a template' in caplog.text
+        assert user.hellos == set(['sender=queue:test-queue'])
+        assert async_action_spy.call_count == 0
+        caplog.clear()
+
+        user.say_hello(task, 'queue:test-queue')
+
+        assert user.hellos == set(['sender=queue:test-queue'])
+        assert async_action_spy.call_count == 0
+
+        user.say_hello(task, 'topic:test-topic')
+
+        assert user.hellos == set(['sender=queue:test-queue', 'sender=topic:test-topic'])
+        assert async_action_spy.call_count == 1
+        args, kwargs = async_action_spy.call_args_list[0]
+
+        assert len(args) == 4
         assert len(kwargs) == 1
-        assert kwargs.get('queue_name', None) == 'test-queue'
-
-        task = RequestTask(RequestMethod.SEND, name='test-send-topic', endpoint='topic:test-topic')
-        user.get_sender_instance(task, task.endpoint)
-        assert queue_spy.call_count == 1
-        assert topic_spy.call_count == 1
-        _, kwargs = topic_spy.call_args_list[0]
-        assert len(kwargs) == 1
-        assert kwargs.get('topic_name', None) == 'test-topic'
-
-    @pytest.mark.usefixtures('locust_environment')
-    def test_get_receiver_instance(self, locust_environment: Environment, mocker: MockerFixture) -> None:
-        ServiceBusUser.host = 'Endpoint=sb://sb.example.org/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc123def456ghi789='
-        user = ServiceBusUser(environment=locust_environment)
-
-        queue_spy = mocker.spy(user.sb_client, 'get_queue_receiver')
-        topic_spy = mocker.spy(user.sb_client, 'get_subscription_receiver')
-
-        task = RequestTask(RequestMethod.RECEIVE, name='test-recv-queue', endpoint='queue:test-queue')
-        user.get_receiver_instance(task, task.endpoint)
-        assert topic_spy.call_count == 0
-        assert queue_spy.call_count == 1
-        _, kwargs = queue_spy.call_args_list[0]
-        assert len(kwargs) == 1
-        assert kwargs.get('queue_name', None) == 'test-queue'
-
-        user._context['message'] = {'wait': 100}
-        user.get_receiver_instance(task, task.endpoint)
-        assert topic_spy.call_count == 0
-        assert queue_spy.call_count == 2
-        _, kwargs = queue_spy.call_args_list[1]
-        assert len(kwargs) == 2
-        assert kwargs.get('queue_name', None) == 'test-queue'
-        assert kwargs.get('max_wait_time', None) == 100
-
-        task = RequestTask(RequestMethod.RECEIVE, name='test-recv-topic', endpoint='topic:test-topic, subscription:test-subscription')
-        user.get_receiver_instance(task, task.endpoint)
-        assert topic_spy.call_count == 1
-        assert queue_spy.call_count == 2
-        _, kwargs = topic_spy.call_args_list[0]
-        assert len(kwargs) == 3
-        assert kwargs.get('topic_name', None) == 'test-topic'
-        assert kwargs.get('subscription_name', None) == 'test-subscription'
-        assert kwargs.get('max_wait_time', None) == 100
-
-        user._context['message'] = {'wait': None}
-        user.get_receiver_instance(task, task.endpoint)
-        assert topic_spy.call_count == 2
-        assert queue_spy.call_count == 2
-        _, kwargs = topic_spy.call_args_list[1]
-        assert len(kwargs) == 2
-        assert kwargs.get('topic_name', None) == 'test-topic'
-        assert kwargs.get('subscription_name', None) == 'test-subscription'
-
-    def test_get_endpoint_details(self) -> None:
-        task = RequestTask(RequestMethod.RECEIVE, name='test', endpoint='test')
-        with pytest.raises(ValueError) as ve:
-            ServiceBusUser.get_endpoint_details(task, task.endpoint)
-        assert 'ServiceBusUser: "test" is not prefixed with queue: or topic:' in str(ve)
-
-        task = RequestTask(RequestMethod.RECEIVE, name='test', endpoint='asdf:test')
-        with pytest.raises(ValueError) as ve:
-            ServiceBusUser.get_endpoint_details(task, task.endpoint)
-        assert 'ServiceBusUser: only support endpoint types queue and topic, not asdf' in str(ve)
-
-        task = RequestTask(RequestMethod.SEND, name='test', endpoint='topic:test, dummy:test')
-        with pytest.raises(ValueError) as ve:
-            ServiceBusUser.get_endpoint_details(task, task.endpoint)
-        assert 'ServiceBusUser: additional arguments in endpoint is not supported for SEND' in str(ve)
-
-        task = RequestTask(RequestMethod.RECEIVE, name='test', endpoint='topic:test, dummy:test')
-        with pytest.raises(ValueError) as ve:
-            ServiceBusUser.get_endpoint_details(task, task.endpoint)
-        assert 'ServiceBusUser: argument dummy is not supported' in str(ve)
-
-        task = RequestTask(RequestMethod.RECEIVE, name='test', endpoint='topic:test')
-        with pytest.raises(ValueError) as ve:
-            ServiceBusUser.get_endpoint_details(task, task.endpoint)
-        assert 'ServiceBusUser: endpoint needs to include subscription when receiving messages from a topic' in str(ve)
-
-        task = RequestTask(RequestMethod.SEND, name='test', endpoint='queue:test')
-        assert ServiceBusUser.get_endpoint_details(task, task.endpoint) == ('queue', 'test', None, )
-
-        task = RequestTask(RequestMethod.SEND, name='test', endpoint='topic:test')
-        assert ServiceBusUser.get_endpoint_details(task, task.endpoint) == ('topic', 'test', None, )
-
-        task = RequestTask(RequestMethod.RECEIVE, name='test', endpoint='queue:test')
-        assert ServiceBusUser.get_endpoint_details(task, task.endpoint) == ('queue', 'test', None, )
-
-        task = RequestTask(RequestMethod.RECEIVE, name='test', endpoint='topic:test, subscription:test')
-        assert ServiceBusUser.get_endpoint_details(task, task.endpoint) == ('topic', 'test', 'test', )
-
-    @pytest.mark.usefixtures('locust_environment')
-    def test_request_not_implemented_method(self, locust_environment: Environment, mocker: MockerFixture) -> None:
-        ServiceBusUser.host = 'Endpoint=sb://sb.example.org/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc123def456ghi789='
-        user = ServiceBusUser(environment=locust_environment)
-
-        remote_variables = {
-            'variables': transform({
-                'AtomicIntegerIncrementer.messageID': 31337,
-                'AtomicDate.now': '',
-                'messageID': 137,
-            }),
+        assert kwargs.get('meta', False)
+        assert args[1] is task
+        assert args[2] == {
+            'worker': None,
+            'action': 'HELLO',
+            'context': {
+                'endpoint': 'topic:test-topic',
+                'url': user.am_context['url'],
+                'message_wait': None,
+            }
         }
-        user.add_context(remote_variables)
+        assert args[3] == 'sender=topic:test-topic'
 
+        task = RequestTask(RequestMethod.RECEIVE, name='test-recv', endpoint='topic:test-topic, subscription:test-subscription')
+
+        user.say_hello(task, task.endpoint)
+
+        assert user.hellos == set(['sender=queue:test-queue', 'sender=topic:test-topic', 'receiver=topic:test-topic, subscription:test-subscription'])
+        assert async_action_spy.call_count == 2
+        args, kwargs = async_action_spy.call_args_list[1]
+
+        assert len(args) == 4
+        assert len(kwargs) == 1
+        assert kwargs.get('meta', False)
+        assert args[1] is task
+        assert args[2] == {
+            'worker': None,
+            'action': 'HELLO',
+            'context': {
+                'endpoint': 'topic:test-topic, subscription:test-subscription',
+                'url': user.am_context['url'],
+                'message_wait': None,
+            }
+        }
+        assert args[3] == 'receiver=topic:test-topic'
+
+    @pytest.mark.usefixtures('locust_environment', 'noop_zmq')
+    def test_request(self, locust_environment: Environment, noop_zmq: Callable[[str], None], mocker: MockerFixture) -> None:
+        noop_zmq('grizzly.users.servicebus')
+
+        ServiceBusUser.host = 'sb://sb.example.org/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc123def456ghi789='
+
+        user = ServiceBusUser(environment=locust_environment)
+        user.worker_id = 'asdf-asdf-asdf'
+
+        send_json_spy = mocker.spy(user.zmq_client, 'send_json')
+        say_hello_spy = mocker.patch.object(user, 'say_hello', side_effect=[None]*10)
         request_fire_spy = mocker.spy(user.environment.events.request, 'fire')
         response_event_fire_spy = mocker.spy(user.response_event, 'fire')
 
-        task = RequestTask(RequestMethod.PUT, name='test-send-queue', endpoint='queue:test-queue')
-        task.source = '{"hello": {{ messageID }}}'
-        task.template = Template(task.source)
+        def mock_recv_json(response: AsyncMessageResponse) -> None:
+            mocker.patch.object(user.zmq_client,
+                'recv_json',
+                side_effect=[zmq.Again(), response],
+            )
+
+        mock_recv_json({
+            'worker': 'asdf-asdf-asdf',
+            'success': False,
+            'message': 'unknown error',
+        })
 
         scenario = GrizzlyContextScenario()
         scenario.name = 'test'
+
+        # unsupported request method
+        task = RequestTask(RequestMethod.PUT, name='test-send', endpoint='queue:test-queue')
+        task.source = 'hello'
+        task.template = Template(task.source)
         scenario.add_task(task)
+        scenario.stop_on_failure = True
+        mocker.patch.object(user.zmq_client, 'disconnect', side_effect=[TypeError])
 
         with pytest.raises(StopUser):
             user.request(task)
 
-        assert response_event_fire_spy.call_count == 1
+        assert say_hello_spy.call_count == 1
+        assert send_json_spy.call_count == 0
         assert request_fire_spy.call_count == 1
+        assert response_event_fire_spy.call_count == 1
 
         _, kwargs = response_event_fire_spy.call_args_list[0]
         assert kwargs.get('name', None) == f'{scenario.identifier} {task.name}'
         assert kwargs.get('request', None) is task
-        metadata, payload = kwargs.get('context', (None, None,))
+        metadata, payload = kwargs.get('context', ({'meta': True}, 'hello',))
         assert metadata is None
-        assert payload == '{"hello": 137}'
+        assert payload is None
         assert kwargs.get('user', None) is user
         assert isinstance(kwargs.get('exception', None), NotImplementedError)
 
@@ -238,209 +229,94 @@ class TestServiceBusUser:
         assert kwargs.get('context', None) == user._context
         exception = kwargs.get('exception', None)
         assert isinstance(exception, NotImplementedError)
-        assert 'has not implemented PUT' in str(exception)
+        assert 'no implementation for PUT requests' in str(exception)
 
+        task.method = RequestMethod.SEND
 
-    @pytest.mark.usefixtures('locust_environment')
-    def test_request_sender(self, locust_environment: Environment, mocker: MockerFixture) -> None:
-        def mocked___enter__(instance: ServiceBusSender) -> ServiceBusSender:
-            return instance
-
-        def noop(*args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> Any:
-            pass
-
-        mocker.patch(
-            'grizzly.users.servicebus.ServiceBusSender.__enter__',
-            mocked___enter__,
-        )
-
-        mocker.patch(
-            'grizzly.users.servicebus.ServiceBusSender.send_messages',
-            noop,
-        )
-
-        ServiceBusUser.host = 'Endpoint=sb://sb.example.org/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc123def456ghi789='
-        user = ServiceBusUser(environment=locust_environment)
-
-        remote_variables = {
-            'variables': transform({
-                'AtomicIntegerIncrementer.messageID': 31337,
-                'AtomicDate.now': '',
-                'messageID': 137,
-            }),
-        }
-        user.add_context(remote_variables)
-
-        request_fire_spy = mocker.spy(user.environment.events.request, 'fire')
-        response_event_fire_spy = mocker.spy(user.response_event, 'fire')
-
-        task = RequestTask(RequestMethod.SEND, name='test-send-queue', endpoint='queue:test-queue')
-        task.source = '{"hello": {{ messageID }}}'
-        task.template = Template(task.source)
-
-        scenario = GrizzlyContextScenario()
-        scenario.name = 'test'
-        scenario.add_task(task)
+        # unsuccessful response from async-messaged
+        scenario.stop_on_failure = False
 
         user.request(task)
-
-        assert response_event_fire_spy.call_count == 1
-        assert request_fire_spy.call_count == 1
-
-        _, kwargs = response_event_fire_spy.call_args_list[0]
-        assert kwargs.get('name', None) == f'{scenario.identifier} {task.name}'
-        assert kwargs.get('request', None) is task
-        metadata, payload = kwargs.get('context', (None, None,))
-        assert isinstance(metadata, dict)
-        assert payload == '{"hello": 137}'
-        assert kwargs.get('user', None) is user
-        assert kwargs.get('exception', None) is None
-
-        _, kwargs = request_fire_spy.call_args_list[0]
-        assert kwargs.get('request_type', None) == 'sb:SEND'
-        assert kwargs.get('name', None) == f'{scenario.identifier} {task.name}'
-        assert kwargs.get('response_time', None) >= 0.0
-        assert kwargs.get('response_length', None) == len('{"hello": 137}')
-        assert kwargs.get('context', None) == user._context
-        assert kwargs.get('exception', None) is None
-
-        task.name = 'test-send-topic'
-        task.endpoint = 'topic:test-topic'
-        task.source = '{"value": {{ AtomicIntegerIncrementer.messageID }}}'
-        task.template = Template(task.source)
-
-        user.request(task)
-
-        assert response_event_fire_spy.call_count == 2
+        assert say_hello_spy.call_count == 2
+        assert send_json_spy.call_count == 1
         assert request_fire_spy.call_count == 2
+        assert response_event_fire_spy.call_count == 2
 
         _, kwargs = response_event_fire_spy.call_args_list[1]
         assert kwargs.get('name', None) == f'{scenario.identifier} {task.name}'
         assert kwargs.get('request', None) is task
         metadata, payload = kwargs.get('context', (None, None,))
-        assert isinstance(metadata, dict)
-        assert payload == '{"value": 31337}'
+        assert metadata is None
+        assert payload is None
         assert kwargs.get('user', None) is user
-        assert kwargs.get('exception', None) is None
+        assert isinstance(kwargs.get('exception', None), AsyncMessageError)
 
         _, kwargs = request_fire_spy.call_args_list[1]
         assert kwargs.get('request_type', None) == 'sb:SEND'
-        assert kwargs.get('name', None) == f'{scenario.identifier} {task.name}'
-        assert kwargs.get('response_time', None) >= 0.0
-        assert kwargs.get('response_length', None) == len('{"value": 31337}')
-        assert kwargs.get('context', None) == user._context
-        assert kwargs.get('exception', None) is None
-
-    @pytest.mark.usefixtures('locust_environment')
-    def test_request_receiver(self, locust_environment: Environment, mocker: MockerFixture) -> None:
-        def mocked___enter__(instance: ServiceBusSender) -> ServiceBusSender:
-            return instance
-
-        def noop(*args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> Any:
-            pass
-
-        mocker.patch(
-            'grizzly.users.servicebus.ServiceBusReceiver.__enter__',
-            mocked___enter__,
-        )
-
-        mocker.patch(
-            'grizzly.users.servicebus.ServiceBusReceiver.complete_message',
-            noop,
-        )
-
-        mocker.patch(
-            'grizzly.users.servicebus.ServiceBusReceiver.next',
-            side_effect=[StopIteration, ServiceBusMessage('{"test": 137}'), ServiceBusMessage('{"value": 31337}')]
-        )
-
-        ServiceBusUser.host = 'Endpoint=sb://sb.example.org/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc123def456ghi789='
-        user = ServiceBusUser(environment=locust_environment)
-
-        remote_variables = {
-            'variables': transform({
-                'AtomicIntegerIncrementer.messageID': 31337,
-                'AtomicDate.now': '',
-                'messageID': 137,
-            }),
-        }
-        user.add_context(remote_variables)
-
-        request_fire_spy = mocker.spy(user.environment.events.request, 'fire')
-        response_event_fire_spy = mocker.spy(user.response_event, 'fire')
-
-        task = RequestTask(RequestMethod.RECEIVE, name='test-recv-queue', endpoint='queue:test-queue')
-
-        scenario = GrizzlyContextScenario()
-        scenario.name = 'test'
-        scenario.add_task(task)
-        scenario.stop_on_failure = True
-
-        with pytest.raises(StopUser):
-            user.request(task)
-
-        assert response_event_fire_spy.call_count == 1
-        assert request_fire_spy.call_count == 1
-
-        _, kwargs = response_event_fire_spy.call_args_list[0]
-        assert kwargs.get('name', None) == f'{scenario.identifier} {task.name}'
-        assert kwargs.get('request', None) is task
-        assert kwargs.get('context', ('', '',)) == (None, None,)
-        assert kwargs.get('user', None) is user
-        exception = kwargs.get('exception', None)
-        assert isinstance(exception, RuntimeError)
-
-        _, kwargs = request_fire_spy.call_args_list[0]
-        assert kwargs.get('request_type', None) == 'sb:RECE'
         assert kwargs.get('name', None) == f'{scenario.identifier} {task.name}'
         assert kwargs.get('response_time', None) >= 0.0
         assert kwargs.get('response_length', None) == 0
         assert kwargs.get('context', None) == user._context
         exception = kwargs.get('exception', None)
-        assert isinstance(exception, RuntimeError)
-        assert 'no message on queue:test-queue' in str(exception)
+        assert 'unknown error' in str(exception)
+        args, _ = send_json_spy.call_args_list[0]
+        assert args[0] == {
+            'worker': 'asdf-asdf-asdf',
+            'action': 'SEND',
+            'payload': 'hello',
+            'context': {
+                'endpoint': 'queue:test-queue',
+                'connection': 'sender',
+                'url': 'sb://sb.example.org/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc123def456ghi789=',
+                'message_wait': None,
+            }
+        }
+
+        # successful request
+        task.method = RequestMethod.RECEIVE
+        task.template = None
+        task.source = None
+
+        mock_recv_json({
+            'worker': 'asdf-asdf-asdf',
+            'success': True,
+            'payload': 'hello',
+            'metadata': {'meta': True},
+            'response_length': 133,
+        })
 
         user.request(task)
-
-        assert response_event_fire_spy.call_count == 2
-        assert request_fire_spy.call_count == 2
-
-        _, kwargs = response_event_fire_spy.call_args_list[1]
-        assert kwargs.get('name', None) == f'{scenario.identifier} {task.name}'
-        assert kwargs.get('request', None) is task
-        metadata, payload = kwargs.get('context', (None, None,))
-        assert isinstance(metadata, dict)
-        assert payload == '{"test": 137}'
-        assert kwargs.get('user', None) is user
-        assert kwargs.get('exception', None) is None
-
-        _, kwargs = request_fire_spy.call_args_list[1]
-        assert kwargs.get('request_type', None) == 'sb:RECE'
-        assert kwargs.get('name', None) == f'{scenario.identifier} {task.name}'
-        assert kwargs.get('response_time', None) >= 0.0
-        assert kwargs.get('response_length', None) == len('{"test": 137}')
-        assert kwargs.get('context', None) == user._context
-        assert kwargs.get('exception', None) is None
-
-        task.endpoint = 'topic:test-topic, subscription:test-subscription'
-        user.request(task)
-
-        assert response_event_fire_spy.call_count == 3
+        assert say_hello_spy.call_count == 3
+        assert send_json_spy.call_count == 2
         assert request_fire_spy.call_count == 3
+        assert response_event_fire_spy.call_count == 3
 
         _, kwargs = response_event_fire_spy.call_args_list[2]
         assert kwargs.get('name', None) == f'{scenario.identifier} {task.name}'
         assert kwargs.get('request', None) is task
         metadata, payload = kwargs.get('context', (None, None,))
-        assert isinstance(metadata, dict)
-        assert payload == '{"value": 31337}'
+        assert metadata == {'meta': True}
+        assert payload is 'hello'
         assert kwargs.get('user', None) is user
-        assert kwargs.get('exception', None) is None
+        assert kwargs.get('exception', '') is None
 
         _, kwargs = request_fire_spy.call_args_list[2]
-        assert kwargs.get('request_type', None) == 'sb:RECE'
+        assert kwargs.get('request_type', None) == 'sb:RECV'
         assert kwargs.get('name', None) == f'{scenario.identifier} {task.name}'
         assert kwargs.get('response_time', None) >= 0.0
-        assert kwargs.get('response_length', None) == len('{"value": 31337}')
+        assert kwargs.get('response_length', None) == 133
         assert kwargs.get('context', None) == user._context
-        assert kwargs.get('exception', None) is None
+        assert kwargs.get('exception', '') is None
+        args, _ = send_json_spy.call_args_list[1]
+        print(args[0])
+        assert args[0] == {
+            'worker': 'asdf-asdf-asdf',
+            'action': 'RECEIVE',
+            'payload': None,
+            'context': {
+                'endpoint': 'queue:test-queue',
+                'connection': 'receiver',
+                'url': 'sb://sb.example.org/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc123def456ghi789=',
+                'message_wait': None,
+            }
+        }

--- a/tests/test_grizzly_extras/async_message/test___init__.py
+++ b/tests/test_grizzly_extras/async_message/test___init__.py
@@ -1,8 +1,24 @@
+from typing import Optional, cast
 from json import dumps as jsondumps
+from os import environ, path, listdir
+from shutil import rmtree
+from platform import node as hostname
 
 import pytest
 
-from grizzly_extras.async_message import JsonBytesEncoder
+from pytest_mock import MockerFixture, mocker  # pylint: disable=unused-import
+from _pytest.tmpdir import TempdirFactory
+from _pytest.capture import CaptureFixture
+
+from grizzly_extras.async_message import (
+    AsyncMessageRequestHandler,
+    JsonBytesEncoder,
+    AsyncMessageResponse,
+    AsyncMessageRequest,
+    AsyncMessageHandler,
+    register,
+    configure_logger,
+)
 
 
 class TestJsonBytesEncoder:
@@ -24,3 +40,146 @@ class TestJsonBytesEncoder:
         with pytest.raises(TypeError):
             encoder.default(None)
 
+
+class TestAsyncMessageHandler:
+    def test_get_handler(self, mocker: MockerFixture) -> None:
+        class AsyncMessageTest(AsyncMessageHandler):
+            def get_handler(self, action: str) -> Optional[AsyncMessageRequestHandler]:
+                return super().get_handler(action)
+
+        handler = AsyncMessageTest('ID-12345')
+
+        assert handler.worker == 'ID-12345'
+
+        with pytest.raises(NotImplementedError):
+            handler.get_handler('TEST')
+
+    def test_handle(self, mocker: MockerFixture) -> None:
+        class AsyncMessageTest(AsyncMessageHandler):
+            def a_handler(self, request: AsyncMessageRequest) -> AsyncMessageResponse:
+                pass
+
+            def get_handler(self, action: str) -> Optional[AsyncMessageRequestHandler]:
+                if action == 'NONE':
+                    return None
+                else:
+                    return cast(AsyncMessageRequestHandler, self.a_handler)
+
+        handler = AsyncMessageTest(worker='asdf-asdf-asdf')
+
+        request: AsyncMessageRequest = {
+            'action': 'NONE',
+        }
+
+        response = handler.handle(request)
+
+        assert response.get('success', True) == False
+        assert response.get('worker', None) == 'asdf-asdf-asdf'
+        assert response.get('message', None) == 'NONE: AsyncMessageError="no implementation for NONE"'
+        assert response.get('response_time', None) is not None
+
+        mocker.patch.object(handler, 'a_handler', side_effect=[{
+            'payload': 'test payload',
+            'metadata': {'value': 'hello world'},
+            'response_length': len('test payload'),
+        }])
+
+        request.update({
+            'action': 'GET',
+            'context': {
+                'endpoint': 'TEST.QUEUE',
+            }
+        })
+
+        response = handler.handle(request)
+
+        assert response.get('success', False) == True
+        assert response.get('worker', None) == 'asdf-asdf-asdf'
+        assert response.get('message', None) is None
+        assert response.get('response_time', None) is not None
+        assert response.get('response_length') == len('test payload')
+        assert response.get('payload') == 'test payload'
+
+
+def test_register() -> None:
+    def handler_a(i: AsyncMessageHandler, request: AsyncMessageRequest) -> AsyncMessageResponse:
+        pass
+
+    def handler_b(i: AsyncMessageHandler, request: AsyncMessageRequest) -> AsyncMessageResponse:
+        pass
+
+    try:
+        from grizzly_extras.async_message.mq import handlers
+
+        actual = list(handlers.keys())
+        actual.sort()
+
+        expected = ['CONN', 'RECEIVE', 'SEND', 'PUT', 'GET']
+        expected.sort()
+
+        assert actual == expected
+
+        register(handlers, 'TEST')(handler_a)
+        register(handlers, 'TEST')(handler_b)
+
+        from grizzly_extras.async_message.mq import handlers
+
+        assert handlers['TEST'] is not handler_b
+        assert handlers['TEST'] is handler_a
+    finally:
+        try:
+            del handlers['TEST']
+        except KeyError:
+            pass
+
+
+def test_configure_logger(mocker: MockerFixture, tmpdir_factory: TempdirFactory, capsys: CaptureFixture) -> None:
+    test_context = tmpdir_factory.mktemp('test_context').mkdir('logs')
+    test_context_root = path.dirname(str(test_context))
+
+    try:
+        environ['GRIZZLY_CONTEXT_ROOT'] = test_context_root
+
+        logger = configure_logger('test.logger')
+        logger.error('hello world')
+        logger.debug('no no')
+
+        std = capsys.readouterr()
+        assert '] INFO : test.logger: level=INFO\n' in std.err
+        assert '] ERROR: test.logger: hello world\n' in std.err
+        assert '] DEBUG: test.logger: no no\n' not in std.err
+
+        log_files = listdir(str(test_context))
+        assert len(log_files) == 0
+
+        environ['GRIZZLY_EXTRAS_LOGLEVEL'] = 'DEBUG'
+
+        logger = configure_logger('test.logger')
+        logger.error('hello world')
+        logger.debug('no no')
+
+        std = capsys.readouterr()
+        log_files = listdir(str(test_context))
+        assert len(log_files) == 1
+        log_file = log_files[0]
+        assert log_file == f'async-messaged.{hostname()}.log'
+
+        with open(path.join(str(test_context), log_file)) as fd:
+            file = fd.read()
+
+        for sink in [std.err, file]:
+            assert '] INFO : test.logger: level=DEBUG\n' in sink
+            assert '] ERROR: test.logger: hello world\n' in sink
+            assert '] DEBUG: test.logger: no no\n' in sink
+    finally:
+        try:
+            del environ['GRIZZLY_CONTEXT_ROOT']
+        except:
+            pass
+
+        try:
+            del environ['GRIZZLY_EXTRAS_LOGLEVEL']
+        except:
+            pass
+
+        rmtree(test_context_root)

--- a/tests/test_grizzly_extras/async_message/test_daemon.py
+++ b/tests/test_grizzly_extras/async_message/test_daemon.py
@@ -57,9 +57,9 @@ def test_worker(mocker: MockerFixture) -> None:
             ],
         )
 
-    def mock_handler_response(response: AsyncMessageResponse) -> None:
+    def mock_handle_response(response: AsyncMessageResponse) -> None:
         mocker.patch(
-            'grizzly_extras.async_message.mq.AsyncMessageQueue.handler',
+            'grizzly_extras.async_message.AsyncMessageHandler.handle',
             side_effect=[response],
         )
 
@@ -82,7 +82,7 @@ def test_worker(mocker: MockerFixture) -> None:
         'message': 'no url found in request context',
     }).encode()
 
-    mock_recv_multipart({'worker': 'ID-12345', 'context': {'url': 'sb://sb.example.com'}})
+    mock_recv_multipart({'worker': 'ID-12345', 'context': {'url': 'http://www.example.com'}})
 
     with pytest.raises(BreakLoop):
         worker(zmq_context, 'ID-12345')
@@ -95,16 +95,16 @@ def test_worker(mocker: MockerFixture) -> None:
         'worker': 'ID-12345',
         'response_time': 0,
         'success': False,
-        'message': 'integration for sb:// is not implemented',
+        'message': 'integration for http:// is not implemented',
     }).encode()
 
     integration_spy = mocker.patch(
-        'grizzly_extras.async_message.mq.AsyncMessageQueue.__init__',
+        'grizzly_extras.async_message.mq.AsyncMessageQueueHandler.__init__',
         side_effect=[None],
     )
 
     mock_recv_multipart({'worker': 'ID-12345', 'context': {'url': 'mq://mq.example.com'}})
-    mock_handler_response({
+    mock_handle_response({
         'worker': 'ID-12345',
         'success': True,
         'payload': 'hello world',

--- a/tests/test_grizzly_extras/async_message/test_sb.py
+++ b/tests/test_grizzly_extras/async_message/test_sb.py
@@ -1,0 +1,372 @@
+import logging
+
+import pytest
+
+from pytest_mock import MockerFixture, mocker  # pylint: disable=unused-import
+
+from azure.servicebus import ServiceBusMessage, TransportType, ServiceBusClient, ServiceBusSender, ServiceBusReceiver
+from grizzly_extras.async_message import AsyncMessageError, AsyncMessageRequest
+from grizzly_extras.async_message.sb import AsyncServiceBusHandler
+
+class TestAsyncServiceBusHandler:
+    def test___init__(self, mocker: MockerFixture) -> None:
+        spy = mocker.patch(
+            'grizzly_extras.async_message.sb.logging.Logger.setLevel',
+            side_effect=[None],
+        )
+
+        handler = AsyncServiceBusHandler('asdf-asdf-asdf')
+        assert handler.worker == 'asdf-asdf-asdf'
+        assert handler.message_wait is None
+        assert handler._sender_cache == {}
+        assert handler._receiver_cache == {}
+
+        assert spy.call_count == 1
+        args, _ = spy.call_args_list[0]
+        assert args[0] == logging.ERROR
+
+    def test_from_message(self) -> None:
+        assert AsyncServiceBusHandler.from_message(None) == (None, None,)
+
+        message = ServiceBusMessage('a message')
+        message.raw_amqp_message.properties = None
+        message.raw_amqp_message.header = None
+        assert AsyncServiceBusHandler.from_message(message) == ({}, 'a message',)
+
+        message = ServiceBusMessage('a message'.encode('utf-8'))
+        metadata, payload = AsyncServiceBusHandler.from_message(message)
+        assert payload == 'a message'
+        assert isinstance(metadata, dict)
+        assert len(metadata) > 0
+
+    def test_get_endpoint_details(self) -> None:
+        with pytest.raises(AsyncMessageError) as ame:
+            AsyncServiceBusHandler.get_endpoint_details('receiver', 'test')
+        assert '"test" is not prefixed with queue: or topic:' in str(ame)
+
+        with pytest.raises(AsyncMessageError) as ame:
+            AsyncServiceBusHandler.get_endpoint_details('sender', 'asdf:test')
+        assert 'only support for endpoint types queue and topic, not asdf' in str(ame)
+
+        with pytest.raises(AsyncMessageError) as ame:
+            AsyncServiceBusHandler.get_endpoint_details('sender', 'topic:test, dummy:test')
+        assert 'additional arguments in endpoint is not supported for sender' in str(ame)
+
+        with pytest.raises(AsyncMessageError) as ame:
+            AsyncServiceBusHandler.get_endpoint_details('receiver', 'topic:test, dummy:test')
+        assert 'argument dummy is not supported' in str(ame)
+
+        with pytest.raises(AsyncMessageError) as ame:
+            AsyncServiceBusHandler.get_endpoint_details('receiver', 'topic:test')
+        assert 'endpoint needs to include subscription when receiving messages from a topic' in str(ame)
+
+        assert AsyncServiceBusHandler.get_endpoint_details('sender', 'queue:test') == ('queue', 'test', None, )
+
+        assert AsyncServiceBusHandler.get_endpoint_details('sender', 'topic:test') == ('topic', 'test', None, )
+
+        assert AsyncServiceBusHandler.get_endpoint_details('receiver', 'queue:test') == ('queue', 'test', None, )
+
+        assert AsyncServiceBusHandler.get_endpoint_details('receiver', 'topic:test, subscription:test') == ('topic', 'test', 'test', )
+
+    def test_get_sender_instance(self, mocker: MockerFixture) -> None:
+        url = 'Endpoint=sb://sb.example.org/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc123def456ghi789='
+        client = ServiceBusClient.from_connection_string(
+            conn_str=url,
+            transport_type=TransportType.AmqpOverWebsocket,
+        )
+
+        queue_spy = mocker.spy(client, 'get_queue_sender')
+        topic_spy = mocker.spy(client, 'get_topic_sender')
+
+        handler = AsyncServiceBusHandler('asdf-asdf-asdf')
+
+        sender = handler.get_sender_instance(client, 'queue:test-queue')
+        assert isinstance(sender, ServiceBusSender)
+        assert topic_spy.call_count == 0
+        assert queue_spy.call_count == 1
+        _, kwargs = queue_spy.call_args_list[0]
+        assert len(kwargs) == 1
+        assert kwargs.get('queue_name', None) == 'test-queue'
+
+        sender = handler.get_sender_instance(client, 'topic:test-topic')
+        assert isinstance(sender, ServiceBusSender)
+        assert queue_spy.call_count == 1
+        assert topic_spy.call_count == 1
+        _, kwargs = topic_spy.call_args_list[0]
+        assert len(kwargs) == 1
+        assert kwargs.get('topic_name', None) == 'test-topic'
+
+    def test_get_receiver_instance(self, mocker: MockerFixture) -> None:
+        url = 'Endpoint=sb://sb.example.org/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc123def456ghi789='
+        client = ServiceBusClient.from_connection_string(
+            conn_str=url,
+            transport_type=TransportType.AmqpOverWebsocket,
+        )
+
+        queue_spy = mocker.spy(client, 'get_queue_receiver')
+        topic_spy = mocker.spy(client, 'get_subscription_receiver')
+
+        handler = AsyncServiceBusHandler('asdf-asdf-asdf')
+
+        receiver = handler.get_receiver_instance(client, 'queue:test-queue')
+        assert isinstance(receiver, ServiceBusReceiver)
+        assert topic_spy.call_count == 0
+        assert queue_spy.call_count == 1
+        _, kwargs = queue_spy.call_args_list[-1]
+        assert len(kwargs) == 1
+        assert kwargs.get('queue_name', None) == 'test-queue'
+
+        handler.get_receiver_instance(client, 'queue:test-queue', 100)
+        assert topic_spy.call_count == 0
+        assert queue_spy.call_count == 2
+        _, kwargs = queue_spy.call_args_list[-1]
+        assert len(kwargs) == 2
+        assert kwargs.get('queue_name', None) == 'test-queue'
+        assert kwargs.get('max_wait_time', None) == 100
+
+        receiver = handler.get_receiver_instance(client, 'topic:test-topic, subscription:test-subscription')
+        assert topic_spy.call_count == 1
+        assert queue_spy.call_count == 2
+        _, kwargs = topic_spy.call_args_list[-1]
+        assert len(kwargs) == 2
+        assert kwargs.get('topic_name', None) == 'test-topic'
+        assert kwargs.get('subscription_name', None) == 'test-subscription'
+
+        receiver = handler.get_receiver_instance(client, 'topic:test-topic, subscription:test-subscription', 100)
+        assert topic_spy.call_count == 2
+        assert queue_spy.call_count == 2
+        _, kwargs = topic_spy.call_args_list[-1]
+        assert len(kwargs) == 3
+        assert kwargs.get('topic_name', None) == 'test-topic'
+        assert kwargs.get('subscription_name', None) == 'test-subscription'
+        assert kwargs.get('max_wait_time', None) == 100
+
+    def test_hello(self, mocker: MockerFixture) -> None:
+        from grizzly_extras.async_message.sb import handlers
+
+        handler = AsyncServiceBusHandler(worker='asdf-asdf-asdf')
+        request: AsyncMessageRequest = {
+            'action': 'HELLO',
+        }
+
+        with pytest.raises(AsyncMessageError) as ame:
+            handlers[request['action']](handler, request)
+        assert 'no context in request' in str(ame)
+
+        assert handler.client is None
+
+        servicebusclient_connect_spy = mocker.spy(ServiceBusClient, 'from_connection_string')
+
+        request = {
+            'action': 'HELLO',
+            'context': {
+                'message_wait': 10,
+                'url': 'sb://sb.example.org/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc123def456ghi789=',
+                'endpoint': 'queue:test-queue',
+                'connection': 'asdf',
+            },
+        }
+
+        with pytest.raises(AsyncMessageError) as ame:
+            handlers[request['action']](handler, request)
+        assert '"asdf" is not a valid value for context.connection' in str(ame)
+
+        assert servicebusclient_connect_spy.call_count == 1
+        _, kwargs = servicebusclient_connect_spy.call_args_list[0]
+        assert kwargs.get('conn_str', None) == f'Endpoint={request["context"]["url"]}'
+        assert kwargs.get('transport_type', None) == TransportType.AmqpOverWebsocket
+        assert isinstance(getattr(handler, 'client', None), ServiceBusClient)
+
+        assert handler._sender_cache == {}
+        assert handler._receiver_cache == {}
+
+        sender_instance_spy = mocker.patch.object(handler, 'get_sender_instance', autospec=True)
+        receiver_instance_spy = mocker.patch.object(handler, 'get_receiver_instance', autospec=True)
+
+        request['context']['connection'] = 'sender'
+
+        assert handlers[request['action']](handler, request) == {
+            'message': 'there general kenobi',
+        }
+
+        assert sender_instance_spy.call_count == 1
+        assert sender_instance_spy.return_value.__enter__.call_count == 1
+        assert receiver_instance_spy.call_count == 0
+
+        args, _ = sender_instance_spy.call_args_list[0]
+        assert len(args) == 2
+        assert args[0] is handler.client
+        assert args[1] == 'queue:test-queue'
+
+        assert handler._sender_cache.get('queue:test-queue', None) is not None
+        assert handler._receiver_cache == {}
+
+        # read from cache
+        assert handlers[request['action']](handler, request) == {
+            'message': 'there general kenobi',
+        }
+
+        assert sender_instance_spy.call_count == 1
+        assert sender_instance_spy.return_value.__enter__.call_count == 1
+        assert receiver_instance_spy.call_count == 0
+
+
+        request['context'].update({
+            'connection': 'receiver',
+            'endpoint': 'topic:test-topic, subscription:test-subscription',
+        })
+
+        assert handlers[request['action']](handler, request) == {
+            'message': 'there general kenobi',
+        }
+
+        assert sender_instance_spy.call_count == 1
+        assert sender_instance_spy.return_value.__enter__.call_count == 1
+        assert receiver_instance_spy.call_count == 1
+        assert receiver_instance_spy.return_value.__enter__.call_count == 1
+
+        args, _ = receiver_instance_spy.call_args_list[0]
+        assert len(args) == 3
+        assert args[0] is handler.client
+        assert args[1] == 'topic:test-topic, subscription:test-subscription'
+        assert args[2] == 10
+
+        assert handler._sender_cache.get('queue:test-queue', None) is not None
+        assert handler._receiver_cache.get('topic:test-topic, subscription:test-subscription', None) is not None
+
+        # read from cache, not new instance needed
+        assert handlers[request['action']](handler, request) == {
+            'message': 'there general kenobi',
+        }
+
+        assert sender_instance_spy.call_count == 1
+        assert sender_instance_spy.return_value.__enter__.call_count == 1
+        assert receiver_instance_spy.call_count == 1
+        assert receiver_instance_spy.return_value.__enter__.call_count == 1
+
+        assert handler._sender_cache.get('queue:test-queue', None) is not None
+        assert handler._receiver_cache.get('topic:test-topic, subscription:test-subscription', None) is not None
+
+    def test_request(self, mocker: MockerFixture) -> None:
+        from grizzly_extras.async_message.sb import handlers
+
+        handler = AsyncServiceBusHandler(worker='asdf-asdf-asdf')
+        sender_instance_spy = mocker.patch.object(handler, 'get_sender_instance', autospec=True)
+        receiver_instance_spy = mocker.patch.object(handler, 'get_receiver_instance', autospec=True)
+
+        request: AsyncMessageRequest = {
+            'action': 'SEND',
+        }
+
+        with pytest.raises(AsyncMessageError) as ame:
+            handlers[request['action']](handler, request)
+        assert 'no context in request' in str(ame)
+
+        assert handler.client is None
+
+        # sender request
+        request = {
+            'action': 'SEND',
+            'context': {
+                'message_wait': 10,
+                'url': 'sb://sb.example.org/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc123def456ghi789=',
+                'endpoint': 'queue:test-queue',
+                'connection': 'asdf',
+            },
+        }
+
+        with pytest.raises(AsyncMessageError) as ame:
+            handlers[request['action']](handler, request)
+        assert '"asdf" is not a valid value for context.connection'
+
+        request['context']['connection'] = 'sender'
+
+        with pytest.raises(AsyncMessageError) as ame:
+            handlers[request['action']](handler, request)
+        assert 'no payload' in str(ame)
+
+        request['payload'] = 'grizzly <3 service bus'
+
+        with pytest.raises(AsyncMessageError) as ame:
+            handlers[request['action']](handler, request)
+        assert 'no HELLO sent for queue:test-queue' in str(ame)
+
+        handler._sender_cache[request['context']['endpoint']] = sender_instance_spy
+
+        with pytest.raises(AsyncMessageError) as ame:
+            handlers[request['action']](handler, request)
+        assert 'failed to send message' in str(ame)
+
+        handler._sender_cache[request['context']['endpoint']] = sender_instance_spy.return_value
+
+        response = handlers[request['action']](handler, request)
+
+        assert len(response) == 3
+        expected_metadata, expected_payload = handler.from_message(ServiceBusMessage('grizzly <3 service bus'))
+        actual_metadata = response.get('metadata', None)
+        assert actual_metadata is not None
+        assert expected_metadata is not None
+        actual_metadata['message_id'] = None
+        expected_metadata['message_id'] = None
+
+        assert response.get('payload', None) == expected_payload
+        assert actual_metadata == expected_metadata
+        assert response.get('response_length', 0) == len('grizzly <3 service bus')
+
+        # receiver request
+        request['action'] = 'RECEIVE'
+        request['context'].update({
+            'connection': 'receiver',
+            'endpoint': 'topic:test-topic, subscription:test-subscription',
+        })
+
+        with pytest.raises(AsyncMessageError) as ame:
+            handlers[request['action']](handler, request)
+        assert 'payload not allowed' in str(ame)
+
+        del request['payload']
+
+        with pytest.raises(AsyncMessageError) as ame:
+            handlers[request['action']](handler, request)
+        assert 'no HELLO sent for topic:test-topic, subscription:test-subscription' in str(ame)
+
+        received_message = ServiceBusMessage('grizzly >3 service bus')
+
+        receiver_instance_spy.return_value.next.side_effect = [StopIteration, received_message]
+        handler._receiver_cache[request['context']['endpoint']] = receiver_instance_spy.return_value
+
+        with pytest.raises(AsyncMessageError) as ame:
+            handlers[request['action']](handler, request)
+        assert 'no messages on topic:test-topic, subscription:test-subscription' in str(ame)
+        assert receiver_instance_spy.return_value.next.call_count == 1
+        assert receiver_instance_spy.return_value.complete_message.call_count == 0
+
+        response = handlers[request['action']](handler, request)
+
+        assert receiver_instance_spy.return_value.next.call_count == 2
+        assert receiver_instance_spy.return_value.complete_message.call_count == 1
+        args, _ = receiver_instance_spy.return_value.complete_message.call_args_list[0]
+        assert args[0] is received_message
+
+        assert len(response) == 3
+        expected_metadata, expected_payload = handler.from_message(received_message)
+        actual_metadata = response.get('metadata', None)
+        assert actual_metadata is not None
+        assert expected_metadata is not None
+        assert expected_payload is not None
+        actual_metadata['message_id'] = None
+        expected_metadata['message_id'] = None
+
+        assert response.get('payload', None) == expected_payload
+        assert actual_metadata == expected_metadata
+        assert response.get('response_length', 0) == len(expected_payload)
+
+    def test_get_handler(self) -> None:
+        handler = AsyncServiceBusHandler(worker='asdf-asdf-asdf')
+
+        assert handler.get_handler('NONE') is None
+        assert handler.get_handler('HELLO') is AsyncServiceBusHandler.hello
+        assert handler.get_handler('RECEIVE') is AsyncServiceBusHandler.request
+        assert handler.get_handler('SEND') is AsyncServiceBusHandler.request
+        assert handler.get_handler('GET') is None
+        assert handler.get_handler('PUT') is None


### PR DESCRIPTION
the reason being that creating connections/sessions towards
azure servicebus is a costly operation that takes around
2000 ms, where as the actual operation on the queue/topic
takes <100ms.

due to gevent and patching of sockets by locust, there was no
clean way of cleaning up with the functionality directly in
the user, which is why servicebus operations was moved to
async-messaged (similar to IBM MQ operations) in a separate
process.