### PR TITLE
Feature/parameterize more

### DIFF
--- a/grizzly/steps/background/shapes.py
+++ b/grizzly/steps/background/shapes.py
@@ -1,5 +1,5 @@
 '''This module contains step implementations that describes the actual load all scenarios in a feature will generate.'''
-from typing import cast
+from typing import Any, Dict, cast
 
 import parse
 
@@ -20,8 +20,8 @@ register_type(
 )
 
 
-@given(u'"{value}" {user_number:UserGramaticalNumber}')
-def step_shapes_user_count(context: Context, value: str, _: str) -> None:
+@given(u'"{value}" {grammar:UserGramaticalNumber}')
+def step_shapes_user_count(context: Context, value: str, **kwargs: Dict[str, Any]) -> None:
     '''Set number of users that will generate load.
 
     ```gherkin
@@ -48,8 +48,8 @@ def step_shapes_user_count(context: Context, value: str, _: str) -> None:
     grizzly.setup.user_count = user_count
 
 
-@given(u'spawn rate is "{value}" {user_number:UserGramaticalNumber} per second')
-def step_shapes_spawn_rate(context: Context, value: str, _: str) -> None:
+@given(u'spawn rate is "{value}" {grammar:UserGramaticalNumber} per second')
+def step_shapes_spawn_rate(context: Context, value: str, **kwargs: Dict[str, Any]) -> None:
     '''Set rate in which locust shall swarm new user instances.
 
     ```gherkin

--- a/grizzly/steps/background/shapes.py
+++ b/grizzly/steps/background/shapes.py
@@ -7,6 +7,7 @@ from behave.runner import Context
 from behave import register_type, given  # pylint: disable=no-name-in-module
 
 from ...context import GrizzlyContext
+from ...testdata.utils import resolve_variable
 
 
 @parse.with_pattern(r'(user[s]?)')
@@ -19,8 +20,8 @@ register_type(
 )
 
 
-@given(u'"{user_count:d}" {user_number:UserGramaticalNumber}')
-def step_shapes_user_count(context: Context, user_count: int, user_number: str) -> None:
+@given(u'"{value}" {user_number:UserGramaticalNumber}')
+def step_shapes_user_count(context: Context, value: str, _: str) -> None:
     '''Set number of users that will generate load.
 
     ```gherkin
