### PR TITLE
Feature/scenario info

### DIFF
--- a/grizzly/context.py
+++ b/grizzly/context.py
@@ -107,6 +107,7 @@ class GrizzlyContextScenarioUser:
 @dataclass(unsafe_hash=True)
 class GrizzlyContextScenario:
     name: str = field(init=False, hash=True)
+    description: str = field(init=False, hash=False)
     user: GrizzlyContextScenarioUser = field(init=False, hash=False, compare=False, default_factory=GrizzlyContextScenarioUser)
     _identifier: Optional[str] = field(init=False, hash=True, default=None)
     iterations: int = field(init=False, repr=False, hash=False, compare=False, default=1)
@@ -223,6 +224,7 @@ class GrizzlyContext:
             name = source
 
         scenario.name = name
+        scenario.description = name
         self._scenarios.append(scenario)
 
     def scenarios(self) -> List[GrizzlyContextScenario]:

--- a/grizzly/locust.py
+++ b/grizzly/locust.py
@@ -1,3 +1,4 @@
+import sys
 import logging
 import subprocess
 
@@ -190,6 +191,32 @@ def setup_environment_listeners(context: Context, environment: Environment, requ
     grizzly.state.environment = environment
 
     return external_dependencies
+
+
+def print_scenario_summary(grizzly: GrizzlyContext) -> None:
+    def print_table_lines(length: int) -> None:
+        length -= 11
+        sys.stdout.write('-' * 10)
+        sys.stdout.write('|')
+        sys.stdout.write('-' * length)
+        sys.stdout.write('|\n')
+
+    rows: List[str] = []
+    max_length = 0
+
+    for scenario in grizzly.scenarios():
+        row = '{:11} {}'.format(scenario.identifier, scenario.description or 'unknown')
+        row_length = len(row)
+        if row_length > max_length:
+            max_length = row_length
+        rows.append(row)
+
+    print('Scenario')
+    print('{:11} {}'.format('identifier', 'description'))
+    print_table_lines(max_length)
+    for row in rows:
+        print(row)
+    print_table_lines(max_length)
 
 
 def run(context: Context) -> int:
@@ -390,13 +417,7 @@ def run(context: Context) -> int:
                 print_stats(runner.stats, current=False)
                 print_percentile_stats(runner.stats)
                 print_error_report(runner.stats)
-
-                print('Scenario')
-                print('{:11} {}'.format('identifier', 'description'))
-                print('-' * 25)
-                for scenario in grizzly.scenarios():
-                    print('{:11} {}'.format(scenario.identifier, scenario.description or 'unknown'))
-                print('-' * 25)
+                print_scenario_summary(grizzly)
 
             return code
 

--- a/grizzly/locust.py
+++ b/grizzly/locust.py
@@ -391,6 +391,12 @@ def run(context: Context) -> int:
                 print_percentile_stats(runner.stats)
                 print_error_report(runner.stats)
 
+                print('Scenario')
+                print('{:11} {}'.format('identifier', 'description'))
+                print('-' * 25)
+                for scenario in grizzly.scenarios():
+                    print('{:11} {}'.format(scenario.identifier, scenario.description or 'unknown'))
+                print('-' * 25)
 
             return code
 

--- a/pydoc-markdown.yaml
+++ b/pydoc-markdown.yaml
@@ -116,7 +116,8 @@ renderer:
               - grizzly.steps.scenario.results.*
           - title: Anywhere
             contents:
-            - grizzly.steps.*
+            - grizzly.steps.setup.*
+            - grizzly.steps.utils.*
       - title: Load Users
         children:
         - title: Rest API


### PR DESCRIPTION
`scenario.name` is used to identify the name of the generated class definition for the user of a scenario and is overwritten in `locust.py` when creating that instance.

This leaves no clear way to identify in which scenario a request failed, unless you manually calculate the `sha1` hash sum of the name and takes the first 8 characters from that.

This fixes it by adding a new attribute to `GrizzlyScenarioContext` called `description` which is populated with the scenario name when a scenario is added to `GrizzlyContext`.

When a feature file is done, grizzly will print out a summary of the identifiers and descriptions, so its easy to know which scenario in the feature file had any failed requests (if any).
