### PR TITLE
request response_time fixes

### DIFF
--- a/grizzly/environment.py
+++ b/grizzly/environment.py
@@ -1,6 +1,6 @@
 from os import environ
 from typing import Any, Dict, Tuple, cast
-from time import monotonic as time_monotonic
+from time import perf_counter as time
 
 import setproctitle as proc
 
@@ -29,7 +29,7 @@ def before_feature(context: Context, *_args: Tuple[Any, ...], **kwargs: Dict[str
     grizzly.state.verbose = context.config.verbose
 
     context.grizzly = grizzly
-    context.started = time_monotonic()
+    context.started = time()
     environ['GRIZZLY_CONTEXT_ROOT'] = context.config.base_dir
 
 
@@ -44,7 +44,7 @@ def after_feature(context: Context, feature: Feature, *_args: Tuple[Any, ...], *
 
     # the features duration is the sum of all scenarios duration, which is the sum of all steps duration
     try:
-        duration = int(time_monotonic() - context.started)
+        duration = int(time() - context.started)
 
         feature.scenarios[-1].steps[-1].duration = duration
     except Exception:

--- a/grizzly/task/getter/__init__.py
+++ b/grizzly/task/getter/__init__.py
@@ -1,6 +1,6 @@
 from typing import Dict, Generator, Type, List, Any, Optional, Set
 from contextlib import contextmanager
-from time import monotonic as time
+from time import perf_counter as time
 
 from locust.exception import StopUser
 

--- a/grizzly/testdata/utils.py
+++ b/grizzly/testdata/utils.py
@@ -3,7 +3,7 @@ import logging
 from typing import Optional, List, Dict, Any, Tuple, Set, cast
 from collections import namedtuple
 from os import environ
-from time import monotonic as time
+from time import perf_counter as time
 
 from jinja2 import Template, Environment
 from jinja2.meta import find_undeclared_variables
@@ -86,14 +86,16 @@ def transform(data: Dict[str, Any], objectify: Optional[bool] = True) -> Dict[st
                 try:
                     value = variable_instance[variable_name]
                 except Exception as e:
+                    import traceback
+                    traceback.print_exc()
                     exception = e
                     logger.error(str(e), exc_info=grizzly.state.verbose)
                 finally:
-                    total_time = int((time() - start_time) * 1000)
+                    response_time = int((time() - start_time) * 1000)
                     grizzly.state.environment.events.request.fire(
                         request_type='VAR ',
                         name=key,
-                        response_time=total_time,
+                        response_time=response_time,
                         response_length=0,
                         context=None,
                         exception=exception,

--- a/grizzly/users/blobstorage.py
+++ b/grizzly/users/blobstorage.py
@@ -31,7 +31,7 @@ import os
 
 from typing import Dict, Any, Tuple, Optional
 from urllib.parse import urlparse, parse_qs
-from time import monotonic as time
+from time import perf_counter as time
 
 from azure.storage.blob import BlobServiceClient
 from locust.exception import StopUser

--- a/grizzly/users/messagequeue.py
+++ b/grizzly/users/messagequeue.py
@@ -96,7 +96,7 @@ Default certificate label is set to `auth.username`, change it by setting `auth.
 from typing import Dict, Any, Generator, Tuple, Optional, cast
 from urllib.parse import urlparse, parse_qs, unquote
 from contextlib import contextmanager
-from time import monotonic as time
+from time import perf_counter as time
 
 
 import zmq

--- a/grizzly/users/restapi.py
+++ b/grizzly/users/restapi.py
@@ -59,7 +59,7 @@ import json
 import re
 
 from typing import Dict, Optional, Any, Tuple, List, cast
-from time import time, monotonic as time_monotonic
+from time import time, perf_counter as time_perf_counter
 from functools import wraps
 from enum import Enum
 from urllib.parse import parse_qs, urlparse
@@ -214,7 +214,7 @@ class RestApiUser(ResponseHandler, RequestLogger, ContextVariables, HttpRequests
         }
 
         auth_user_context = self._context['auth']['user']
-        start_time = time_monotonic()
+        start_time = time_perf_counter()
         total_response_length = 0
         try:
             if self._context['auth']['url'] is None:
@@ -454,7 +454,7 @@ class RestApiUser(ResponseHandler, RequestLogger, ContextVariables, HttpRequests
 
             request_meta = {
                 'request_type': 'GET',
-                'response_time': (time_monotonic() - start_time) * 1000,
+                'response_time': int((time_perf_counter() - start_time) * 1000),
                 'name': f'{name} OAuth2 user token',
                 'context': self._context,
                 'response': None,

--- a/grizzly/users/servicebus.py
+++ b/grizzly/users/servicebus.py
@@ -67,7 +67,7 @@ And set response content type to "application/xml"
 '''
 from typing import Generator, Dict, Any, Tuple, Optional, Set, cast
 from urllib.parse import urlparse, parse_qs
-from time import monotonic as time
+from time import perf_counter as time
 from contextlib import contextmanager
 
 import zmq

--- a/grizzly/users/sftp.py
+++ b/grizzly/users/sftp.py
@@ -31,7 +31,7 @@ Then get request from endpoint "/pub/blobs/blob.file"
 '''
 from typing import Any, Dict, Tuple, Optional
 from urllib.parse import urlparse
-from time import monotonic as time
+from time import perf_counter as time
 from os import path, environ, mkdir
 
 from locust.exception import StopUser
@@ -132,11 +132,11 @@ class SftpUser(ContextVariables, FileRequests):
         except Exception as e:
             exception = e
         finally:
-            total_time = int((time() - start_time) * 1000)
+            response_time = int((time() - start_time) * 1000)
             self.environment.events.request.fire(
                 request_type=f'sftp:{request.method.name[:4]}',
                 name=name,
-                response_time=total_time,
+                response_time=response_time,
                 response_length=response_length,
                 context=self._context,
                 exception=exception,


### PR DESCRIPTION
make sure that response_time always is an int.
use perf_counter instead of monotonic to measure
spent time.

fixed test coverage.