### PR TITLE
transparent support for setting content type in endpoint

### DIFF
--- a/grizzly/steps/scenario/tasks.py
+++ b/grizzly/steps/scenario/tasks.py
@@ -60,6 +60,18 @@ def step_task_request_text_with_name_to_endpoint(context: Context, method: Reque
     Then receive request with name "test-receive" from endpoint "queue:receive-queue"
     ```
 
+    `endpoint` has support for setting response content type as a parameter:
+
+    ```gherkin
+    Then receive request with name "test-receive" from endpoint "queue:receive-queue | content_type=xml"
+
+    # same as
+    Then receive request with name "test-receive" from endpoint "queue:receive-queue"
+    And set response content type to "xml"
+    ```
+
+    `content_type` will be removed from the actual `endpoint` value.
+
     Args:
         method (RequestMethod): type of request
         name (str): name of the requests in logs, can contain variables
@@ -89,6 +101,18 @@ def step_task_request_file_with_name_endpoint(context: Context, method: RequestM
     Then put request "test/request.j2.json" with name "test-put" to endpoint "/api/test"
     ```
 
+    `endpoint` has support for setting response content type as a parameter:
+
+    ```gherkin
+    Then put request "test/request.j2.json" with name "test-put" to endpoint "/api/test | content_type=json"
+
+    # same as
+    Then put request "test/request.j2.json" with name "test-put" to endpoint "/api/test"
+    And set response content type to "application/json"
+    ```
+
+    `content_type` will be removed from the actual `endpoint` value.
+
     Args:
         method (RequestMethod): type of request
         source (str): path to a template file relative to the directory `requests/`, which **must** exist in the directory the feature file is located
@@ -112,6 +136,18 @@ def step_task_request_file_with_name(context: Context, method: RequestMethod, so
     Then post request "test/request1.j2.json" with name "test-post1" to endpoint "/api/test"
     Then post request "test/request2.j2.json" with name "test-post2" to endpoint "/api/test"
     ```
+
+    `endpoint` has support for setting response content type as a parameter:
+
+    ```gherkin
+    Then post request "test/request1.j2.json" with name "test-post1" to endpoint "/api/test | content_type=json"
+
+    # same as
+    Then post request "test/request1.j2.json" with name "test-post1" to endpoint "/api/test"
+    And set response content type to "application/json"
+    ```
+
+    `content_type` will be removed from the actual `endpoint` value.
 
     Args:
         method (RequestMethod): type of request

--- a/grizzly/task/request.py
+++ b/grizzly/task/request.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 
 from jinja2.environment import Template
 from grizzly_extras.transformer import TransformerContentType
+from grizzly_extras.arguments import parse_arguments, split_value, unquote
 
 from ..types import HandlerType, RequestMethod
 from ..context import GrizzlyTask, GrizzlyTasksBase
@@ -63,6 +64,25 @@ class RequestTask(GrizzlyTask):
     source: Optional[str] = field(init=False, repr=False, default=None)
 
     response: RequestTaskResponse = field(init=False, repr=False, default_factory=RequestTaskResponse)
+
+    def __post_init__(self) -> None:
+        content_type: TransformerContentType = TransformerContentType.GUESS
+
+        if '|' in self.endpoint:
+            value, value_arguments = split_value(self.endpoint)
+            arguments = parse_arguments(value_arguments, unquote=False)
+
+            if 'content_type' in arguments:
+                content_type = TransformerContentType.from_string(unquote(arguments['content_type']))
+                del arguments['content_type']
+
+            value_arguments = ', '.join([f'{key}={value}' for key, value in arguments.items()])
+            if len(value_arguments) > 0:
+                self.endpoint = f'{value} | {value_arguments}'
+            else:
+                self.endpoint = value
+
+        self.response.content_type = content_type
 
     def implementation(self) -> Callable[[GrizzlyTasksBase], Any]:
         def _implementation(parent: GrizzlyTasksBase) -> Any:

--- a/grizzly/users/messagequeue.py
+++ b/grizzly/users/messagequeue.py
@@ -107,6 +107,7 @@ from locust.exception import StopUser
 from grizzly.types import RequestDirection
 from grizzly_extras.async_message import AsyncMessageContext, AsyncMessageRequest, AsyncMessageResponse, AsyncMessageError
 from grizzly_extras.arguments import get_unsupported_arguments, parse_arguments
+from grizzly_extras.transformer import TransformerContentType
 
 from ..types import RequestDirection
 from ..task import RequestTask
@@ -306,10 +307,12 @@ class MessageQueueUser(ResponseHandler, RequestLogger, ContextVariables):
             'worker': self.worker_id,
             'context': {
                 'endpoint': endpoint,
-                'content_type': request.response.content_type.name.lower(),
             },
             'payload': payload,
         }
+
+        if request.response.content_type != TransformerContentType.GUESS:
+            am_request['context']['content_type'] = request.response.content_type.name.lower()
 
         with action(am_request, name) as metadata:
             metadata['abort'] = True

--- a/grizzly_extras/arguments.py
+++ b/grizzly_extras/arguments.py
@@ -9,6 +9,13 @@ def get_unsupported_arguments(valid_arguments: List[str], arguments: Dict[str, A
     return [argument for argument in arguments.keys() if argument not in valid_arguments]
 
 
+def unquote(argument: str) -> str:
+    if argument[0] == argument[-1] and argument[0] in ['"', "'"]:
+        argument = argument[1:-1]
+
+    return argument
+
+
 def parse_arguments(arguments: str, separator: str = '=', unquote: bool = True) -> Dict[str, Any]:
     if separator not in arguments or (arguments.count(separator) > 1 and (arguments.count('"') < 2 and arguments.count("'") < 2) and ', ' not in arguments):
         raise ValueError(f'incorrect format in arguments: "{arguments}"')

--- a/tests/test_grizzly/steps/scenario/test_response.py
+++ b/tests/test_grizzly/steps/scenario/test_response.py
@@ -297,3 +297,16 @@ def test_step_response_content_type(behave_context: Context) -> None:
     with pytest.raises(AssertionError) as ae:
         step_response_content_type(behave_context, TransformerContentType.GUESS)
     assert 'It is now allowed to set GUESS with this step' in str(ae)
+
+    request = RequestTask(RequestMethod.POST, 'test-request', endpoint='queue:INCOMING.MESSAGE | content_type="application/xml"')
+
+    assert request.response.content_type == TransformerContentType.XML
+    assert request.endpoint == 'queue:INCOMING.MESSAGE'
+
+    grizzly.scenario.add_task(request)
+
+    for content_type in TransformerContentType:
+        if content_type == TransformerContentType.GUESS:
+            continue
+        step_response_content_type(behave_context, content_type)
+        assert request.response.content_type == content_type

--- a/tests/test_grizzly_extras/test_arguments.py
+++ b/tests/test_grizzly_extras/test_arguments.py
@@ -1,6 +1,6 @@
 import pytest
 
-from grizzly_extras.arguments import split_value, get_unsupported_arguments, parse_arguments
+from grizzly_extras.arguments import split_value, get_unsupported_arguments, parse_arguments, unquote
 
 @pytest.mark.parametrize('separator', ['|', ', '])
 def test_split_value(separator: str) -> None:
@@ -26,6 +26,12 @@ def test_get_unsupported_arguments() -> None:
         'foo': True,
         'bar': False,
     }) == []
+
+
+def test_unquote() -> None:
+    assert unquote('"hello"') == 'hello'
+    assert unquote("'hello world'") == 'hello world'
+    assert unquote('foo bar') == 'foo bar'
 
 
 @pytest.mark.parametrize('separator', ['=', ':', '%'])


### PR DESCRIPTION
support for setting content type via endpoint in RequestTask.
if argument content_type is present in endpoint, .response.content_type
will be set accordingly and then removed from the endpoint value.

any additional arguments will be preserved, and if content_type is the
only argument `|` will also be removed.