### PR TITLE
simplified AtomicMessageQueue and AtomicServiceBus

### DIFF
--- a/tests/test_grizzly/testdata/test_communication.py
+++ b/tests/test_grizzly/testdata/test_communication.py
@@ -91,7 +91,7 @@ class TestTestdataProducer:
             if pymqi.__name__ != 'grizzly_extras.dummy_pymqi':
                 source['result']['DocumentID'] = '{{ AtomicMessageQueue.document_id }}'
                 grizzly.state.variables['AtomicMessageQueue.document_id'] =(
-                    'TEST.QUEUE | url="mq://mq.example.com?QueueManager=QM1&Channel=SRV.CONN", expression="$.test.result", content_type=json'
+                    'TEST.QUEUE | url="mq://mq.example.com?QueueManager=QM1&Channel=SRV.CONN"'
                 )
 
             request.source = json.dumps(source)
@@ -529,12 +529,17 @@ class TestTestdataConsumer:
 
                 grizzly = cast(GrizzlyContext, behave_context.grizzly)
                 grizzly.state.variables['AtomicMessageQueue.document_id'] = (
-                    'TEST.QUEUE | url="mq://mq.example.com?QueueManager=QM1&Channel=SRV.CONN", expression="$.document.id", content_type=json'
+                    'TEST.QUEUE | url="mq://mq.example.com?QueueManager=QM1&Channel=SRV.CONN"'
                 )
 
                 assert consumer.request('test') == {
                     'variables': transform({
-                        'AtomicMessageQueue.document_id': 'DOCUMENT_1337-2',
+                        'AtomicMessageQueue.document_id': json.dumps({
+                            'document': {
+                                'id': 'DOCUMENT_1337-2',
+                                'name': 'Very important memo about the TPM report',
+                            },
+                        }),
                         'AtomicIntegerIncrementer.messageID': 100,
                         'test': None,
                     })

--- a/tests/test_grizzly/testdata/variables/test_servicebus.py
+++ b/tests/test_grizzly/testdata/variables/test_servicebus.py
@@ -8,7 +8,6 @@ from pytest_mock import mocker, MockerFixture  # pylint: disable=unused-import
 from grizzly.testdata.variables.servicebus import AtomicServiceBus, atomicservicebus_url, atomicservicebus_endpoint, atomicservicebus__base_type__
 from grizzly.context import GrizzlyContext
 from grizzly_extras.async_message import AsyncMessageResponse
-from grizzly_extras.transformer import transformer, TransformerContentType
 
 from ...fixtures import noop_zmq  # pylint: disable=unused-import
 
@@ -31,40 +30,15 @@ def test_atomicservicebus__base_type() -> None:
     assert 'AtomicServiceBus: url parameter must be specified' in str(ve)
 
     with pytest.raises(ValueError) as ve:
-        atomicservicebus__base_type__('queue:documents-in | url="sb://sb.example.com/;SharedAccessKeyName=name;SharedAccessKey=asdf-asdf-asdf="')
-    assert 'AtomicServiceBus: expression parameter must be specified' in str(ve)
-
-    with pytest.raises(ValueError) as ve:
-        atomicservicebus__base_type__('queue:documents-in | url="sb://sb.example.com/;SharedAccessKeyName=name;SharedAccessKey=asdf-asdf-asdf=", expression="$."')
-    assert 'AtomicServiceBus: content_type parameter must be specified' in str(ve)
-
-    json_transformer = transformer.available[TransformerContentType.JSON]
-    del transformer.available[TransformerContentType.JSON]
-
-    with pytest.raises(ValueError) as ve:
         atomicservicebus__base_type__(
-            'queue:documents-in | url="sb://sb.example.com/;SharedAccessKeyName=name;SharedAccessKey=asdf-asdf-asdf=", expression="$.", content_type=json',
-        )
-    assert 'AtomicServiceBus: could not find a transformer for JSON' in str(ve)
-
-    with pytest.raises(ValueError) as ve:
-        atomicservicebus__base_type__(
-            'queue:documents-in | url="sb://sb.example.com/;SharedAccessKeyName=name;SharedAccessKey=asdf-asdf-asdf=", expression="$.", content_type=json, argument=False',
+            'queue:documents-in | url="sb://sb.example.com/;SharedAccessKeyName=name;SharedAccessKey=asdf-asdf-asdf=", argument=False',
         )
     assert 'AtomicServiceBus: argument argument is not allowed' in str(ve)
 
-    transformer.available[TransformerContentType.JSON] = json_transformer
-
-    with pytest.raises(ValueError) as ve:
-        atomicservicebus__base_type__(
-            'queue:documents-in | url="sb://sb.example.com/;SharedAccessKeyName=name;SharedAccessKey=asdf-asdf-asdf=", expression="$.", content_type=json',
-        )
-    assert 'AtomicServiceBus: expression "$." is not a valid expression for JSON' in str(ve)
-
     safe_value = atomicservicebus__base_type__(
-        'queue:documents-in| url="sb://sb.example.com/;SharedAccessKeyName=name;SharedAccessKey=asdf-asdf-asdf=", expression="$.test.result", content_type=json',
+        'queue:documents-in| url="sb://sb.example.com/;SharedAccessKeyName=name;SharedAccessKey=asdf-asdf-asdf="',
     )
-    assert safe_value == 'queue:documents-in | url="sb://sb.example.com/;SharedAccessKeyName=name;SharedAccessKey=asdf-asdf-asdf=", expression="$.test.result", content_type=json'
+    assert safe_value == 'queue:documents-in | url="sb://sb.example.com/;SharedAccessKeyName=name;SharedAccessKey=asdf-asdf-asdf="'
 
 
 def test_atomicservicebus_url() -> None:
@@ -192,7 +166,7 @@ class TestAtomicServiceBus:
         try:
             v = AtomicServiceBus(
                 'test1',
-                'queue:documents-in | url="Endpoint=sb://sb.example.org/;SharedAccessKeyName=name;SharedAccessKey=key", expression="$.test.result", content_type=json',
+                'queue:documents-in | url="Endpoint=sb://sb.example.org/;SharedAccessKeyName=name;SharedAccessKey=key"',
             )
 
             assert v._initialized
@@ -203,8 +177,6 @@ class TestAtomicServiceBus:
                 'wait': None,
                 'endpoint_name': 'queue:documents-in',
                 'url': 'Endpoint=sb://sb.example.org/;SharedAccessKeyName=name;SharedAccessKey=key',
-                'expression': '$.test.result',
-                'content_type': TransformerContentType.JSON,
                 'context': None,
                 'worker': None,
             }
