### PR TITLE
Feature/request until

### DIFF
--- a/grizzly/__init__.py
+++ b/grizzly/__init__.py
@@ -1,7 +1,1 @@
 __version__ = '0.0.0'
-
-try:
-    from gevent.monkey import patch_all
-    patch_all()
-except:
-    pass  # setup.py that is importing __version__

--- a/grizzly/steps/helpers.py
+++ b/grizzly/steps/helpers.py
@@ -88,9 +88,18 @@ def add_request_task_response_status_codes(request: RequestTask, status_list: st
         request.response.add_status_code(int(status.strip()))
 
 
-def add_request_task(context: Context, method: RequestMethod, source: Optional[str] = None, name: Optional[str] = None, endpoint: Optional[str] = None) -> None:
+def add_request_task(
+    context: Context,
+    method: RequestMethod,
+    source: Optional[str] = None,
+    name: Optional[str] = None,
+    endpoint: Optional[str] = None,
+    in_scenario: Optional[bool] = True,
+) -> List[RequestTask]:
     grizzly = cast(GrizzlyContext, context.grizzly)
     scenario_tasks_count = len(grizzly.scenario.tasks)
+
+    request_tasks: List[RequestTask] = []
 
     table: List[Optional[Row]]
     content_type: Optional[TransformerContentType] = None
@@ -143,7 +152,12 @@ def add_request_task(context: Context, method: RequestMethod, source: Optional[s
         name = orig_name
         source = orig_source
 
-        grizzly.scenario.tasks.append(request_task)
+        if in_scenario:
+            grizzly.scenario.tasks.append(request_task)
+        else:
+            request_tasks.append(request_task)
+
+    return request_tasks
 
 
 def get_matches(

--- a/grizzly/steps/helpers.py
+++ b/grizzly/steps/helpers.py
@@ -95,11 +95,11 @@ def add_request_task(
     name: Optional[str] = None,
     endpoint: Optional[str] = None,
     in_scenario: Optional[bool] = True,
-) -> List[RequestTask]:
+) -> List[Tuple[RequestTask, Dict[str, str]]]:
     grizzly = cast(GrizzlyContext, context.grizzly)
     scenario_tasks_count = len(grizzly.scenario.tasks)
 
-    request_tasks: List[RequestTask] = []
+    request_tasks: List[Tuple[RequestTask, Dict[str, str]]] = []
 
     table: List[Optional[Row]]
     content_type: Optional[TransformerContentType] = None
@@ -137,11 +137,11 @@ def add_request_task(
 
         if row is not None:
             for key, value in row.as_dict().items():
+                substitutes.update({key: value})
                 endpoint = endpoint.replace(f'{{{{ {key} }}}}', value)
                 if name is not None:
                     name = name.replace(f'{{{{ {key} }}}}', value)
                 if source is not None:
-                    substitutes.update({key: value})
                     source = source.replace(f'{{{{ {key} }}}}', value)
 
         request_task = create_request_task(context, method, source, endpoint, name, substitutes=substitutes)
@@ -155,7 +155,7 @@ def add_request_task(
         if in_scenario:
             grizzly.scenario.tasks.append(request_task)
         else:
-            request_tasks.append(request_task)
+            request_tasks.append((request_task, substitutes,))
 
     return request_tasks
 

--- a/grizzly/steps/scenario/tasks.py
+++ b/grizzly/steps/scenario/tasks.py
@@ -28,7 +28,7 @@ register_type(
     ContentType=TransformerContentType.from_string,
 )
 
-@then(u'{method:Method} request with name "{name}" from endpoint "{endpoint}" until "{condition}')
+@then(u'{method:Method} request with name "{name}" from endpoint "{endpoint}" until "{condition}"')
 def step_task_request_with_name_to_endpoint_until(context: Context, method: RequestMethod, name: str, endpoint: str, condition: str) -> None:
     '''Creates a named request to an endpoint on `host` and repeat it until `condition` is true in the response.
 
@@ -59,11 +59,18 @@ def step_task_request_with_name_to_endpoint_until(context: Context, method: Requ
 
     grizzly = cast(GrizzlyContext, context.grizzly)
 
-    for request_task in request_tasks:
+    for request_task, substitues in request_tasks:
+        condition_rendered = condition
+        for key, value in substitues.items():
+            condition_rendered = condition_rendered.replace(f'{{{{ {key} }}}}', value)
+
         grizzly.scenario.tasks.append(UntilRequestTask(
             request=request_task,
-            condition=condition,
+            condition=condition_rendered,
         ))
+
+        if '{{' in condition_rendered and '}}' in condition_rendered:
+            grizzly.scenario.orphan_templates.append(condition_rendered)
 
 
 

--- a/grizzly/steps/scenario/tasks.py
+++ b/grizzly/steps/scenario/tasks.py
@@ -29,7 +29,7 @@ register_type(
 )
 
 @then(u'{method:Method} request with name "{name}" from endpoint "{endpoint}" until "{condition}')
-def step_task_request_text_with_name_to_endpoint_until(context: Context, method: RequestMethod, name: str, endpoint: str, condition: str) -> None:
+def step_task_request_with_name_to_endpoint_until(context: Context, method: RequestMethod, name: str, endpoint: str, condition: str) -> None:
     '''Creates a named request to an endpoint on `host` and repeat it until `condition` is true in the response.
 
     ```gherkin

--- a/grizzly/task/__init__.py
+++ b/grizzly/task/__init__.py
@@ -2,6 +2,7 @@ from .request import RequestTask, RequestTaskHandlers, RequestTaskResponse
 from .wait import WaitTask
 from .print import PrintTask
 from .transformer import TransformerTask
+from .until import UntilRequestTask
 
 __all__ = [
     'RequestTaskHandlers',
@@ -10,4 +11,5 @@ __all__ = [
     'PrintTask',
     'WaitTask',
     'TransformerTask',
+    'UntilRequestTask',
 ]

--- a/grizzly/task/transformer.py
+++ b/grizzly/task/transformer.py
@@ -25,7 +25,7 @@ class TransformerTask(GrizzlyTask):
     content_type: TransformerContentType
 
     _transformer: Type[Transformer] = field(init=False, repr=False)
-    _get_values: Callable[[Any], List[str]] = field(init=False, repr=False)
+    _parser: Callable[[Any], List[str]] = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
         grizzly = GrizzlyContext()
@@ -42,7 +42,7 @@ class TransformerTask(GrizzlyTask):
         if not self._transformer.validate(self.expression):
             raise ValueError(f'{self.__class__.__name__}: {self.expression} is not a valid expression for {self.content_type.name}')
 
-        self._get_values = self._transformer.parser(self.expression)
+        self._parser = self._transformer.parser(self.expression)
 
     def implementation(self) -> Callable[[GrizzlyTasksBase], Any]:
         def _implementation(parent: GrizzlyTasksBase) -> Any:
@@ -54,7 +54,7 @@ class TransformerTask(GrizzlyTask):
                 parent.logger.error(f'failed to transform as {self.content_type.name}: {content_raw}')
                 raise TransformerLocustError(f'{self.__class__.__name__}: failed to transform {self.content_type.name}') from e
 
-            values = self._get_values(content)
+            values = self._parser(content)
 
             number_of_values = len(values)
 

--- a/grizzly/task/until.py
+++ b/grizzly/task/until.py
@@ -1,0 +1,104 @@
+'''This task calls the `request` method of a `grizzly.users` implementation, until condition matches the
+payload returned for the request.
+
+`condition` is a JSON- or Xpath expression, that also has support for "grizzly style" arguments:
+
+Arguments:
+
+* `retries` (int): maximum number of times to repeat the request if `condition` is not met (default `3`)
+
+* `wait` (float): number of seconds to wait between retries (default `1.0`)
+
+Instances of this task is created with step expression:
+
+* [`step_task_request_text_with_name_to_endpoint_until`](/grizzly/usage/steps/scenario/tasks/#step_task_request_text_with_name_to_endpoint_until)
+'''
+from typing import Callable, Any, Type, List, Optional
+from dataclasses import dataclass, field
+from time import perf_counter as time
+
+from jinja2 import Template
+from gevent import sleep as gsleep
+from locust.exception import StopUser
+from grizzly_extras.transformer import Transformer, transformer
+from grizzly_extras.arguments import get_unsupported_arguments, parse_arguments, split_value
+
+from ..context import GrizzlyTask, GrizzlyTasksBase
+from .request import RequestTask
+
+@dataclass
+class UntilRequestTask(GrizzlyTask):
+    request: RequestTask
+    condition: str
+
+    transform: Type[Transformer] = field(init=False)
+    matcher: Callable[[Any], List[str]] = field(init=False)
+
+    retries: int = field(init=False, default=3)
+    wait: float = field(init=False, default=1.0)
+
+    def __post_init__(self) -> None:
+        self.transform = transformer.available[self.request.response.content_type]
+
+
+    def implementation(self) -> Callable[[GrizzlyTasksBase], Any]:
+        if self.transform is None:
+            raise TypeError(f'could not find a transformer for {self.request.response.content_type.name}')
+
+        if '|' in self.condition:
+            self.condition, until_arguments = split_value(self.condition)
+
+            arguments = parse_arguments(until_arguments)
+
+            unsupported_arguments = get_unsupported_arguments(['retries', 'wait'], arguments)
+
+            if len(unsupported_arguments) > 0:
+                raise ValueError(f'unsupported arguments {", ".join(unsupported_arguments)}')
+
+            self.retries = arguments.get('retries', self.retries)
+            self.wait = arguments.get('wait', self.wait)
+
+        def _implementation(parent: GrizzlyTasksBase) -> Any:
+            interpolated_expression = Template(self.condition).render(parent.user.context_variables)
+
+            if self.transform.validate(interpolated_expression):
+                raise RuntimeError(f'{interpolated_expression} is not a valid expression for {self.request.response.content_type.name}')
+
+            parser = self.transform.parser(self.condition)
+            number_of_matches = 0
+            retry = 0
+            exception: Optional[Exception] = None
+
+            start = time()
+
+            try:
+                while number_of_matches != 1 and retry < self.retries:
+                    _, payload = parent.user.request(self.request)
+
+                    number_of_matches = len(parser(payload))
+
+                    if number_of_matches != 1:
+                        parent.logger.debug(f'')
+                        gsleep(self.wait)
+                        retry += 1
+            except Exception as e:
+                exception = e
+            finally:
+                response_time = int((time() - start) * 1000)
+
+                if exception is not None and number_of_matches != 1:
+                    exception = RuntimeError(f'found {number_of_matches} matching values for {interpolated_expression} in payload')
+
+                parent.user.environment.events.request.fire(
+                    request_type='UNTIL',
+                    name=f'{self.request.scenario.identifier} {self.request.name}, wait={self.wait}s, retries={self.retries}',
+                    response_time=response_time,
+                    response_length=0,
+                    context=parent.user._context,
+                    exception=exception,
+                )
+
+                if exception is not None:
+                    raise StopUser()
+
+        return _implementation

--- a/grizzly/types.py
+++ b/grizzly/types.py
@@ -69,6 +69,8 @@ TestdataType = Dict[str, Dict[str, Any]]
 
 GrizzlyDictValueType = Union[str, float, int, bool]
 
+GrizzlyResponse = Tuple[Optional[Dict[str, Any]], Optional[Any]]
+
 WrappedFunc = TypeVar('WrappedFunc', bound=Callable[..., Any])
 
 T = TypeVar('T')

--- a/grizzly/users/blobstorage.py
+++ b/grizzly/users/blobstorage.py
@@ -37,7 +37,7 @@ from azure.storage.blob import BlobServiceClient
 from locust.exception import StopUser
 
 from .meta import ContextVariables
-from ..types import RequestMethod
+from ..types import RequestMethod, GrizzlyResponse
 from ..task import RequestTask
 from ..utils import merge_dicts
 
@@ -75,7 +75,7 @@ class BlobStorageUser(ContextVariables):
         self.client = BlobServiceClient.from_connection_string(conn_str=self.host)
         self._context = merge_dicts(super().context(), self.__class__._context)
 
-    def request(self, request: RequestTask) -> None:
+    def request(self, request: RequestTask) -> GrizzlyResponse:
         request_name, endpoint, payload = self.render(request)
 
         name = f'{request.scenario.identifier} {request_name}'
@@ -104,3 +104,5 @@ class BlobStorageUser(ContextVariables):
 
             if exception is not None and request.scenario.stop_on_failure:
                 raise StopUser()
+
+            return {}, payload

--- a/grizzly/users/meta/context_variables.py
+++ b/grizzly/users/meta/context_variables.py
@@ -9,6 +9,7 @@ from locust.env import Environment
 
 from grizzly.context import GrizzlyContextScenario
 
+from ...types import GrizzlyResponse
 from ...task import RequestTask
 from ...utils import merge_dicts
 from . import logger, FileRequests
@@ -31,7 +32,7 @@ class ContextVariables(User):
         self._context = merge_dicts({}, ContextVariables._context)
 
     @abstractmethod
-    def request(self, request: RequestTask) -> None:
+    def request(self, request: RequestTask) -> GrizzlyResponse:
         raise NotImplementedError(f'{self.__class__.__name__} has not implemented request(RequestTask)')
 
     def render(self, request: RequestTask) -> Tuple[str, str, Optional[str]]:

--- a/grizzly/users/restapi.py
+++ b/grizzly/users/restapi.py
@@ -71,7 +71,7 @@ import requests
 from locust.clients import ResponseContextManager
 from locust.exception import CatchResponseError, StopUser
 
-from ..types import WrappedFunc
+from ..types import GrizzlyResponse, WrappedFunc
 from ..utils import merge_dicts
 from ..types import RequestMethod
 from ..task import RequestTask
@@ -538,7 +538,7 @@ class RestApiUser(ResponseHandler, RequestLogger, ContextVariables, HttpRequests
         return message
 
     @refresh_token()
-    def request(self, request: RequestTask) -> None:
+    def request(self, request: RequestTask) -> GrizzlyResponse:
         if request.method not in [RequestMethod.GET, RequestMethod.PUT, RequestMethod.POST]:
             raise NotImplementedError(f'{request.method.name} is not implemented for {self.__class__.__name__}')
 
@@ -591,6 +591,10 @@ class RestApiUser(ResponseHandler, RequestLogger, ContextVariables, HttpRequests
 
             if not response._manual_result == True and request.scenario.stop_on_failure:
                 raise StopUser()
+
+            headers = dict(response.headers) if response.headers not in [None, {}] else None
+
+            return headers, response.text
 
     def add_context(self, context: Dict[str, Any]) -> None:
         if context.get('auth', {}).get('user', {}).get('username', None) is not None:

--- a/grizzly/utils.py
+++ b/grizzly/utils.py
@@ -91,10 +91,10 @@ def create_user_class_type(scenario: GrizzlyContextScenario, global_context: Opt
         global_context = {}
 
     if not hasattr(scenario, 'user') or scenario.user is None:
-        raise ValueError(f'{scenario.identifier} does not have user set')
+        raise ValueError(f'scenario {scenario.description} has not set a user')
 
     if not hasattr(scenario.user, 'class_name') or scenario.user.class_name is None:
-        raise ValueError(f'{scenario.identifier} user does not have class_name set')
+        raise ValueError(f'scenario {scenario.description} does not have a user type set')
 
     if scenario.user.class_name.count('.') > 0:
         module, user_class_name = scenario.user.class_name.rsplit('.', 1)

--- a/grizzly_extras/transformer.py
+++ b/grizzly_extras/transformer.py
@@ -114,7 +114,7 @@ class JsonTransformer(Transformer):
 
             jsonpath = jsonpath_parse(expression)
 
-            def get_values(input_payload: Any) -> List[str]:
+            def _parser(input_payload: Any) -> List[str]:
                 values: List[str] = []
                 for m in jsonpath.find(input_payload):
                     if m is None or m.value is None:
@@ -129,7 +129,7 @@ class JsonTransformer(Transformer):
 
                 return values
 
-            return get_values
+            return _parser
         except Exception as e:
             raise ValueError(f'{cls.__name__}: unable to parse "{expression}": {str(e)}') from e
 

--- a/tests/test_grizzly/helpers.py
+++ b/tests/test_grizzly/helpers.py
@@ -6,27 +6,10 @@ from types import MethodType
 from locust import task
 
 from grizzly.users.meta import ContextVariables
-from grizzly.types import GrizzlyResponse, RequestMethod
+from grizzly.types import GrizzlyResponse
 from grizzly.task import RequestTask
 from grizzly.tasks import GrizzlyTasks
 
-
-def clone_request(method: str, this: RequestTask) -> RequestTask:
-    that = RequestTask(RequestMethod.from_string(method), name=this.name, endpoint=this.endpoint)
-    that.source = this.source
-    that.scenario = this.scenario
-    that.template = this.template
-
-    return that
-
-
-class WaitCalled(Exception):
-    time: float
-
-    def __init__(self, time: float) -> None:
-        super().__init__()
-
-        self.time = time
 
 class RequestCalled(Exception):
     endpoint: str

--- a/tests/test_grizzly/helpers.py
+++ b/tests/test_grizzly/helpers.py
@@ -6,7 +6,7 @@ from types import MethodType
 from locust import task
 
 from grizzly.users.meta import ContextVariables
-from grizzly.types import RequestMethod
+from grizzly.types import GrizzlyResponse, RequestMethod
 from grizzly.task import RequestTask
 from grizzly.tasks import GrizzlyTasks
 
@@ -52,7 +52,7 @@ class TestUser(ContextVariables):
     def config_property(self, value: Optional[str]) -> None:
         self._config_property = value
 
-    def request(self, request: RequestTask) -> None:
+    def request(self, request: RequestTask) -> GrizzlyResponse:
         raise RequestCalled(request)
 
 

--- a/tests/test_grizzly/task/test_request.py
+++ b/tests/test_grizzly/task/test_request.py
@@ -17,7 +17,7 @@ from grizzly.types import RequestMethod
 from ..fixtures import grizzly_context, request_task, behave_context, locust_environment  # pylint: disable=unused-import
 
 class TestRequestTaskHandlers:
-    def tests(self) -> None:
+    def test(self) -> None:
         handlers = RequestTaskHandlers()
 
         assert hasattr(handlers, 'metadata')

--- a/tests/test_grizzly/task/test_until.py
+++ b/tests/test_grizzly/task/test_until.py
@@ -1,0 +1,36 @@
+from typing import Callable
+
+import pytest
+
+from pytest_mock import mocker, MockerFixture
+
+from grizzly.types import RequestMethod
+from grizzly.task import UntilRequestTask, RequestTask
+from grizzly_extras.transformer import TransformerContentType
+from ..fixtures import grizzly_context, request_task, behave_context, locust_environment  # pylint: disable=unused-import
+
+class TestUntilRequestTask:
+    @pytest.mark.usefixtures('grizzly_context')
+    def test(self, grizzly_context: Callable, mocker: MockerFixture) -> None:
+        request = RequestTask(RequestMethod.GET, name='test', endpoint='/api/test')
+
+        with pytest.raises(ValueError) as ve:
+            task = UntilRequestTask(request, '$.`this`[?status="ready"]')
+        assert 'content type must be specified for request' in str(ve)
+
+        request.response.content_type = TransformerContentType.JSON
+        task = UntilRequestTask(request, '$.`this`[?status="ready"]')
+
+        assert task.condition == '$.`this`[?status="ready"]'
+        assert task.wait == 1.0
+        assert task.retries == 3
+
+        task = UntilRequestTask(request, '$.`this`[?status="ready"] | wait=100, retries=10')
+
+        assert task.condition == '$.`this`[?status="ready"]'
+        assert task.wait == 100
+        assert task.retries == 10
+
+    @pytest.mark.usefixtures('grizzly_context')
+    def test_data_table(self, grizzly_context: Callable, mocker: MockerFixture) -> None:
+        pass

--- a/tests/test_grizzly/task/test_until.py
+++ b/tests/test_grizzly/task/test_until.py
@@ -1,24 +1,30 @@
-from typing import Callable
+from typing import Callable, Dict, Tuple, List, cast
 
 import pytest
 
-from pytest_mock import mocker, MockerFixture
+from pytest_mock import mocker, MockerFixture  # pylint: disable=unused-import
 
+from locust.exception import StopUser
 from grizzly.types import RequestMethod
 from grizzly.task import UntilRequestTask, RequestTask
-from grizzly_extras.transformer import TransformerContentType
+from grizzly_extras.transformer import TransformerContentType, transformer
 from ..fixtures import grizzly_context, request_task, behave_context, locust_environment  # pylint: disable=unused-import
 
 class TestUntilRequestTask:
     @pytest.mark.usefixtures('grizzly_context')
-    def test(self, grizzly_context: Callable, mocker: MockerFixture) -> None:
+    def test_create(self) -> None:
         request = RequestTask(RequestMethod.GET, name='test', endpoint='/api/test')
 
         with pytest.raises(ValueError) as ve:
-            task = UntilRequestTask(request, '$.`this`[?status="ready"]')
+            UntilRequestTask(request, '$.`this`[?status="ready"]')
         assert 'content type must be specified for request' in str(ve)
 
         request.response.content_type = TransformerContentType.JSON
+
+        with pytest.raises(ValueError) as ve:
+            UntilRequestTask(request, '$.`this`[?status="ready"] | foo=bar, bar=foo')
+        assert 'unsupported arguments foo, bar' in str(ve)
+
         task = UntilRequestTask(request, '$.`this`[?status="ready"]')
 
         assert task.condition == '$.`this`[?status="ready"]'
@@ -32,5 +38,128 @@ class TestUntilRequestTask:
         assert task.retries == 10
 
     @pytest.mark.usefixtures('grizzly_context')
-    def test_data_table(self, grizzly_context: Callable, mocker: MockerFixture) -> None:
-        pass
+    def test_implementation(self, grizzly_context: Callable, mocker: MockerFixture) -> None:
+        _, _, tasks, [_, _, request] = grizzly_context()
+        request = cast(RequestTask, request)
+        request.response.content_type = TransformerContentType.JSON
+        request.method = RequestMethod.GET
+
+        def create_response(status: str) -> Dict[str, Dict[str, str]]:
+            return {
+                'response': {
+                    'status': status,
+                }
+            }
+
+        request_spy = mocker.patch.object(
+            tasks.user,
+            'request',
+            side_effect=[
+                (None, create_response('working')),
+                (None, create_response('working')),
+                (None, create_response('ready')),
+            ],
+        )
+
+        time_spy = mocker.patch('grizzly.task.until.time', side_effect=[0.0, 153.5, 0.0, 12.25, 0.0, 1.5])
+
+        fire_spy = mocker.patch.object(
+            tasks.user.environment.events.request,
+            'fire',
+        )
+
+        gsleep_spy = mocker.patch('grizzly.task.until.gsleep', autospec=True)
+
+        task = UntilRequestTask(request, '/status[text()="ready"]')
+        implementation = task.implementation()
+
+        with pytest.raises(RuntimeError) as re:
+            implementation(tasks)
+        assert '/status[text()="ready"] is not a valid expression for JSON' in str(re)
+
+        jsontransformer_orig = transformer.available[TransformerContentType.JSON]
+        del transformer.available[TransformerContentType.JSON]
+
+        task = UntilRequestTask(request, '$.`this`[?status="ready"] | wait=100, retries=10')
+
+        with pytest.raises(TypeError) as te:
+            task.implementation()
+        assert 'could not find a transformer for JSON' in str(te)
+
+        transformer.available[TransformerContentType.JSON] = jsontransformer_orig
+
+        task = UntilRequestTask(request, '$.`this`[?status="ready"] | wait=100, retries=10')
+        implementation = task.implementation()
+
+        implementation(tasks)
+
+        assert time_spy.call_count == 2
+        assert request_spy.call_count == 3
+        assert gsleep_spy.call_count == 3
+        call_args_list: List[Tuple[float]] = []
+        for args_list in gsleep_spy.call_args_list:
+            args, _ = args_list
+            call_args_list.append(args)
+        assert call_args_list == [(100.0, ), (100.0, ), (100.0, )]
+
+        assert fire_spy.call_count == 1
+        _, kwargs = fire_spy.call_args_list[0]
+
+        assert kwargs.get('request_type', None) == 'UNTL'
+        assert kwargs.get('name', None) == f'{request.scenario.identifier}, wait=100.0s, retries=10'
+        assert kwargs.get('response_time', None) == 153500
+        assert kwargs.get('response_length', None) == 0
+        assert kwargs.get('context', None) == {'variables': {}}
+        assert kwargs.get('exception', '') is None
+
+        request_spy = mocker.patch.object(
+            tasks.user,
+            'request',
+            side_effect=[
+                (None, create_response('working')),
+                (None, create_response('working')),
+            ],
+        )
+
+        task = UntilRequestTask(request, '$.`this`[?status="ready"] | wait=10, retries=2')
+        implementation = task.implementation()
+
+        with pytest.raises(StopUser):
+            implementation(tasks)
+
+        assert fire_spy.call_count == 2
+        _, kwargs = fire_spy.call_args_list[1]
+
+        assert kwargs.get('request_type', None) == 'UNTL'
+        assert kwargs.get('name', None) == f'{request.scenario.identifier}, wait=10.0s, retries=2'
+        assert kwargs.get('response_time', None) == 12250
+        assert kwargs.get('response_length', None) == 0
+        assert kwargs.get('context', None) == {'variables': {}}
+        exception = kwargs.get('exception', None)
+        assert exception is not None
+        assert isinstance(exception, RuntimeError)
+        assert str(exception) == 'found 0 matching values for $.`this`[?status="ready"] in payload'
+
+        request_spy = mocker.patch.object(
+            tasks.user,
+            'request',
+            side_effect=[
+                RuntimeError('foo bar'),
+            ],
+        )
+
+        with pytest.raises(StopUser):
+            implementation(tasks)
+
+        assert fire_spy.call_count == 3
+        _, kwargs = fire_spy.call_args_list[2]
+
+        assert kwargs.get('request_type', None) == 'UNTL'
+        assert kwargs.get('name', None) == f'{request.scenario.identifier}, wait=10.0s, retries=2'
+        assert kwargs.get('response_time', None) == 1500
+        assert kwargs.get('response_length', None) == 0
+        assert kwargs.get('context', None) == {'variables': {}}
+        exception = kwargs.get('exception', None)
+        assert exception is not None
+        assert isinstance(exception, RuntimeError)
+        assert str(exception) == 'foo bar'

--- a/tests/test_grizzly/users/test_blobstorage.py
+++ b/tests/test_grizzly/users/test_blobstorage.py
@@ -6,9 +6,9 @@ from contextlib import contextmanager
 
 import pytest
 
-from azure.servicebus import ServiceBusMessage
 from locust.env import Environment
 from locust.exception import StopUser
+from azure.servicebus import ServiceBusMessage
 
 from pytest_mock import mocker  # pylint: disable=unused-import
 from pytest_mock.plugin import MockerFixture
@@ -140,15 +140,18 @@ class TestBlobStorageUser:
         dummy_blobclient = DummyBlobClient()
         dummy_client.set_blobclient(dummy_blobclient)
 
-        user.request(request)
+        metadata, payload = user.request(request)
 
         assert dummy_blobclient.blob_data is not None
+        assert metadata == {}
 
         msg: str = ''
         for part in dummy_blobclient.blob_data.body:
             msg += part.decode('utf-8')
 
         json_msg = json.loads(msg)
+        payload = json.loads(msg)
+        assert json_msg == payload
         assert json_msg['result']['id'] == 'ID-31337'
         assert dummy_blobclient.container == cast(RequestTask, scenario.tasks[-1]).endpoint
         assert dummy_blobclient.blob == os.path.basename(scenario.name)

--- a/tests/test_grizzly/users/test_blobstorage.py
+++ b/tests/test_grizzly/users/test_blobstorage.py
@@ -21,7 +21,7 @@ from grizzly.task import RequestTask
 from grizzly.testdata.utils import transform
 
 from ..fixtures import grizzly_context, request_task  # pylint: disable=unused-import
-from ..helpers import ResultFailure, RequestEvent, RequestSilentFailureEvent, clone_request
+from ..helpers import ResultFailure, RequestEvent, RequestSilentFailureEvent
 
 import logging
 
@@ -163,7 +163,8 @@ class TestBlobStorageUser:
         with pytest.raises(ResultFailure):
             user.request(cast(RequestTask, scenario.tasks[-1]))
 
-        request_error = clone_request('RECEIVE', cast(RequestTask, scenario.tasks[-1]))
+        request_error = cast(RequestTask, scenario.tasks[-1])
+        request_error.method = RequestMethod.RECEIVE
         with pytest.raises(ResultFailure) as e:
             user.request(request_error)
         assert 'has not implemented RECEIVE' in str(e)

--- a/tests/test_grizzly/users/test_messagequeue.py
+++ b/tests/test_grizzly/users/test_messagequeue.py
@@ -340,7 +340,7 @@ class TestMessageQueueUser:
             'message': 'connected',
         }
 
-        payload = '<?xml encoding="utf-8"?>'
+        test_payload = '<?xml encoding="utf-8"?>'
 
         mocker.patch(
             'grizzly.users.messagequeue.zmq.sugar.socket.Socket.recv_json',
@@ -352,7 +352,7 @@ class TestMessageQueueUser:
                     'response_length': 24,
                     'response_time': -1337,  # fake so message queue daemon response time is a huge chunk
                     'metadata': pymqi.MD().get(),
-                    'payload': payload,
+                    'payload': test_payload,
                 }
             ],
         )
@@ -398,7 +398,7 @@ class TestMessageQueueUser:
 
         user.add_context(remote_variables)
 
-        user.request(request)
+        metadata, payload = user.request(request)
 
         assert request_event_spy.call_count == 2
         _, kwargs = request_event_spy.call_args_list[0]
@@ -409,13 +409,16 @@ class TestMessageQueueUser:
         _, kwargs = request_event_spy.call_args_list[1]
         assert kwargs['request_type'] == 'mq:GET'
         assert kwargs['exception'] is None
-        assert kwargs['response_length'] == len(payload)
+        assert kwargs['response_length'] == len(test_payload)
 
         assert response_event_spy.call_count == 1
         _, kwargs = response_event_spy.call_args_list[0]
         assert kwargs['request'] is request
-        assert kwargs['context'] == (pymqi.MD().get(), payload)
+        assert kwargs['context'] == (pymqi.MD().get(), test_payload)
         assert kwargs['user'] is user
+
+        assert payload == test_payload
+        assert metadata == pymqi.MD().get()
 
         request_event_spy.reset_mock()
         response_event_spy.reset_mock()
@@ -440,7 +443,7 @@ class TestMessageQueueUser:
                     'response_length': 24,
                     'response_time': 1337,
                     'metadata': pymqi.MD().get(),
-                    'payload': payload,
+                    'payload': test_payload,
                 }
             ],
         )
@@ -459,12 +462,12 @@ class TestMessageQueueUser:
         _, kwargs = response_event_spy.call_args_list[0]
         assert kwargs['request'] is request
         assert kwargs['user'] is user
-        assert kwargs['context'] == (pymqi.MD().get(), payload)
+        assert kwargs['context'] == (pymqi.MD().get(), test_payload)
 
         request_event_spy.reset_mock()
         response_event_spy.reset_mock()
 
-        payload = '''{
+        test_payload = '''{
             "test": "payload_variable value"
         }'''
 
@@ -478,7 +481,7 @@ class TestMessageQueueUser:
                     'response_length': 24,
                     'response_time': 1337,
                     'metadata': pymqi.MD().get(),
-                    'payload': payload,
+                    'payload': test_payload,
                 },
             ],
         )
@@ -513,7 +516,7 @@ class TestMessageQueueUser:
                     'response_length': 0,
                     'response_time': 1337,
                     'metadata': pymqi.MD().get(),
-                    'payload': payload,
+                    'payload': test_payload,
                     'message': 'no implementation for POST'
                 }
             ],
@@ -536,7 +539,7 @@ class TestMessageQueueUser:
                     'response_length': 0,
                     'response_time': 1337,
                     'metadata': pymqi.MD().get(),
-                    'payload': payload,
+                    'payload': test_payload,
                     'message': 'no implementation for POST'
                 } for _ in range(3)
             ],

--- a/tests/test_grizzly/users/test_messagequeue.py
+++ b/tests/test_grizzly/users/test_messagequeue.py
@@ -2,6 +2,7 @@ import subprocess
 
 from typing import Callable, Dict, Tuple, Any, cast, Optional
 from os import environ
+from dataclasses import replace
 
 try:
     import pymqi
@@ -29,7 +30,6 @@ from grizzly.steps.helpers import add_save_handler
 from grizzly_extras.async_message import AsyncMessageResponse
 
 from ..fixtures import grizzly_context, request_task, locust_environment, noop_zmq  # pylint: disable=unused-import
-from ..helpers import clone_request
 
 import logging
 
@@ -505,7 +505,9 @@ class TestMessageQueueUser:
         assert kwargs['exception'] is not None
         request_event_spy.reset_mock()
 
-        request_error = clone_request('POST', request)
+        request_error = replace(request)
+        request_error.scenario = request.scenario
+        request_error.method = RequestMethod.POST
 
         mocker.patch(
             'grizzly.users.messagequeue.zmq.sugar.socket.Socket.recv_json',
@@ -750,7 +752,9 @@ class TestMessageQueueUser:
         assert kwargs['exception'] is not None
         request_event_spy.reset_mock()
 
-        request_error = clone_request('POST', request)
+        request_error = replace(request)
+        request_error.scenario = request.scenario
+        request_error.method = RequestMethod.POST
 
         mocker.patch(
             'grizzly.users.messagequeue.zmq.sugar.socket.Socket.recv_json',

--- a/tests/test_grizzly/users/test_restapi.py
+++ b/tests/test_grizzly/users/test_restapi.py
@@ -3,6 +3,10 @@ from time import time
 from enum import Enum
 from urllib.parse import urlparse
 
+from locust.clients import ResponseContextManager
+from locust.exception import StopUser
+from locust.event import EventHook
+
 import pytest
 import requests
 
@@ -10,9 +14,6 @@ from pytest_mock import mocker  # pylint: disable=unused-import
 from pytest_mock.plugin import MockerFixture
 from requests.models import Response
 from json import dumps as jsondumps
-from locust.clients import ResponseContextManager
-from locust.exception import StopUser
-from locust.event import EventHook
 from jinja2 import Template
 
 from grizzly.users.restapi import AuthMethod, RestApiUser, refresh_token
@@ -664,7 +665,10 @@ class TestRestApiUser:
         scenario.stop_on_failure = False
 
         # status_code != 200, stop_on_failure = False
-        user.request(request)
+        metadata, payload = user.request(request)
+
+        assert metadata is None
+        assert payload == '{}'
 
         mock_client_post(status_code=200)
 

--- a/tests/test_grizzly/users/test_servicebus.py
+++ b/tests/test_grizzly/users/test_servicebus.py
@@ -328,11 +328,14 @@ class TestServiceBusUser:
             'response_length': 133,
         })
 
-        user.request(task)
+        metadata, payload = user.request(task)
         assert say_hello_spy.call_count == 3
         assert send_json_spy.call_count == 2
         assert request_fire_spy.call_count == 3
         assert response_event_fire_spy.call_count == 3
+
+        assert metadata == {'meta': True}
+        assert payload == 'hello'
 
         _, kwargs = response_event_fire_spy.call_args_list[2]
         assert kwargs.get('name', None) == f'{scenario.identifier} {task.name}'
@@ -379,11 +382,14 @@ class TestServiceBusUser:
             'response_length': 133,
         })
 
-        user.request(task)
+        metadata, payload = user.request(task)
         assert say_hello_spy.call_count == 4
         assert send_json_spy.call_count == 3
         assert request_fire_spy.call_count == 4
         assert response_event_fire_spy.call_count == 4
+
+        assert metadata == {'meta': True}
+        assert payload == 'hello'
 
         _, kwargs = response_event_fire_spy.call_args_list[3]
         assert kwargs.get('name', None) == f'{scenario.identifier} {task.name}'
@@ -391,7 +397,7 @@ class TestServiceBusUser:
 
         metadata, payload = kwargs.get('context', (None, None,))
         assert metadata == {'meta': True}
-        assert payload is 'hello'
+        assert payload == 'hello'
         assert kwargs.get('user', None) is user
         assert kwargs.get('exception', '') is None
 

--- a/tests/test_grizzly/users/test_sftp.py
+++ b/tests/test_grizzly/users/test_sftp.py
@@ -7,6 +7,7 @@ from jinja2.environment import Template
 import pytest
 
 from _pytest.tmpdir import TempdirFactory
+from pytest_mock import mocker, MockerFixture  # pylint: disable=unused-import
 from locust.env import Environment
 from locust.exception import StopUser
 
@@ -17,7 +18,7 @@ from grizzly.context import GrizzlyContextScenario
 from grizzly.task import RequestTask
 
 from ..fixtures import locust_environment, paramiko_mocker  # pylint: disable=unused-import
-from ..helpers import ResultFailure, ResultSuccess, RequestEvent, RequestSilentFailureEvent
+
 
 
 class TestSftpUser:
@@ -77,7 +78,7 @@ class TestSftpUser:
             del environ['GRIZZLY_CONTEXT_ROOT']
 
     @pytest.mark.usefixtures('locust_environment', 'paramiko_mocker', 'tmpdir_factory')
-    def test_request(self, locust_environment: Environment, paramiko_mocker: Callable, tmpdir_factory: TempdirFactory) -> None:
+    def test_request(self, locust_environment: Environment, paramiko_mocker: Callable, tmpdir_factory: TempdirFactory, mocker: MockerFixture) -> None:
         paramiko_mocker()
 
         test_context = tmpdir_factory.mktemp('test_context').mkdir('requests')
@@ -93,6 +94,8 @@ class TestSftpUser:
             }
             user = SftpUser(locust_environment)
 
+            mocker.patch('grizzly.users.sftp.time', side_effect=[0.0] * 100)
+
             request = RequestTask(RequestMethod.SEND, name='test', endpoint='/tmp')
             request.source = 'test/file.txt'
             request.template = Template(request.source)
@@ -102,7 +105,8 @@ class TestSftpUser:
 
             request.scenario = scenario
 
-            locust_environment.events.request = RequestSilentFailureEvent()
+            fire_spy = mocker.spy(user.environment.events.request, 'fire')
+            response_event_spy = mocker.spy(user.response_event, 'fire')
 
             request.scenario.stop_on_failure = False
             metadata, payload = user.request(request)
@@ -110,29 +114,110 @@ class TestSftpUser:
             assert metadata is None
             assert payload == 'test/file.txt'
 
+            assert fire_spy.call_count == 1
+            _, kwargs = fire_spy.call_args_list[0]
+
+            assert kwargs.get('request_type', None) == 'sftp:SEND'
+            assert kwargs.get('name', None) == f'{request.scenario.identifier} test'
+            assert kwargs.get('response_time', None) == 0
+            assert kwargs.get('response_length', None) == 0
+            assert kwargs.get('context', None) == user._context
+            exception = kwargs.get('exception', None)
+            assert isinstance(exception, NotImplementedError)
+            assert 'SftpUser has not implemented SEND' in str(exception)
+
             request.scenario.stop_on_failure = True
             with pytest.raises(StopUser):
                 user.request(request)
 
-            locust_environment.events.request = RequestEvent()
+            assert fire_spy.call_count == 2
+            _, kwargs = fire_spy.call_args_list[1]
+
+            assert kwargs.get('request_type', None) == 'sftp:SEND'
+            assert kwargs.get('name', None) == f'{request.scenario.identifier} test'
+            assert kwargs.get('response_time', None) == 0
+            assert kwargs.get('response_length', None) == 0
+            assert kwargs.get('context', None) == user._context
+            exception = kwargs.get('exception', None)
+            assert isinstance(exception, NotImplementedError)
+            assert 'SftpUser has not implemented SEND' in str(exception)
 
             request.method = RequestMethod.GET
 
-            with pytest.raises(ResultSuccess):
-                user.request(request)
+            user.request(request)
+
+            assert response_event_spy.call_count == 3
+            _, kwargs = response_event_spy.call_args_list[-1]
+            assert kwargs.get('name', None) == f'{request.scenario.identifier} test'
+            assert kwargs.get('request', None) is request
+            assert kwargs.get('context', None) == ({
+                'host': user.host,
+                'method': 'get',
+                'time': 0,
+                'path': '/tmp',
+            }, 'test/file.txt')
+            assert kwargs.get('user', None) is user
+            assert kwargs.get('exception', '') is None
 
             request.method = RequestMethod.PUT
             request.template = None
 
-            with pytest.raises(ResultFailure):
+            with pytest.raises(StopUser):
                 user.request(request)
 
-            request.source = 'hello world'
+            assert response_event_spy.call_count == 4
+            _, kwargs = response_event_spy.call_args_list[-1]
+
+            assert kwargs.get('name', None) == f'{request.scenario.identifier} test'
+            assert kwargs.get('request', None) is request
+            assert kwargs.get('context', None) == ({
+                'host': user.host,
+                'method': 'put',
+                'time': 0,
+                'path': '/tmp',
+            }, None)
+            assert kwargs.get('user', None) is user
+            exception = kwargs.get('exception', None)
+
+            assert exception is not None
+            assert isinstance(exception, ValueError)
+            assert 'SftpUser: request a94a8fe5 test does not have a payload, incorrect method specified' in str(exception)
+
+            request.source = 'foo.bar'
             request.template = Template(request.source)
 
-            with pytest.raises(ResultSuccess):
+            user.request(request)
+
+            assert response_event_spy.call_count == 5
+            _, kwargs = response_event_spy.call_args_list[-1]
+            assert kwargs.get('name', None) == f'{request.scenario.identifier} test'
+            assert kwargs.get('request', None) is request
+            assert kwargs.get('context', None) == ({
+                'host': user.host,
+                'method': 'put',
+                'time': 0,
+                'path': '/tmp',
+            }, path.join(test_context_root, 'requests', 'foo.bar'))
+            assert kwargs.get('user', None) is user
+            assert kwargs.get('exception', '') is None
+
+            mocker.patch.object(user.response_event, 'fire', side_effect=[RuntimeError('error error')])
+
+            with pytest.raises(StopUser):
                 user.request(request)
 
+            assert fire_spy.call_count == 6
+            _, kwargs = fire_spy.call_args_list[-1]
+
+            assert kwargs.get('request_type', None) == 'sftp:PUT'
+            assert kwargs.get('name', None) == f'{request.scenario.identifier} test'
+            assert kwargs.get('response_time', None) == 0
+            assert kwargs.get('response_length', None) == 100
+            assert kwargs.get('context', None) == user._context
+            exception = kwargs.get('exception', '')
+            assert exception is not None
+            assert isinstance(exception, RuntimeError)
+            assert str(exception) == 'error error'
         finally:
             shutil.rmtree(test_context_root)
             del environ['GRIZZLY_CONTEXT_ROOT']

--- a/tests/test_grizzly/users/test_sftp.py
+++ b/tests/test_grizzly/users/test_sftp.py
@@ -57,16 +57,16 @@ class TestSftpUser:
 
             user = SftpUser(locust_environment)
 
-            assert isinstance(user.client, SftpClientSession)
-            assert user.client.port == 22
-            assert user.client.host == 'test.nu'
+            assert isinstance(user.sftp_client, SftpClientSession)
+            assert user.sftp_client.port == 22
+            assert user.sftp_client.host == 'test.nu'
 
             SftpUser.host = 'sftp://test.nu:1337'
             user = SftpUser(locust_environment)
 
-            assert isinstance(user.client, SftpClientSession)
-            assert user.client.port == 1337
-            assert user.client.host == 'test.nu'
+            assert isinstance(user.sftp_client, SftpClientSession)
+            assert user.sftp_client.port == 1337
+            assert user.sftp_client.host == 'test.nu'
 
             SftpUser._context['auth']['key_file'] = '~/.ssh/id_rsa'
 
@@ -105,7 +105,10 @@ class TestSftpUser:
             locust_environment.events.request = RequestSilentFailureEvent()
 
             request.scenario.stop_on_failure = False
-            user.request(request)
+            metadata, payload = user.request(request)
+
+            assert metadata is None
+            assert payload == 'test/file.txt'
 
             request.scenario.stop_on_failure = True
             with pytest.raises(StopUser):

--- a/tests/test_grizzly_extras/test_transformer.py
+++ b/tests/test_grizzly_extras/test_transformer.py
@@ -123,6 +123,7 @@ class TestJsonTransformer:
 
     def test_validate(self) -> None:
         assert JsonTransformer.validate('$.test.something')
+        assert JsonTransformer.validate('$.`this`[?status="ready"]')
         assert not JsonTransformer.validate('$.')
         assert not JsonTransformer.validate('.test.something')
 


### PR DESCRIPTION
new tasks that will repeat a `RequestTask` until the specified condition is met, or fail the step if the specified number of `retries` has been reached.

the condition is specified as an json/x-path expression (or, rather, anything related to the implemented grizzly_extra.transformer).

this step is useful when a certain condition has to be met before continuing with a scenario.
a word of warning though, it will increase the number of requests sent, which might skew the traffic model from the endpoints point of view. use with caution.