### PR TITLE
expression support for service bus functionality

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -2,8 +2,8 @@ name: code quality
 
 on:
   pull_request:
-    types: [opened, synchronize]
-  workflow_dispatch:
+    branches:
+    - main
 
 jobs:
   code-quality:

--- a/grizzly/locust.py
+++ b/grizzly/locust.py
@@ -412,8 +412,7 @@ def run(context: Context) -> int:
                 logger.info(f'stopping {external_dependency}')
                 external_process.terminate()
                 if context.config.verbose:
-                    stdout, _ = external_process.communicate()
-                    logger.debug(stdout.decode())
+                    external_process.communicate()
                     logger.debug(f'{external_process.returncode=}')
 
             external_processes.clear()

--- a/grizzly/steps/scenario/tasks.py
+++ b/grizzly/steps/scenario/tasks.py
@@ -219,6 +219,9 @@ def step_task_print_message(context: Context, message: str) -> None:
     grizzly = cast(GrizzlyContext, context.grizzly)
     grizzly.scenario.add_task(PrintTask(message=message))
 
+    if '{{' in message and '}}' in message:
+        grizzly.scenario.orphan_templates.append(message)
+
 
 @then(u'parse "{content}" as "{content_type:ContentType}" and save value of "{expression}" in variable "{variable}"')
 def step_task_transform(context: Context, content: str, content_type: TransformerContentType, expression: str, variable: str) -> None:

--- a/grizzly/users/messagequeue.py
+++ b/grizzly/users/messagequeue.py
@@ -30,7 +30,7 @@ a specific message is to be retrieved from the queue. The format of endpoint is:
 queue:<queue_name>[, expression:<expression>]
 ```
 
-Where `<expression>` can be of XPath or jsonpath type, depending on the specified content type. See example below.
+Where `<expression>` can be a XPath or jsonpath expression, depending on the specified content type. See example below.
 
 ## Examples
 
@@ -58,7 +58,7 @@ In this example, the request will not fail if there is a message on queue within
 When specifying an expression, the messages on the queue are first browsed. If any message matches the expression, it is
 later consumed from the queue. If no matching message was found during browsing, it is repeated again after a slight delay,
 up until the specified `message.wait` seconds has elapsed. To use expressions, a content type must be specified for the get
-request, e.g. `"application/xml"`:
+request, e.g. `application/xml`:
 
 ```gherkin
 Given a user of type "MessageQueue" load testing "mq://mq.example.com/?QueueManager=QM01&Channel=SRVCONN01"
@@ -315,7 +315,7 @@ class MessageQueueUser(ResponseHandler, RequestLogger, ContextVariables):
             metadata['abort'] = True
             # Parse the endpoint to validate queue name / expression parts
             try:
-                arguments = parse_arguments(request.endpoint, ':')
+                arguments = parse_arguments(endpoint, ':')
             except ValueError as e:
                 raise RuntimeError(str(e)) from e
 

--- a/grizzly/users/messagequeue.py
+++ b/grizzly/users/messagequeue.py
@@ -104,6 +104,7 @@ import zmq
 
 from gevent import sleep as gsleep
 from locust.exception import StopUser
+from grizzly.types import RequestDirection
 from grizzly_extras.async_message import AsyncMessageContext, AsyncMessageRequest, AsyncMessageResponse, AsyncMessageError
 from grizzly_extras.arguments import get_unsupported_arguments, parse_arguments
 

--- a/grizzly/users/servicebus.py
+++ b/grizzly/users/servicebus.py
@@ -73,6 +73,7 @@ from locust.exception import StopUser
 from gevent import sleep as gsleep
 from grizzly_extras.async_message import AsyncMessageContext, AsyncMessageResponse, AsyncMessageRequest, AsyncMessageError
 from grizzly_extras.arguments import parse_arguments, get_unsupported_arguments
+from grizzly_extras.transformer import TransformerContentType
 
 from ..types import RequestMethod, RequestDirection
 from ..task import RequestTask
@@ -305,9 +306,10 @@ class ServiceBusUser(ResponseHandler, RequestLogger, ContextVariables):
         self.say_hello(request, endpoint)
 
         context = cast(AsyncMessageContext, dict(self.am_context))
