### PR TITLE
init racecondition

### DIFF
--- a/grizzly/testdata/variables/csv_row.py
+++ b/grizzly/testdata/variables/csv_row.py
@@ -125,20 +125,20 @@ class AtomicCsvRow(AtomicVariable[Dict[str, Any]]):
 
         super().__init__(variable, {})
 
-        if self.__initialized:
-            with self._semaphore:
+        with self._semaphore:
+            if self.__initialized:
                 if variable not in self._rows:
                     self._rows[variable] = self._create_row_queue(csv_file)
 
                 if variable not in self._settings:
                     self._settings[variable] = settings
 
-            return
+                return
 
-        self.context_root = os.path.join(os.environ.get('GRIZZLY_CONTEXT_ROOT', ''), 'requests')
-        self._rows = {variable: self._create_row_queue(csv_file)}
-        self._settings = {variable: settings}
-        self.__initialized = True
+            self.context_root = os.path.join(os.environ.get('GRIZZLY_CONTEXT_ROOT', ''), 'requests')
+            self._rows = {variable: self._create_row_queue(csv_file)}
+            self._settings = {variable: settings}
+            self.__initialized = True
 
     def _create_row_queue(self, value: str) -> List[Dict[str, Any]]:
         queue: List[Dict[str, Any]] = []

--- a/grizzly/testdata/variables/date.py
+++ b/grizzly/testdata/variables/date.py
@@ -152,14 +152,14 @@ class AtomicDate(AtomicVariable[Union[str, datetime]]):
 
         super().__init__(variable, date_value)
 
-        if self.__initialized:
-            with self._semaphore:
+        with self._semaphore:
+            if self.__initialized:
                 self._settings[variable] = settings
 
-            return
+                return
 
-        self._settings = {variable: settings}
-        self.__initialized = True
+            self._settings = {variable: settings}
+            self.__initialized = True
 
     @classmethod
     def clear(cls: Type['AtomicDate']) -> None:

--- a/grizzly/testdata/variables/directory_contents.py
+++ b/grizzly/testdata/variables/directory_contents.py
@@ -99,20 +99,20 @@ class AtomicDirectoryContents(AtomicVariable[str]):
 
         super().__init__(variable, directory)
 
-        if self.__initialized:
-            with self._semaphore:
+        with self._semaphore:
+            if self.__initialized:
                 if variable not in self._files:
                     self._files[variable] = self._create_file_queue(directory)
 
                 if variable not in self._settings:
                     self._settings[variable] = settings
 
-            return
+                return
 
-        self._requests_context_root = os.path.join(os.environ.get('GRIZZLY_CONTEXT_ROOT', '.'), 'requests')
-        self._files = {variable: self._create_file_queue(directory)}
-        self._settings = {variable: settings}
-        self.__initialized = True
+            self._requests_context_root = os.path.join(os.environ.get('GRIZZLY_CONTEXT_ROOT', '.'), 'requests')
+            self._files = {variable: self._create_file_queue(directory)}
+            self._settings = {variable: settings}
+            self.__initialized = True
 
     @classmethod
     def clear(cls: Type['AtomicDirectoryContents']) -> None:

--- a/grizzly/testdata/variables/integer_incrementer.py
+++ b/grizzly/testdata/variables/integer_incrementer.py
@@ -92,15 +92,15 @@ class AtomicIntegerIncrementer(AtomicVariable[int]):
 
         super().__init__(variable, int(initial_value))
 
-        if self.__initialized:
-            with self._semaphore:
+        with self._semaphore:
+            if self.__initialized:
                 if variable not in self._steps:
                     self._steps[variable] = step
 
-            return
+                return
 
-        self._steps = {variable: step}
-        self.__initialized = True
+            self._steps = {variable: step}
+            self.__initialized = True
 
     @classmethod
     def clear(cls: Type['AtomicIntegerIncrementer']) -> None:

--- a/grizzly/testdata/variables/messagequeue.py
+++ b/grizzly/testdata/variables/messagequeue.py
@@ -160,8 +160,8 @@ class AtomicMessageQueue(AtomicVariable[str]):
 
         super().__init__(variable, queue_name)
 