@@ -213,27 +185,22 @@ class TestAtomicServiceBus:
 
             t = AtomicServiceBus(
                 'test2',
-                (
-                    'topic:documents-in, subscription:application-x | url="sb://sb.example.org/;SharedAccessKeyName=name;SharedAccessKey=key", '
-                    'expression="//test/result/text()", content_type=xml, wait=15'
-                ),
+                'topic:documents-in, subscription:application-x | url="sb://sb.example.org/;SharedAccessKeyName=name;SharedAccessKey=key", wait=15',
             )
 
             assert v is t
             assert len(v._values.keys()) == 2
-            assert len(v._endpoint_values.keys()) == 2
+            assert len(v._endpoint_messages.keys()) == 2
             assert len(v._settings.keys()) == 2
             assert len(v._endpoint_clients.keys()) == 2
             assert 'test2' in v._values
             assert v._values.get('test2', None) == 'topic:documents-in, subscription:application-x'
-            assert v._endpoint_values.get('test2', None) == []
+            assert v._endpoint_messages.get('test2', None) == []
             assert v._settings.get('test2', None) == {
                 'repeat': False,
                 'wait': 15,
                 'endpoint_name': 'topic:documents-in, subscription:application-x',
                 'url': 'sb://sb.example.org/;SharedAccessKeyName=name;SharedAccessKey=key',
-                'expression': '//test/result/text()',
-                'content_type': TransformerContentType.XML,
                 'context': None,
                 'worker': None,
             }
