### PR TITLE
AtomicMessageQueue content type support

### DIFF
--- a/grizzly/testdata/variables/messagequeue.py
+++ b/grizzly/testdata/variables/messagequeue.py
@@ -126,7 +126,7 @@ class AtomicMessageQueue(AtomicVariable[str]):
     _zmq_url = 'tcp://127.0.0.1:5554'
     _zmq_context: zmq.Context
 
-    arguments: Dict[str, Any] = {'repeat': bool_typed, 'url': str, 'wait': int}
+    arguments: Dict[str, Any] = {'content_type': str, 'repeat': bool_typed, 'url': str, 'wait': int}
 
     def __init__(self, variable: str, value: str):
         if pymqi.__name__ == 'grizzly_extras.dummy_pymqi':

--- a/grizzly/testdata/variables/messagequeue.py
+++ b/grizzly/testdata/variables/messagequeue.py
@@ -245,7 +245,7 @@ class AtomicMessageQueue(AtomicVariable[str]):
             'key_file': key_file,
             'cert_label': cert_label,
             'ssl_cipher': ssl_cipher,
-            'message_wait': settings.get('wait', None)
+            'message_wait': settings.get('wait', None),
         }
 
     def create_client(self, variable: str, settings: Dict[str, Any]) -> zmq.Socket:
@@ -329,6 +329,9 @@ class AtomicMessageQueue(AtomicVariable[str]):
                 },
                 'payload': None
             }
+            if 'content_type' in self._settings[variable]:
+                request['context']['content_type'] = self._settings[variable]['content_type']
+
 
             self._endpoint_clients[variable].send_json(request)
 

--- a/grizzly/testdata/variables/messagequeue.py
+++ b/grizzly/testdata/variables/messagequeue.py
@@ -50,7 +50,7 @@ Given a user of type "RestApi" load testing "http://example.com"
 ...
 Then get request "fetch-document" from "/api/v1/document/{{ AtomicMessageQueue.document_id }}"
 
-# Using expression to get specific document by text value of "DocumentReference"
+### Using expression to get specific message
 
 And value of variable "AtomicMessageQueue.document_id" is "queue:IN.DOCUMENTS, expression:'//DocumentReference[text()='123abc']' | wait=120, url='mqs://mq_subscription:$conf::mq.password@mq.example.com/?QueueManager=QM1&Channel=SRV.CONN', repeat=True"
 And set response content type to "application/xml"

--- a/grizzly/testdata/variables/messagequeue.py
+++ b/grizzly/testdata/variables/messagequeue.py
@@ -11,10 +11,13 @@ pip3 install grizzly-loadtester[mq]
 
 ## Format
 
+`queue:<queue_name>[, expression:<expression>] | url=<url>, wait=<wait>[, content_type=<content_type>][, repeat=<repeat>]`
+
 Initial value is the name of the queue, prefixed with `queue:`, on the MQ server specified in argument `url`.
+Expression is optional, and can be specified if a message matching specific criteria is to be fetched. The expression format depends on
+content type, which needs to be specified as an argument (e.g. XPATH expressions are used with `application/xml` content type).
 
-## Arguments
-
+* `content_type` _str_ (optional) - specifies the content type of messages on the queue, needed if expressions are to be used when getting messages
 * `repeat` _bool_ (optional) - if `True`, values read for the queue will be saved in a list and re-used if there are no new messages available
 * `url` _str_ - see format of url below.
 * `wait` _int_ - number of seconds to wait for a message on the queue

--- a/grizzly_extras/async_message/mq.py
+++ b/grizzly_extras/async_message/mq.py
@@ -132,8 +132,8 @@ class AsyncMessageQueueHandler(AsyncMessageHandler):
 
         try:
             get_values = transform.parser(expression)
-        except TransformerError as e:
-            raise AsyncMessageError(e.message)
+        except Exception as e:
+            raise AsyncMessageError(str(e))
 
         with self.queue_context(endpoint=queue_name, browsing=True) as browse_queue:
             # Check the queue over and over again until timeout, if nothing was found
@@ -173,6 +173,8 @@ class AsyncMessageQueueHandler(AsyncMessageHandler):
                 cur_time = time()
                 if message_wait is not None and cur_time - start_time >= message_wait:
                     raise AsyncMessageError('timeout while waiting for matching message')
+                elif message_wait is None:
+                    return None
                 else:
                     logger.debug(f'_find_message: no matching message found, trying again after some sleep')
                     sleep(0.5)

--- a/tests/test_grizzly/testdata/variables/test_messagequeue.py
+++ b/tests/test_grizzly/testdata/variables/test_messagequeue.py
@@ -3,7 +3,6 @@ import subprocess
 from os import environ
 from typing import Optional, Callable, cast
 from json import dumps as jsondumps
-from unittest.mock import MagicMock
 
 import pytest
 import zmq

--- a/tests/test_grizzly/testdata/variables/test_messagequeue.py
+++ b/tests/test_grizzly/testdata/variables/test_messagequeue.py
@@ -3,6 +3,7 @@ import subprocess
 from os import environ
 from typing import Optional, Callable, cast
 from json import dumps as jsondumps
+from unittest.mock import MagicMock
 
 import pytest
 import zmq
@@ -56,6 +57,12 @@ def test_atomicmessagequeue__base_type__() -> None:
             'queue:TEST.QUEUE|url="mq://mq.example.com/?QueueManager=QM1&Channel=SRV.CONN", repeat=True, wait=asdf',
         )
     assert "invalid literal for int() with base 10: 'asdf'" in str(ve)
+
+    with pytest.raises(ValueError) as ve:
+        atomicmessagequeue__base_type__(
+            'kurt:TEST.QUEUE|url="mq://mq.example.com/?QueueManager=QM1&Channel=SRV.CONN", repeat=True, wait=20',
+        )
+    assert 'AtomicMessageQueue: queue name must be prefixed with queue:' in str(ve)
 
     safe_value = atomicmessagequeue__base_type__(
         'queue:TEST.QUEUE|url="mq://mq.example.com/?QueueManager=QM1&Channel=SRV.CONN", repeat=True, wait=20',
@@ -451,6 +458,17 @@ class TestAtomicMessageQueue:
             assert v['test'] == jsondumps({'test': {'result': 'hello world'}})
             assert len(v._endpoint_messages['test']) == 1
             assert v._endpoint_messages['test'][0] == jsondumps({'test': {'result': 'hello world'}})
+
+            send_json_spy = mocker.spy(zmq.sugar.socket.Socket, 'send_json')
+            v._settings['test']['content_type'] = 'xml'
+            v['test']
+            send_json_spy.assert_called_once()
+            arg_in = send_json_spy.call_args_list[0][0][1]
+            assert 'context' in arg_in
+            assert 'content_type' in arg_in['context']
+            assert arg_in['context']['content_type'] == 'xml'
+            send_json_spy.reset_mock()
+
         finally:
             try:
                 AtomicMessageQueue.destroy()


### PR DESCRIPTION
Support for specifying content_type as argument to AtomicMessageQueue, plus more test coverage