@@ -32,21 +33,23 @@ def step_shapes_user_count(context: Context, user_count: int, user_number: str) 
     Args:
         user_count (int): Number of users locust should create
     '''
-    if user_count > 1:
-        assert user_number == 'users', 'when user_count is greater than 1, use "users"'
-    else:
-        assert user_number == 'user', 'when user_count is 1, use "user"'
-
     grizzly = cast(GrizzlyContext, context.grizzly)
+    should_resolve = '{{' in value and '}}' in value or value[0] == '$'
+    user_count = int(round(float(resolve_variable(grizzly, value)), 0))
+
+    if should_resolve and user_count < 1:
+        user_count = 1
+
+    assert user_count >= 0, f'{value} resolved to {user_count} users, which is not valid'
 
     if grizzly.setup.spawn_rate is not None:
-        assert user_count > grizzly.setup.spawn_rate, f'spawn rate can not be greater than user count'
+        assert user_count >= grizzly.setup.spawn_rate, f'spawn rate ({grizzly.setup.spawn_rate}) can not be greater than user count ({user_count})'
 
     grizzly.setup.user_count = user_count
 
 
-@given(u'spawn rate is "{spawn_rate:g}" {user_number:UserGramaticalNumber} per second')
-def step_shapes_spawn_rate(context: Context, spawn_rate: float, user_number: str) -> None:
+@given(u'spawn rate is "{value}" {user_number:UserGramaticalNumber} per second')
+def step_shapes_spawn_rate(context: Context, value: str, _: str) -> None:
     '''Set rate in which locust shall swarm new user instances.
 
     ```gherkin
@@ -58,7 +61,15 @@ def step_shapes_spawn_rate(context: Context, spawn_rate: float, user_number: str
     Args:
         spawn_rate (float): number of users per second
     '''
+    assert isinstance(value, str), f'{value} is not a string'
     grizzly = cast(GrizzlyContext, context.grizzly)
+    should_resolve = '{{' in value and '}}' in value or value[0] == '$'
+    spawn_rate = float(resolve_variable(grizzly, value))
+
+    if should_resolve and spawn_rate < 0.01:
+        spawn_rate = 0.01
+
+    assert spawn_rate > 0.0, f'{value} resolved to {spawn_rate} users, which is not valid'
 
     if grizzly.setup.user_count is not None:
         assert int(spawn_rate) <= grizzly.setup.user_count, f'spawn rate can not be greater than user count'

--- a/grizzly/steps/setup.py
+++ b/grizzly/steps/setup.py
@@ -1,12 +1,13 @@
 from typing import cast
 from os import environ
 
-from behave import given  # pylint: disable=no-name-in-module
+from behave import given, then  # pylint: disable=no-name-in-module
 from behave.runner import Context
 
 from ..context import GrizzlyContext
 
 
+@then(u'ask for value of variable "{name}"')
 @given(u'ask for value of variable "{name}"')
 def step_setup_variable_value_ask(context: Context, name: str) -> None:
     '''This step is used to indicate for `grizzly-cli` that it should ask for an initial value for the variable.

--- a/tests/test_grizzly/steps/background/test_shapes.py
+++ b/tests/test_grizzly/steps/background/test_shapes.py
@@ -29,36 +29,36 @@ def test_step_shapes_user_count(behave_context: Context) -> None:
     grizzly = cast(GrizzlyContext, behave_context.grizzly)
     assert grizzly.setup.user_count == 0
 
-    step_impl(behave_context, '10', 'user')
+    step_impl(behave_context, '10', grammar='user')
     assert grizzly.setup.user_count == 10
 
-    step_impl(behave_context, '10', 'users')
+    step_impl(behave_context, '10', grammar='users')
     assert grizzly.setup.user_count == 10
 
-    step_impl(behave_context, '1', 'user')
+    step_impl(behave_context, '1', grammar='user')
     assert grizzly.setup.user_count == 1
 
-    step_impl(behave_context, '1', 'users')
+    step_impl(behave_context, '1', grammar='users')
     assert grizzly.setup.user_count == 1
 
     grizzly.setup.spawn_rate = 10
 
     with pytest.raises(AssertionError):
-        step_impl(behave_context, '1', 'user')
+        step_impl(behave_context, '1', grammar='user')
 
     grizzly.setup.spawn_rate = 4
 
     with pytest.raises(AssertionError) as ae:
-        step_impl(behave_context, '{{ user_count }}', 'user')
+        step_impl(behave_context, '{{ user_count }}', grammar='user')
     assert 'value contained variable "user_count" which has not been set' in str(ae)
 
     grizzly.state.variables['user_count'] = 5
-    step_impl(behave_context, '{{ user_count }}', 'user')
+    step_impl(behave_context, '{{ user_count }}', grammar='user')
     assert grizzly.setup.user_count == 5
 
     grizzly.setup.spawn_rate = None
 
-    step_impl(behave_context, '{{ user_count * 0.1 }}', 'user')
+    step_impl(behave_context, '{{ user_count * 0.1 }}', grammar='user')
     assert grizzly.setup.user_count == 1
 
 
@@ -71,29 +71,29 @@ def test_step_shapes_spawn_rate(behave_context: Context) -> None:
 
     # spawn_rate must be <= user_count
     with pytest.raises(AssertionError):
-        step_impl(behave_context, '1', 'user')
+        step_impl(behave_context, '1', grammar='user')
 
     grizzly.setup.user_count = 10
-    step_impl(behave_context, '0.1', 'users')
+    step_impl(behave_context, '0.1', grammar='users')
     assert grizzly.setup.spawn_rate == 0.1
 
-    step_impl(behave_context, '10', 'users')
+    step_impl(behave_context, '10', grammar='users')
     assert grizzly.setup.spawn_rate == 10
 
     grizzly.setup.user_count = 1
 
     with pytest.raises(AssertionError):
-        step_impl(behave_context, '10', 'users')
+        step_impl(behave_context, '10', grammar='users')
 
     with pytest.raises(AssertionError) as ae:
-        step_impl(behave_context, '{{ spawn_rate }}', 'users')
+        step_impl(behave_context, '{{ spawn_rate }}', grammar='users')
     assert 'value contained variable "spawn_rate" which has not been set' in str(ae)
 
     grizzly.setup.spawn_rate = None
     grizzly.state.variables['spawn_rate'] = 1
-    step_impl(behave_context, '{{ spawn_rate }}', 'users')
+    step_impl(behave_context, '{{ spawn_rate }}', grammar='users')
     assert grizzly.setup.spawn_rate == 1.0
 
-    step_impl(behave_context, '{{ spawn_rate / 1000 }}', 'users')
+    step_impl(behave_context, '{{ spawn_rate / 1000 }}', grammar='users')
     assert grizzly.setup.spawn_rate == 0.01
 

--- a/tests/test_grizzly/steps/background/test_shapes.py
+++ b/tests/test_grizzly/steps/background/test_shapes.py
@@ -29,24 +29,37 @@ def test_step_shapes_user_count(behave_context: Context) -> None:
     grizzly = cast(GrizzlyContext, behave_context.grizzly)
     assert grizzly.setup.user_count == 0
 
-    with pytest.raises(AssertionError):
-        step_impl(behave_context, 10, 'user')
-
-    step_impl(behave_context, 10, 'users')
-
+    step_impl(behave_context, '10', 'user')
     assert grizzly.setup.user_count == 10
 
-    step_impl(behave_context, 1, 'user')
+    step_impl(behave_context, '10', 'users')
+    assert grizzly.setup.user_count == 10
 
+    step_impl(behave_context, '1', 'user')
     assert grizzly.setup.user_count == 1
 
-    with pytest.raises(AssertionError):
-        step_impl(behave_context, 1, 'users')
+    step_impl(behave_context, '1', 'users')
+    assert grizzly.setup.user_count == 1
 
     grizzly.setup.spawn_rate = 10
 
     with pytest.raises(AssertionError):
-        step_impl(behave_context, 1, 'user')
+        step_impl(behave_context, '1', 'user')
+
+    grizzly.setup.spawn_rate = 4
+
+    with pytest.raises(AssertionError) as ae:
+        step_impl(behave_context, '{{ user_count }}', 'user')
+    assert 'value contained variable "user_count" which has not been set' in str(ae)
+
+    grizzly.state.variables['user_count'] = 5
+    step_impl(behave_context, '{{ user_count }}', 'user')
+    assert grizzly.setup.user_count == 5
+
+    grizzly.setup.spawn_rate = None
+
+    step_impl(behave_context, '{{ user_count * 0.1 }}', 'user')
+    assert grizzly.setup.user_count == 1
 
 
 @pytest.mark.usefixtures('behave_context')
@@ -58,16 +71,29 @@ def test_step_shapes_spawn_rate(behave_context: Context) -> None:
 
     # spawn_rate must be <= user_count
     with pytest.raises(AssertionError):
-        step_impl(behave_context, 1, 'user')
+        step_impl(behave_context, '1', 'user')
 
     grizzly.setup.user_count = 10
-    step_impl(behave_context, 0.1, 'users')
+    step_impl(behave_context, '0.1', 'users')
     assert grizzly.setup.spawn_rate == 0.1
 
-    step_impl(behave_context, 10, 'users')
+    step_impl(behave_context, '10', 'users')
     assert grizzly.setup.spawn_rate == 10
 
     grizzly.setup.user_count = 1
 
     with pytest.raises(AssertionError):
-        step_impl(behave_context, 10, 'users')
+        step_impl(behave_context, '10', 'users')
+
+    with pytest.raises(AssertionError) as ae:
+        step_impl(behave_context, '{{ spawn_rate }}', 'users')
+    assert 'value contained variable "spawn_rate" which has not been set' in str(ae)
+
+    grizzly.setup.spawn_rate = None
+    grizzly.state.variables['spawn_rate'] = 1
+    step_impl(behave_context, '{{ spawn_rate }}', 'users')
+    assert grizzly.setup.spawn_rate == 1.0
+
+    step_impl(behave_context, '{{ spawn_rate / 1000 }}', 'users')
+    assert grizzly.setup.spawn_rate == 0.01
+


### PR DESCRIPTION
Templating support for values in grizzly.steps.background.shape

Which allows user provided values at run time.

This also requires >= grizzly-loadtester-cli-1.0.4.