-        if self.__initialized:
-            with self._semaphore:
+        with self._semaphore:
+            if self.__initialized:
                 if variable not in self._endpoint_messages:
                     self._endpoint_messages[variable] = []
 
@@ -171,13 +171,13 @@ class AtomicMessageQueue(AtomicVariable[str]):
                 if variable not in self._endpoint_clients:
                     self._endpoint_clients[variable] = self.create_client(variable, settings)
 
-            return
+                return
 
-        self._endpoint_messages = {variable: []}
-        self._settings = {variable: settings}
-        self._zmq_context = zmq.Context()
-        self._endpoint_clients = {variable: self.create_client(variable, settings)}
-        self.__initialized = True
+            self._endpoint_messages = {variable: []}
+            self._settings = {variable: settings}
+            self._zmq_context = zmq.Context()
+            self._endpoint_clients = {variable: self.create_client(variable, settings)}
+            self.__initialized = True
 
     @classmethod
     def create_context(cls, settings: Dict[str, Any]) -> AsyncMessageContext:

--- a/grizzly/testdata/variables/random_integer.py
+++ b/grizzly/testdata/variables/random_integer.py
@@ -58,15 +58,15 @@ class AtomicRandomInteger(AtomicVariable[int]):
 
         super().__init__(variable, minimum)
 
-        if self.__initialized:
-            with self._semaphore:
+        with self._semaphore:
+            if self.__initialized:
                 if variable not in self._max:
                     self._max[variable] = maximum
 
-            return
+                return
 
-        self._max = {variable: maximum}
-        self.__initialized = True
+            self._max = {variable: maximum}
+            self.__initialized = True
 
     @classmethod
     def clear(cls: Type['AtomicRandomInteger']) -> None:

--- a/grizzly/testdata/variables/random_string.py
+++ b/grizzly/testdata/variables/random_string.py
@@ -111,15 +111,15 @@ class AtomicRandomString(AtomicVariable[str]):
 
         super().__init__(variable, string_pattern)
 
-        if self.__initialized:
-            with self._semaphore:
+        with self._semaphore:
+            if self.__initialized:
                 if variable not in self._strings:
                     self._strings[variable] = self._generate_strings(string_pattern, settings)
 
-            return
+                return
 
-        self._strings = {variable: self._generate_strings(string_pattern, settings)}
-        self.__initialized = True
+            self._strings = {variable: self._generate_strings(string_pattern, settings)}
+            self.__initialized = True
 
     def _generate_s(self) -> str:
         return choice(ascii_letters)

--- a/grizzly/testdata/variables/servicebus.py
+++ b/grizzly/testdata/variables/servicebus.py
@@ -257,8 +257,8 @@ class AtomicServiceBus(AtomicVariable[str]):
 
         super().__init__(variable, endpoint_name)
 
-        if self.__initialized:
-            with self._semaphore:
+        with self._semaphore:
+            if self.__initialized:
                 if variable not in self._endpoint_messages:
                     self._endpoint_messages[variable] = []
 
@@ -268,13 +268,13 @@ class AtomicServiceBus(AtomicVariable[str]):
                 if variable not in self._endpoint_clients:
                     self._endpoint_clients[variable] = self.create_client(variable, settings)
 
-            return
+                return
 
-        self._endpoint_messages = {variable: []}
-        self._settings = {variable: settings}
-        self._zmq_context = zmq.Context()
-        self._endpoint_clients = {variable: self.create_client(variable, settings)}
-        self.__initialized = True
+            self._endpoint_messages = {variable: []}
+            self._settings = {variable: settings}
+            self._zmq_context = zmq.Context()
+            self._endpoint_clients = {variable: self.create_client(variable, settings)}
+            self.__initialized = True
 
     @classmethod
     def create_context(cls, settings: Dict[str, Any]) -> AsyncMessageContext:


### PR DESCRIPTION
all variables used the semphore incorrectly, which
caused a race condition when initializing variables, causing them
overwrite settings etc. for each other.

mostly noticeable with AtomicServiceBus and AtomicMessageQueue
which has some "slow" calls in __init__.