-        context.update({
-            'endpoint': endpoint,
-        })
+        context['endpoint'] = endpoint
+
+        if request.response.content_type != TransformerContentType.GUESS:
+            context['content_type'] = request.response.content_type.name.lower()
 
         am_request: AsyncMessageRequest = {
             'action': request.method.name,

--- a/grizzly/users/servicebus.py
+++ b/grizzly/users/servicebus.py
@@ -231,6 +231,9 @@ class ServiceBusUser(ResponseHandler, RequestLogger, ContextVariables):
             'meta': False,
         }
 
+        if task.response.content_type != TransformerContentType.GUESS:
+            request['context']['content_type'] = task.response.content_type.name.lower()
+
         response: Optional[AsyncMessageResponse] = None
         exception: Optional[Exception] = None
 
@@ -307,9 +310,6 @@ class ServiceBusUser(ResponseHandler, RequestLogger, ContextVariables):
 
         context = cast(AsyncMessageContext, dict(self.am_context))
         context['endpoint'] = endpoint
-
-        if request.response.content_type != TransformerContentType.GUESS:
-            context['content_type'] = request.response.content_type.name.lower()
 
         am_request: AsyncMessageRequest = {
             'action': request.method.name,

--- a/grizzly_extras/arguments.py
+++ b/grizzly_extras/arguments.py
@@ -9,7 +9,7 @@ def get_unsupported_arguments(valid_arguments: List[str], arguments: Dict[str, A
     return [argument for argument in arguments.keys() if argument not in valid_arguments]
 
 
-def parse_arguments(arguments: str, separator:str = '=') -> Dict[str, Any]:
+def parse_arguments(arguments: str, separator: str = '=', unquote: bool = True) -> Dict[str, Any]:
     if separator not in arguments or (arguments.count(separator) > 1 and (arguments.count('"') < 2 and arguments.count("'") < 2) and ', ' not in arguments):
         raise ValueError(f'incorrect format in arguments: "{arguments}"')
 
@@ -41,12 +41,14 @@ def parse_arguments(arguments: str, separator:str = '=') -> Dict[str, Any]:
             if value[-1] != value[0]:
                 raise ValueError(f'value is incorrectly quoted: "{value}"')
             start_quote = value[0]
-            value = value[1:]
+            if unquote:
+                value = value[1:]
 
         if value[-1] in ['"', "'"]:
             if start_quote is None:
                 raise ValueError(f'value is incorrectly quoted: "{value}"')
-            value = value[:-1]
+            if unquote:
+                value = value[:-1]
 
         if start_quote is None and ' ' in value:
             raise ValueError(f'value needs to be quoted: "{value}"')

--- a/grizzly_extras/async_message/__init__.py
+++ b/grizzly_extras/async_message/__init__.py
@@ -75,8 +75,8 @@ class AsyncMessageHandler(ABC):
     def handle(self, request: AsyncMessageRequest) -> AsyncMessageResponse:
         action = request['action']
         request_handler = self.get_handler(action)
-        logger.debug(f'handling {action}')
-        logger.debug(jsondumps(request, indent=2, cls=JsonBytesEncoder))
+        logger.debug(f'{self.worker}: handling {action}')
+        logger.debug(f'{self.worker}: {jsondumps(request, indent=2, cls=JsonBytesEncoder)}')
 
         response: AsyncMessageResponse
 
@@ -93,6 +93,7 @@ class AsyncMessageHandler(ABC):
                 'success': False,
                 'message': f'{action}: {e.__class__.__name__}="{str(e)}"',
             }
+            logger.error(f'{self.worker}: {action}: {e.__class__.__name__}="{str(e)}"', exc_info=True)
         finally:
             total_time = int((time() - start_time) * 1000)
             response.update({
@@ -100,8 +101,8 @@ class AsyncMessageHandler(ABC):
                 'response_time': total_time,
             })
 
-            logger.debug(f'handled {action}')
-            logger.debug(jsondumps(response, indent=2, cls=JsonBytesEncoder))
+            logger.debug(f'{self.worker}: handled {action}')
+            logger.debug(f'{self.worker}: {jsondumps(response, indent=2, cls=JsonBytesEncoder)}')
 
             return response
 

--- a/grizzly_extras/async_message/mq.py
+++ b/grizzly_extras/async_message/mq.py
@@ -125,7 +125,7 @@ class AsyncMessageQueueHandler(AsyncMessageHandler):
     def _find_message(self, queue_name: str, expression: str, content_type: TransformerContentType, message_wait: Optional[int]) -> Optional[bytearray]:
         start_time = time()
 
-        logger.debug(f'_find_message: searching {queue_name} for messages matching: {expression}, content_type {content_type.name.lower()}')
+        logger.debug(f'{self.worker}: _find_message: searching {queue_name} for messages matching: {expression}, content_type {content_type.name.lower()}')
         transform = transformer.available.get(content_type, None)
         if transform is None:
             raise AsyncMessageError(f'could not find a transformer for {content_type.name}')
@@ -156,7 +156,7 @@ class AsyncMessageQueueHandler(AsyncMessageHandler):
 
                         if len(values) > 0:
                             # Found a matching message, return message id
-                            logger.debug(f'_find_message: found matching message: {md["MsgId"]}')
+                            logger.debug(f'{self.worker}: _find_message: found matching message: {md["MsgId"]}')
                             return cast(bytearray, md['MsgId'])
 
                         gmo.Options = pymqi.CMQC.MQGMO_BROWSE_NEXT
@@ -176,7 +176,7 @@ class AsyncMessageQueueHandler(AsyncMessageHandler):
                 elif message_wait is None:
                     return None
                 else:
-                    logger.debug(f'_find_message: no matching message found, trying again after some sleep')
+                    logger.debug(f'{self.worker}: _find_message: no matching message found, trying again after some sleep')
                     sleep(0.5)
 
     def _get_content_type(self, request: AsyncMessageRequest) -> TransformerContentType:
@@ -225,7 +225,7 @@ class AsyncMessageQueueHandler(AsyncMessageHandler):
             # Adjust message_wait for getting the message
             if message_wait is not None:
                 message_wait -= elapsed_time
-                logger.debug(f'_request: remaining message_wait after finding message: {message_wait}')
+                logger.debug(f'{self.worker}: _request: remaining message_wait after finding message: {message_wait}')
 
         md = pymqi.MD()
         with self.queue_context(endpoint=queue_name) as queue:

--- a/grizzly_extras/transformer.py
+++ b/grizzly_extras/transformer.py
@@ -95,7 +95,16 @@ class JsonTransformer(Transformer):
 
     @classmethod
     def validate(cls, expression: str) -> bool:
-        return expression.startswith('$.') and len(expression) > 2
+        valid = expression.startswith('$.') and len(expression) > 2
+        if not valid:
+            return valid
+
+        try:
+            jsonpath_parse(expression)
+        except:
+            valid = False
+
+        return valid
 
     @classmethod
     def parser(cls, expression: str) -> Callable[[Any], List[str]]:

--- a/grizzly_extras/transformer.py
+++ b/grizzly_extras/transformer.py
@@ -117,7 +117,7 @@ class JsonTransformer(Transformer):
             def get_values(input_payload: Any) -> List[str]:
                 values: List[str] = []
                 for m in jsonpath.find(input_payload):
-                    if m.value is None:
+                    if m is None or m.value is None:
                         continue
 
                     if isinstance(m.value, (dict, list, )):

--- a/tests/test_grizzly/testdata/variables/test_messagequeue.py
+++ b/tests/test_grizzly/testdata/variables/test_messagequeue.py
@@ -15,6 +15,7 @@ from grizzly.testdata.variables import AtomicMessageQueue
 from grizzly.testdata.variables.messagequeue import atomicmessagequeue__base_type__
 from grizzly.context import GrizzlyContext
 from grizzly_extras.async_message import AsyncMessageResponse
+from grizzly_extras.transformer import TransformerContentType
 
 try:
     import pymqi
@@ -459,7 +460,7 @@ class TestAtomicMessageQueue:
             assert v._endpoint_messages['test'][0] == jsondumps({'test': {'result': 'hello world'}})
 
             send_json_spy = mocker.spy(zmq.sugar.socket.Socket, 'send_json')
-            v._settings['test']['content_type'] = 'xml'
+            v._settings['test']['content_type'] = TransformerContentType.XML
             v['test']
             send_json_spy.assert_called_once()
             arg_in = send_json_spy.call_args_list[0][0][1]

--- a/tests/test_grizzly/testdata/variables/test_servicebus.py
+++ b/tests/test_grizzly/testdata/variables/test_servicebus.py
@@ -387,7 +387,9 @@ class TestAtomicServiceBus:
             client = context.socket(zmq.REQ)
 
             v._settings['test2'] = {
-                'context': {},
+                'context': {
+                    'endpoint': 'topic:test-topic',
+                },
                 'worker': None,
             }
 
@@ -410,7 +412,9 @@ class TestAtomicServiceBus:
             assert args[0] == {
                 'worker': None,
                 'action': 'HELLO',
-                'context': {},
+                'context': {
+                    'endpoint': 'topic:test-topic',
+                },
             }
             assert v._settings['test2'].get('worker', '') is None
 

--- a/tests/test_grizzly/users/test_messagequeue.py
+++ b/tests/test_grizzly/users/test_messagequeue.py
@@ -426,8 +426,14 @@ class TestMessageQueueUser:
         )
 
         mocker.patch(
+            'grizzly.users.messagequeue.zmq.sugar.socket.Socket.disconnect',
+            side_effect=[zmq.ZMQError] * 10,
+        )
+
+        mocker.patch(
             'grizzly.users.messagequeue.zmq.sugar.socket.Socket.recv_json',
             side_effect=[
+                zmq.Again,
                 {
                     'success': True,
                     'worker': '0000-1337',
@@ -581,7 +587,7 @@ class TestMessageQueueUser:
         user.request(request)
         assert send_json_spy.call_count == 1
         args, _ = send_json_spy.call_args_list[0]
-        ctx : Dict[str, str] = args[1]['context']
+        ctx: Dict[str, str] = args[1]['context']
         assert ctx['endpoint'] == request.endpoint
 
         # Test with specifying queue: prefix as endpoint
@@ -599,6 +605,7 @@ class TestMessageQueueUser:
         args, _ = send_json_spy.call_args_list[2]
         ctx = args[1]['context']
         assert ctx['endpoint'] == request.endpoint
+
 
         # Test specifying queue: prefix with expression, and spacing
         request.endpoint = 'queue: IFKTEST2  , expression: /class/student[marks>85]'
@@ -621,7 +628,33 @@ class TestMessageQueueUser:
         with pytest.raises(StopUser):
             user.request(request)
 
+        # Test with expression argument but wrong method
+        request.endpoint = 'IFKTEST3, expression:/class/student[marks<55]'
+        request.method = RequestMethod.PUT
+
+        with pytest.raises(StopUser):
+            user.request(request)
+
+        assert response_event_spy.call_count == 7
         assert send_json_spy.call_count == 5
+        _, kwargs = response_event_spy.call_args_list[6]
+        exception = kwargs.get('exception', None)
+        assert isinstance(exception, RuntimeError)
+        assert str(exception) == 'argument "expression" is not allowed when sending to an endpoint'
+
+        # Test with empty queue name
+        request.endpoint = 'queue:, expression:/class/student[marks<55]'
+        request.method = RequestMethod.GET
+
+        with pytest.raises(StopUser):
+            user.request(request)
+
+        assert response_event_spy.call_count == 8
+        assert send_json_spy.call_count == 5
+        _, kwargs = response_event_spy.call_args_list[7]
+        exception = kwargs.get('exception', None)
+        assert isinstance(exception, RuntimeError)
+        assert str(exception) == f'failed to extract queue name from: {request.endpoint}'
 
         send_json_spy.reset_mock()
         request_event_spy.reset_mock()

--- a/tests/test_grizzly/users/test_messagequeue.py
+++ b/tests/test_grizzly/users/test_messagequeue.py
@@ -629,7 +629,7 @@ class TestMessageQueueUser:
             user.request(request)
 
         # Test with expression argument but wrong method
-        request.endpoint = 'IFKTEST3, expression:/class/student[marks<55]'
+        request.endpoint = 'queue:IFKTEST3, expression:/class/student[marks<55]'
         request.method = RequestMethod.PUT
 
         with pytest.raises(StopUser):
@@ -654,7 +654,7 @@ class TestMessageQueueUser:
         _, kwargs = response_event_spy.call_args_list[7]
         exception = kwargs.get('exception', None)
         assert isinstance(exception, RuntimeError)
-        assert str(exception) == f'failed to extract queue name from: {request.endpoint}'
+        assert str(exception) == f'invalid value for argument "queue"'
 
         send_json_spy.reset_mock()
         request_event_spy.reset_mock()

--- a/tests/test_grizzly/users/test_servicebus.py
+++ b/tests/test_grizzly/users/test_servicebus.py
@@ -245,6 +245,7 @@ class TestServiceBusUser:
         _, kwargs = response_event_fire_spy.call_args_list[1]
         assert kwargs.get('name', None) == f'{scenario.identifier} {task.name}'
         assert kwargs.get('request', None) is task
+
         metadata, payload = kwargs.get('context', (None, None,))
         assert metadata is None
         assert payload is None
@@ -259,6 +260,7 @@ class TestServiceBusUser:
         assert kwargs.get('context', None) == user._context
         exception = kwargs.get('exception', None)
         assert 'unknown error' in str(exception)
+
         args, _ = send_json_spy.call_args_list[0]
         assert args[0] == {
             'worker': 'asdf-asdf-asdf',
@@ -294,6 +296,7 @@ class TestServiceBusUser:
         _, kwargs = response_event_fire_spy.call_args_list[2]
         assert kwargs.get('name', None) == f'{scenario.identifier} {task.name}'
         assert kwargs.get('request', None) is task
+
         metadata, payload = kwargs.get('context', (None, None,))
         assert metadata == {'meta': True}
         assert payload is 'hello'
@@ -307,8 +310,8 @@ class TestServiceBusUser:
         assert kwargs.get('response_length', None) == 133
         assert kwargs.get('context', None) == user._context
         assert kwargs.get('exception', '') is None
+
         args, _ = send_json_spy.call_args_list[1]
-        print(args[0])
         assert args[0] == {
             'worker': 'asdf-asdf-asdf',
             'action': 'RECEIVE',

--- a/tests/test_grizzly/users/test_servicebus.py
+++ b/tests/test_grizzly/users/test_servicebus.py
@@ -168,7 +168,7 @@ class TestServiceBusUser:
                 'message_wait': None,
             }
         }
-        assert args[3] == 'receiver=topic:test-topic'
+        assert args[3] == 'receiver=topic:test-topic, subscription:test-subscription'
 
         # error handling
         task.endpoint = 'test-topic'
@@ -202,7 +202,7 @@ class TestServiceBusUser:
         assert 'endpoint needs to include subscription when receiving messages from a topic' in str(re)
 
         task.method = RequestMethod.SEND
-        task.endpoint = 'topic:test-topic, expression:$.test.result'
+        task.endpoint = 'topic:test-topic2, expression:$.test.result'
         with pytest.raises(RuntimeError) as re:
             user.say_hello(task, task.endpoint)
         assert 'argument expression is only allowed when receiving messages' in str(re)

--- a/tests/test_grizzly_extras/test_transformer.py
+++ b/tests/test_grizzly_extras/test_transformer.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Any
+from typing import List, Tuple, Any, Dict
 from json import dumps as jsondumps, loads as jsonloads
 from json.decoder import JSONDecodeError
 
@@ -150,7 +150,7 @@ class TestJsonTransformer:
         with pytest.raises(ValueError):
             JsonTransformer.parser('$.')
 
-        example = {
+        example: Dict[str, Any] = {
             'glossary': {
                 'title': 'example glossary',
                 'GlossDiv': {
@@ -213,6 +213,17 @@ class TestJsonTransformer:
         actual = get_values(False)
         assert len(actual) == 1
         assert actual == ['False']
+
+        example = {
+            'document': {
+                'name': 'test',
+                'id': 13,
+            },
+        }
+        get_values = JsonTransformer.parser('$.`this`[?(@.name="test")]')
+        actual = get_values(example)
+
+        assert len(actual) > 0
 
 
 class TestXmlTransformer:


### PR DESCRIPTION
only get messages that matches the expression (if specified). support in both `AtomicServiceBus` and `ServiceBusUser`.

however, this does not work as good as it does for message queue, because when returning a message (abandon) will increase the delivery count which will result after 10 (default value) abandonings move the message to the dead-letter queue.

so do not use this if you actually care about the messages that doesn't match your expression, and instead use subscriptions with filters on the "server side" instead.