@@ -293,15 +260,13 @@ class TestAtomicServiceBus:
                 'test',
                 (
                     'topic:documents-in, subscription:application-x | url="sb://sb.example.org/;SharedAccessKeyName=name;SharedAccessKey=key", '
-                    'expression="//test/result/text()", content_type=xml, wait=15, repeat=True'
+                    'wait=15, repeat=True'
                 ),
             )
             assert isinstance(v._endpoint_clients.get('test', None), zmq.Socket)
             assert v._settings.get('test', None) == {
                 'repeat': True,
                 'wait': 15,
-                'expression': '//test/result/text()',
-                'content_type': TransformerContentType.XML,
                 'worker': None,
                 'url': 'sb://sb.example.org/;SharedAccessKeyName=name;SharedAccessKey=key',
                 'endpoint_name': 'topic:documents-in, subscription:application-x',
@@ -337,7 +302,7 @@ class TestAtomicServiceBus:
                     'test',
                     (
                         'topic:documents-in, subscription:application-x | url="sb://sb.example.org/;SharedAccessKeyName=name;SharedAccessKey=key", '
-                        'expression="//test/result/text()", content_type=xml, wait=15, repeat=True'
+                        'wait=15, repeat=True'
                     ),
                 )
             except:
@@ -425,28 +390,28 @@ class TestAtomicServiceBus:
                 'test1',
                 (
                     'topic:documents-in, subscription:application-x | url="sb://sb.example.org/;SharedAccessKeyName=name;SharedAccessKey=key", '
-                    'expression="//test/result/text()", content_type=xml, wait=15, repeat=True'
+                    'wait=15, repeat=True'
                 ),
             )
             v = AtomicServiceBus(
                 'test2',
                 (
                     'queue:documents-in | url="sb://sb.example.org/;SharedAccessKeyName=name;SharedAccessKey=key", '
-                    'expression="//test/result/text()", content_type=xml, wait=15, repeat=True'
+                    'wait=15, repeat=True'
                 ),
             )
 
             assert say_hello_spy.call_count == 2
 
             assert len(v._settings.keys()) == 2
-            assert len(v._endpoint_values.keys()) == 2
+            assert len(v._endpoint_messages.keys()) == 2
             assert len(v._endpoint_clients.keys()) == 2
             assert len(v._values.keys()) == 2
 
             AtomicServiceBus.clear()
 
             assert len(v._settings.keys()) == 0
-            assert len(v._endpoint_values.keys()) == 0
+            assert len(v._endpoint_messages.keys()) == 0
             assert len(v._endpoint_clients.keys()) == 0
             assert len(v._values.keys()) == 0
         finally:
@@ -478,7 +443,7 @@ class TestAtomicServiceBus:
                 'test1',
                 (
                     'topic:documents-in, subscription:application-x | url="sb://sb.example.org/;SharedAccessKeyName=name;SharedAccessKey=key", '
-                    'expression="//test/result/text()", content_type=xml, wait=15, repeat=True'
+                    'wait=15, repeat=True'
                 ),
             )
             with pytest.raises(RuntimeError) as re:
@@ -496,7 +461,7 @@ class TestAtomicServiceBus:
                 'test1',
                 (
                     'topic:documents-in, subscription:application-x | url="sb://sb.example.org/;SharedAccessKeyName=name;SharedAccessKey=key", '
-                    'expression="//test/result/text()", content_type=xml, wait=15, repeat=True'
+                    'wait=15, repeat=True'
                 ),
             )
             with pytest.raises(RuntimeError) as re:
@@ -514,14 +479,14 @@ class TestAtomicServiceBus:
                 v['test1']
             assert 'AtomicServiceBus.test1: no message on topic:documents-in, subscription:application-x' in str(re)
 
-            v._endpoint_values['test1'] += ['hello world', 'world hello']
+            v._endpoint_messages['test1'] += ['hello world', 'world hello']
 
             assert v['test1'] == 'hello world'
             assert v['test1'] == 'world hello'
             assert v['test1'] == 'hello world'
             assert v['test1'] == 'world hello'
 
-            v._endpoint_values['test1'].clear()
+            v._endpoint_messages['test1'].clear()
 
             v._settings['test1']['repeat'] = False
             with pytest.raises(RuntimeError) as re:
@@ -541,57 +506,27 @@ class TestAtomicServiceBus:
                 'success': True,
                 'payload': '<?xml version="1.0" encoding="utf-8"?><test><result>hello world</result></test>',
             }, 4)
-            xml_transformer = transformer.available[TransformerContentType.XML]
-            del transformer.available[TransformerContentType.XML]
 
