### PR TITLE
support for offset in AtomicDate

### DIFF
--- a/grizzly/testdata/variables/date.py
+++ b/grizzly/testdata/variables/date.py
@@ -9,6 +9,7 @@ at the time of access.
 
 * `format` _str_ - a python [`strftime` format string](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes), this argument is required
 * `timezone` _str_ (optional) - a valid [timezone name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
+* `offset` _str_ (optional) - a time span string describing the offset, Y = years, M = months, D = days, h = hours, m = minutes, s = seconds, e.g. `1Y-2M10D`
 
 ## Example
 
@@ -25,12 +26,15 @@ This can then be used in a template:
 }
 ```
 '''
+import re
+
 from typing import Union, Dict, Any, List, Type, Optional, cast
 from datetime import datetime
 
 import pytz
 
 from dateutil.parser import ParserError, parse as dateparse
+from dateutil.relativedelta import relativedelta
 from tzlocal import get_localzone as get_local_timezone
 
 from grizzly_extras.arguments import split_value, parse_arguments
@@ -63,6 +67,9 @@ def atomicdate__base_type__(value: str) -> str:
             except pytz.UnknownTimeZoneError:
                 raise ValueError(f'AtomicDate: unknown timezone "{arguments["timezone"]}"')
 
+        if 'offset' in arguments:
+            parse_timespan(arguments['offset'])
+
         value = f'{date_value} | {date_arguments}'
     else:
         date_value = value
@@ -78,11 +85,28 @@ def atomicdate__base_type__(value: str) -> str:
         raise ValueError(f'AtomicDate: {str(e)}') from e
 
 
+def parse_timespan(timespan: str) -> Dict[str, int]:
+    if re.match(r'^-?\d+$', timespan):
+        # if an int is specified we assume they want days
+        return {'days': int(timespan)}
+
+    pattern = re.compile(r'((?P<years>-?\d+?)Y)?((?P<months>-?\d+?)M)?((?P<days>-?\d+?)D)?((?P<hours>-?\d+?)h)?((?P<minutes>-?\d+?)m)?((?P<seconds>-?\d+?)s)?')
+    parts = pattern.match(timespan)
+    if not parts:
+        raise ValueError('invalid time span format')
+    group = parts.groupdict()
+    parameters = {name: int(value) for name, value in group.items() if value}
+    if not parameters:
+        raise ValueError('invalid time span format')
+
+    return parameters
+
+
 class AtomicDate(AtomicVariable[Union[str, datetime]]):
     __base_type__ = atomicdate__base_type__
     __initialized: bool = False
     _settings: Dict[str, Dict[str, Any]]
-    arguments: Dict[str, Any] = {'format': str, 'timezone': str}
+    arguments: Dict[str, Any] = {'format': str, 'timezone': str, 'offset': int}
 
     _special_variables: List[str] = ['now']
 
@@ -94,6 +118,7 @@ class AtomicDate(AtomicVariable[Union[str, datetime]]):
         initial_value: str
         timezone: pytz.BaseTzInfo = get_local_timezone()
         date_format = '%Y-%m-%d %H:%M:%S'
+        offset: Optional[Dict[str, int]] = None
 
         safe_value = self.__class__.__base_type__(value)
 
@@ -106,12 +131,16 @@ class AtomicDate(AtomicVariable[Union[str, datetime]]):
 
             if 'timezone' in arguments:
                 timezone = pytz.timezone(arguments['timezone'])
+
+            if 'offset' in arguments:
+                offset = parse_timespan(arguments['offset'])
         else:
             initial_value = safe_value
 
         settings = {
             'format': date_format,
             'timezone': timezone,
+            'offset': offset,
         }
 
         date_value: Union[str, datetime]
@@ -153,6 +182,11 @@ class AtomicDate(AtomicVariable[Union[str, datetime]]):
                 date_value = value
             else:
                 raise ValueError(f'{self.__class__.__name__}.{variable} was incorrectly initialized with "{value}"')
+
+            offset = self._settings[variable]['offset']
+
+            if offset is not None:
+                date_value += relativedelta(**offset)
 
             return date_value.astimezone(
                 self._settings[variable]['timezone'],


### PR DESCRIPTION
describes the offset with a time span string supporting years, months, days,
hours, minutes and seconds.

all offsets supports negative values.