-            with pytest.raises(TypeError) as te:
-                v['test1']
-            assert 'AtomicServiceBus.test1: could not find a transformer for XML' in str(te)
-
-            transformer.available[TransformerContentType.XML] = xml_transformer
-
-            assert len(v._endpoint_values['test1']) == 0
-            assert v['test1'] == 'hello world'
-            assert len(v._endpoint_values['test1']) == 0
+            assert len(v._endpoint_messages['test1']) == 0
+            assert v['test1'] == '<?xml version="1.0" encoding="utf-8"?><test><result>hello world</result></test>'
+            assert len(v._endpoint_messages['test1']) == 0
 
             v._settings['test1']['repeat'] = True
-            assert v['test1'] == 'hello world'
-            assert len(v._endpoint_values['test1']) == 1
-            assert v._endpoint_values['test1'][0] == 'hello world'
-
-            v._settings['test1']['expression'] = '/test/result/value/text()'
-            with pytest.raises(RuntimeError) as re:
-                v['test1']
-            assert 'AtomicServiceBus.test1: "/test/result/value/text()" returned no values' in str(re)
+            assert v['test1'] == '<?xml version="1.0" encoding="utf-8"?><test><result>hello world</result></test>'
+            assert len(v._endpoint_messages['test1']) == 1
+            assert v._endpoint_messages['test1'][0] == '<?xml version="1.0" encoding="utf-8"?><test><result>hello world</result></test>'
 
             mock_response({
                 'success': True,
                 'payload': '<?xml version="1.0" encoding="utf-8"?><test><result>hello world</result><result>world hello</result></test>',
             })
 
-            v._settings['test1']['expression'] = '//result/text()'
-
-            with pytest.raises(RuntimeError) as re:
-                v['test1']
-            assert 'AtomicServiceBus.test1: "//result/text()" returned more than one value' in str(re)
-
-            v._settings['test1']['expression'] = '/test/result/text()'
-
-            mock_response({
-                'success': True,
-                'payload': '{"test": {"result": "hello world"}}',
-            })
-
-            with pytest.raises(RuntimeError) as re:
-                v['test1']
-            assert 'AtomicServiceBus.test1: failed to transform input as XML' in str(re)
-
             mock_response({
                 'success': True,
                 'payload': '<?xml version="1.0" encoding="utf-8"?><test><result>hello world</result></test>',
             })
 
-            assert v['test1'] == 'hello world'
+            assert v['test1'] == '<?xml version="1.0" encoding="utf-8"?><test><result>hello world</result></test>'
         finally:
             try:
                 AtomicServiceBus.destroy()
@@ -612,7 +547,7 @@ class TestAtomicServiceBus:
 
         mocker.patch(
             'grizzly.testdata.variables.servicebus.AtomicServiceBus.say_hello',
-            side_effect=[None] * 2,
+            autospec=True,
         )
 
         try:
@@ -620,7 +555,7 @@ class TestAtomicServiceBus:
                 'test',
                 (
                     'topic:documents-in, subscription:application-x | url="sb://sb.example.org/;SharedAccessKeyName=name;SharedAccessKey=key", '
-                    'expression="//test/result/text()", content_type=xml, wait=15, repeat=True'
+                    'wait=15, repeat=True'
                 ),
             )
             assert v['test'] == 'topic:documents-in, subscription:application-x'
@@ -659,7 +594,7 @@ class TestAtomicServiceBus:
                 'test',
                 (
                     'topic:documents-in, subscription:application-x | url="sb://sb.example.org/;SharedAccessKeyName=name;SharedAccessKey=key", '
-                    'expression="//test/result/text()", content_type=xml, wait=15, repeat=True'
+                    'wait=15, repeat=True'
                 ),
             )
             assert v['test'] == 'topic:documents-in, subscription:application-x'
@@ -678,7 +613,7 @@ class TestAtomicServiceBus:
                 'test',
                 (
                     'topic:documents-in, subscription:application-x | url="sb://sb.example.org/;SharedAccessKeyName=name;SharedAccessKey=key", '
-                    'expression="//test/result/text()", content_type=xml, wait=15, repeat=True'
+                    'wait=15, repeat=True'
                 ),
             )
             assert len(v._values.keys()) == 1


### PR DESCRIPTION
do not extract parts of the message, just always return complete messages.

then use TransformationTask to extract parts of the message.