### PR TITLE
Bug/async messaged logging

### DIFF
--- a/grizzly/testdata/variables/messagequeue.py
+++ b/grizzly/testdata/variables/messagequeue.py
@@ -66,6 +66,8 @@ When the scenario starts `grizzly` will wait up to 120 seconds until `AtomicMess
 If there are no messages within 120 seconds, and it is the first iteration of the scenario, it will fail. If there has been at least one message on the queue since
 the scenario started, it will use the oldest of those values, and then add it back in the end of the list again.
 '''
+import logging
+
 from typing import Dict, Any, Type, Optional, List, cast
 from urllib.parse import urlparse, parse_qs, unquote
 
@@ -145,6 +147,10 @@ class AtomicMessageQueue(AtomicVariable[str]):
     def __init__(self, variable: str, value: str):
         if pymqi.__name__ == 'grizzly_extras.dummy_pymqi':
             raise NotImplementedError('AtomicMessageQueue could not import pymqi, have you installed IBM MQ dependencies?')
+
+        # silence uamqp loggers
+        for uamqp_logger_name in ['uamqp', 'uamqp.c_uamqp']:
+            logging.getLogger(uamqp_logger_name).setLevel(logging.ERROR)
 
         safe_value = self.__class__.__base_type__(value)
 

--- a/grizzly/testdata/variables/servicebus.py
+++ b/grizzly/testdata/variables/servicebus.py
@@ -78,6 +78,7 @@ be specified for the endpint, e.g. `application/xml`.
 And value of variable "AtomicServiceBus.document_id" is "queue:documents-in | wait=120, url=$conf::sb.endpoint, repeat=True, content_type=json, expression='$.document[?(@.name=='TPM Report')'"
 ```
 '''
+import logging
 
 from typing import Dict, Any, List, Type, Optional, cast
 from urllib.parse import urlparse, parse_qs
@@ -237,6 +238,10 @@ class AtomicServiceBus(AtomicVariable[str]):
     }
 
     def __init__(self, variable: str, value: str) -> None:
+        # silence uamqp loggers
+        for uamqp_logger_name in ['uamqp', 'uamqp.c_uamqp']:
+            logging.getLogger(uamqp_logger_name).setLevel(logging.ERROR)
+
         safe_value = self.__class__.__base_type__(value)
 
         settings = {'repeat': False, 'wait': None, 'url': None, 'worker': None, 'context': None, 'endpoint_name': None, 'content_type': None}

--- a/grizzly/users/messagequeue.py
+++ b/grizzly/users/messagequeue.py
@@ -93,14 +93,14 @@ Default SSL cipher is `ECDHE_RSA_AES_256_GCM_SHA384`, change it by setting `auth
 
 Default certificate label is set to `auth.username`, change it by setting `auth.cert_label` context variable.
 '''
+import logging
+
 from typing import Dict, Any, Generator, Tuple, Optional, cast
 from urllib.parse import urlparse, parse_qs, unquote
 from contextlib import contextmanager
 from time import perf_counter as time
 
-
 import zmq
-
 
 from gevent import sleep as gsleep
 from locust.exception import StopUser
@@ -202,6 +202,10 @@ class MessageQueueUser(ResponseHandler, RequestLogger, ContextVariables):
         })
 
         self.worker_id = None
+
+        # silence uamqp loggers
+        for uamqp_logger_name in ['uamqp', 'uamqp.c_uamqp']:
+            logging.getLogger(uamqp_logger_name).setLevel(logging.ERROR)
 
 
     def request(self, request: RequestTask) -> None:

--- a/grizzly/users/servicebus.py
+++ b/grizzly/users/servicebus.py
@@ -65,6 +65,8 @@ Then receive request "topic-recv" from endpoint "topic:shared-topic, subscriptio
 And set response content type to "application/xml"
 ```
 '''
+import logging
+
 from typing import Generator, Dict, Any, Tuple, Optional, Set, cast
 from urllib.parse import urlparse, parse_qs
 from time import perf_counter as time
@@ -144,6 +146,10 @@ class ServiceBusUser(ResponseHandler, RequestLogger, ContextVariables):
             'url': self.host[9:],
             'message_wait': self._context.get('message', {}).get('wait', None)
         }
+
+        # silence uamqp loggers
+        for uamqp_logger_name in ['uamqp', 'uamqp.c_uamqp']:
+            logging.getLogger(uamqp_logger_name).setLevel(logging.ERROR)
 
         self.hellos = set()
         self.worker_id = None

--- a/grizzly_extras/async_message/__init__.py
+++ b/grizzly_extras/async_message/__init__.py
@@ -115,6 +115,10 @@ class AsyncMessageHandler(ABC):
         self.message_wait = None
         self.logger = ThreadLogger(f'handler::{worker}')
 
+        # silence uamqp loggers
+        for uamqp_logger_name in ['uamqp', 'uamqp.c_uamqp']:
+            logging.getLogger(uamqp_logger_name).setLevel(logging.ERROR)
+
     @abstractmethod
     def get_handler(self, action: str) -> Optional['AsyncMessageRequestHandler']:
         raise NotImplementedError(f'{self.__class__.__name__}: get_handler is not implemented')

--- a/grizzly_extras/async_message/__init__.py
+++ b/grizzly_extras/async_message/__init__.py
@@ -2,7 +2,7 @@ import logging
 import sys
 
 from abc import ABC, abstractmethod
-from typing import Optional, Dict, Any, TypedDict, Callable, cast
+from typing import Optional, Dict, Any, TypedDict, Callable, List, cast
 from os import environ, path
 from platform import node as hostname
 from json import dumps as jsondumps
@@ -13,18 +13,59 @@ from datetime import datetime
 
 from grizzly_extras.transformer import JsonBytesEncoder
 
-__all__ = [
-    'AsyncMessageContext',
-    'AsyncMessageMetadata',
-    'AsyncMessagePayload',
-    'AsyncMessageRequest',
-    'AsyncMessageResponse',
-    'AsyncMessageError',
-]
+__all__: List[str] = []
 
 
 AsyncMessageMetadata = Optional[Dict[str, Any]]
 AsyncMessagePayload = Optional[Any]
+
+class ThreadLogger:
+    _logger: logging.Logger
+    _lock: Lock = Lock()
+
+    def __init__(self, name: str) -> None:
+        logger = logging.getLogger(name)
+        log_format = '[%(asctime)s] %(levelname)-5s: %(name)s: %(message)s'
+        formatter = logging.Formatter(log_format)
+        level = logging.getLevelName(environ.get('GRIZZLY_EXTRAS_LOGLEVEL', 'INFO'))
+        logger.setLevel(level)
+        logger.handlers = []
+        stdout_handler = logging.StreamHandler(sys.stderr)
+        stdout_handler.setFormatter(formatter)
+        logger.addHandler(stdout_handler)
+
+        root_logger = logging.getLogger()
+        root_logger.setLevel(logging.NOTSET)  # root logger needs to have lower or equal log level
+        root_logger.handlers = []
+        root_logger.addHandler(logging.StreamHandler(StringIO()))  # disable messages from root logger
+
+        grizzly_context_root = environ.get('GRIZZLY_CONTEXT_ROOT', None)
+
+        print(f'{grizzly_context_root=}')
+
+        if grizzly_context_root is not None:
+            file_name = f'async-messaged.{hostname()}.{name}.{datetime.now().strftime("%Y%m%dT%H%M%S%f")}.log'
+            file_handler = logging.FileHandler(path.join(grizzly_context_root, 'logs', file_name))
+            file_handler.setFormatter(formatter)
+            logger.addHandler(file_handler)
+
+        self._logger = logger
+
+    def _log(self, level: int, message: str, exc_info: Optional[bool] = False) -> None:
+        with self._lock:
+            self._logger.log(level, message, exc_info=exc_info)
+
+    def debug(self, message: str) -> None:
+        self._log(logging.DEBUG, message)
+
+    def info(self, message: str) -> None:
+        self._log(logging.INFO, message)
+
+    def error(self, message: str, exc_info: Optional[bool] = False) -> None:
+        self._log(logging.ERROR, message, exc_info=exc_info)
+
+    def warning(self, message: str) -> None:
+        self._log(logging.WARNING, message)
 
 class AsyncMessageContext(TypedDict, total=False):
     url: str
@@ -65,10 +106,12 @@ class AsyncMessageError(Exception):
 class AsyncMessageHandler(ABC):
     worker: str
     message_wait: Optional[int]
+    logger: ThreadLogger
 
     def __init__(self, worker: str) -> None:
         self.worker = worker
         self.message_wait = None
+        self.logger = ThreadLogger(f'handler::{worker}')
 
     @abstractmethod
     def get_handler(self, action: str) -> Optional['AsyncMessageRequestHandler']:
@@ -77,8 +120,8 @@ class AsyncMessageHandler(ABC):
     def handle(self, request: AsyncMessageRequest) -> AsyncMessageResponse:
         action = request['action']
         request_handler = self.get_handler(action)
-        logger.debug(f'{self.worker}: handling {action}')
-        logger.debug(f'{self.worker}: {jsondumps(request, indent=2, cls=JsonBytesEncoder)}')
+        self.logger.debug(f'handling {action}')
+        self.logger.debug(f'{jsondumps(request, indent=2, cls=JsonBytesEncoder)}')
 
         response: AsyncMessageResponse
 
@@ -95,7 +138,7 @@ class AsyncMessageHandler(ABC):
                 'success': False,
                 'message': f'{action}: {e.__class__.__name__}="{str(e)}"',
             }
-            logger.error(f'{self.worker}: {action}: {e.__class__.__name__}="{str(e)}"', exc_info=True)
+            self.logger.error(f'{self.worker}: {action}: {e.__class__.__name__}="{str(e)}"', exc_info=True)
         finally:
             total_time = int((time() - start_time) * 1000)
             response.update({
@@ -103,8 +146,8 @@ class AsyncMessageHandler(ABC):
                 'response_time': total_time,
             })
 
-            logger.debug(f'{self.worker}: handled {action}')
-            logger.debug(f'{self.worker}: {jsondumps(response, indent=2, cls=JsonBytesEncoder)}')
+            self.logger.debug(f'handled {action}')
+            self.logger.debug(f'{jsondumps(response, indent=2, cls=JsonBytesEncoder)}')
 
             return response
 
@@ -131,49 +174,3 @@ def register(handlers: Dict[str, AsyncMessageRequestHandler], action: str, *acti
         return func
 
     return decorator
-
-class ThreadLogger:
-    _logger: logging.Logger
-    _lock: Lock = Lock()
-
-    def __init__(self, name: str) -> None:
-        logger = logging.getLogger(name)
-        log_format = '[%(asctime)s] %(levelname)-5s: %(name)s: %(message)s'
-        formatter = logging.Formatter(log_format)
-        level = logging.getLevelName(environ.get('GRIZZLY_EXTRAS_LOGLEVEL', 'INFO'))
-        logger.setLevel(level)
-        logger.handlers = []
-        stdout_handler = logging.StreamHandler(sys.stderr)
-        stdout_handler.setFormatter(formatter)
-        logger.addHandler(stdout_handler)
-
-        root_logger = logging.getLogger()
-        root_logger.setLevel(logging.NOTSET)  # root logger needs to have lower or equal log level
-        root_logger.handlers = []
-        root_logger.addHandler(logging.StreamHandler(StringIO()))  # disable messages from root logger
-
-        if level < logging.INFO:
-            file_name = f'async-messaged.{hostname()}.{datetime.now().strftime("%Y%m%dT%H%M%S%f")}.log'
-            file_handler = logging.FileHandler(path.join(environ.get('GRIZZLY_CONTEXT_ROOT', '.'), 'logs', file_name))
-            file_handler.setFormatter(formatter)
-            logger.addHandler(file_handler)
-
-        self._logger = logger
-
-        self.info(f'level={logging.getLevelName(level)}')
-
-    def _log(self, level: int, message: str, exc_info: Optional[bool] = False) -> None:
-        with self._lock:
-            self._logger.log(level, message, exc_info=exc_info)
-
-    def debug(self, message: str) -> None:
-        self._log(logging.DEBUG, message)
-
-    def info(self, message: str) -> None:
-        self._log(logging.INFO, message)
-
-    def error(self, message: str, exc_info: Optional[bool] = False) -> None:
-        self._log(logging.ERROR, message, exc_info=exc_info)
-
-
-logger = ThreadLogger(__name__)

--- a/grizzly_extras/async_message/daemon.py
+++ b/grizzly_extras/async_message/daemon.py
@@ -19,6 +19,7 @@ from . import (
 
 from grizzly_extras.transformer import JsonBytesEncoder
 
+
 def router() -> None:
     proc.setproctitle('grizzly')
     logger.debug('router: starting')

--- a/grizzly_extras/async_message/mq.py
+++ b/grizzly_extras/async_message/mq.py
@@ -13,7 +13,6 @@ from . import (
     AsyncMessageRequestHandler,
     AsyncMessageHandler,
     register,
-    logger,
 )
 
 try:
@@ -125,7 +124,7 @@ class AsyncMessageQueueHandler(AsyncMessageHandler):
     def _find_message(self, queue_name: str, expression: str, content_type: TransformerContentType, message_wait: Optional[int]) -> Optional[bytearray]:
         start_time = time()
 
-        logger.debug(f'{self.worker}: _find_message: searching {queue_name} for messages matching: {expression}, content_type {content_type.name.lower()}')
+        self.logger.debug(f'_find_message: searching {queue_name} for messages matching: {expression}, content_type {content_type.name.lower()}')
         transform = transformer.available.get(content_type, None)
         if transform is None:
             raise AsyncMessageError(f'could not find a transformer for {content_type.name}')
@@ -156,7 +155,7 @@ class AsyncMessageQueueHandler(AsyncMessageHandler):
 
                         if len(values) > 0:
                             # Found a matching message, return message id
-                            logger.debug(f'{self.worker}: _find_message: found matching message: {md["MsgId"]}')
+                            self.logger.debug(f'_find_message: found matching message: {md["MsgId"]}')
                             return cast(bytearray, md['MsgId'])
 
                         gmo.Options = pymqi.CMQC.MQGMO_BROWSE_NEXT
@@ -176,7 +175,7 @@ class AsyncMessageQueueHandler(AsyncMessageHandler):
                 elif message_wait is None:
                     return None
                 else:
-                    logger.debug(f'{self.worker}: _find_message: no matching message found, trying again after some sleep')
+                    self.logger.debug('_find_message: no matching message found, trying again after some sleep')
                     sleep(0.5)
 
     def _get_content_type(self, request: AsyncMessageRequest) -> TransformerContentType:
@@ -225,7 +224,7 @@ class AsyncMessageQueueHandler(AsyncMessageHandler):
             # Adjust message_wait for getting the message
             if message_wait is not None:
                 message_wait -= elapsed_time
-                logger.debug(f'{self.worker}: _request: remaining message_wait after finding message: {message_wait}')
+                self.logger.debug('_request: remaining message_wait after finding message: {message_wait}')
 
         md = pymqi.MD()
         with self.queue_context(endpoint=queue_name) as queue:

--- a/grizzly_extras/async_message/sb.py
+++ b/grizzly_extras/async_message/sb.py
@@ -19,7 +19,6 @@ from . import (
     AsyncMessageResponse,
     AsyncMessageError,
     register,
-    logger,
 )
 
 __all__ = [
@@ -278,10 +277,10 @@ class AsyncServiceBusHandler(AsyncMessageHandler):
                 for received_message in receiver:
                     message = cast(ServiceBusMessage, received_message)
 
-                    logger.debug(f'{self.worker}: got message id: {message.message_id}')
+                    self.logger.debug(f'got message id: {message.message_id}')
 
                     if expression is None:
-                        logger.debug(f'{self.worker}: completing message id: {message.message_id}')
+                        self.logger.debug(f'completing message id: {message.message_id}')
                         receiver.complete_message(message)
                         break
 
@@ -295,15 +294,15 @@ class AsyncServiceBusHandler(AsyncMessageHandler):
                         try:
                             _, transformed_payload = transform.transform(content_type, payload)
                         except TransformerError as e:
-                            logger.error(f'{self.worker}: {payload}')
+                            self.logger.error(payload)
                             raise AsyncMessageError(e.message)
 
                         values = get_values(transformed_payload)
 
-                        logger.debug(f'{self.worker}: expression={request_arguments["expression"]}, matches={values}, payload={transformed_payload}')
+                        self.logger.debug(f'expression={request_arguments["expression"]}, matches={values}, payload={transformed_payload}')
 
                         if len(values) > 0:
-                            logger.debug(f'{self.worker}: completing message id: {message.message_id}, with expression "{request_arguments["expression"]}"')
+                            self.logger.debug(f'completing message id: {message.message_id}, with expression "{request_arguments["expression"]}"')
                             receiver.complete_message(message)
                             had_error = False
                             break
@@ -312,7 +311,7 @@ class AsyncServiceBusHandler(AsyncMessageHandler):
                     finally:
                         if had_error:
                             if message is not None:
-                                logger.debug(f'{self.worker}: abandoning message id: {message.message_id}, {message._raw_amqp_message.header.delivery_count}')
+                                self.logger.debug(f'abandoning message id: {message.message_id}, {message._raw_amqp_message.header.delivery_count}')
                                 receiver.abandon_message(message)
                                 message = None
 

--- a/grizzly_extras/async_message/sb.py
+++ b/grizzly_extras/async_message/sb.py
@@ -1,5 +1,3 @@
-import logging
-
 from typing import Any, Callable, Dict, Optional, Union, Tuple, Iterable, cast
 from time import monotonic as time, sleep
 from mypy_extensions import VarArg, KwArg
@@ -46,9 +44,6 @@ class AsyncServiceBusHandler(AsyncMessageHandler):
         self._sender_cache = {}
         self._receiver_cache = {}
         self._arguments = {}
-
-        # silence uamqp loggers
-        logging.getLogger('uamqp').setLevel(logging.ERROR)
 
     @classmethod
     def get_sender_instance(cls, client: ServiceBusClient, arguments: Dict[str, str]) -> ServiceBusSender:

--- a/grizzly_extras/transformer.py
+++ b/grizzly_extras/transformer.py
@@ -238,8 +238,8 @@ class JsonBytesEncoder(JSONEncoder):
     def default(self, o: Any) -> Any:
         if isinstance(o, bytes):
             try:
-                return o.decode('utf-8')
+                return o.decode('utf-8', 'ignore')
             except:
-                return o.decode('latin-1')
+                return o.decode('latin-1', 'ignore')
 
         return JSONEncoder.default(self, o)

--- a/grizzly_extras/transformer.py
+++ b/grizzly_extras/transformer.py
@@ -238,8 +238,8 @@ class JsonBytesEncoder(JSONEncoder):
     def default(self, o: Any) -> Any:
         if isinstance(o, bytes):
             try:
-                return o.decode('utf-8', 'ignore')
+                return o.decode('utf-8')
             except:
-                return o.decode('latin-1', 'ignore')
+                return o.decode('latin-1')
 
         return JSONEncoder.default(self, o)

--- a/tests/test_grizzly/fixtures.py
+++ b/tests/test_grizzly/fixtures.py
@@ -117,7 +117,7 @@ def locust_environment(tmpdir_factory: TempdirFactory) -> Generator[Environment,
     try:
         os.environ['GRIZZLY_CONTEXT_ROOT'] = test_context_root
         yield Environment()
-    except:
+    finally:
         try:
             del os.environ['GRIZZLY_CONTEXT_ROOT']
         except KeyError:

--- a/tests/test_grizzly/test_environment.py
+++ b/tests/test_grizzly/test_environment.py
@@ -26,34 +26,40 @@ def test_before_feature() -> None:
     except:
         pass
 
-    base_dir = '.'
-    context = Context(
-        runner=Runner(
-            config=Configuration(
-                command_args=[],
-                load_config=False,
-                base_dir=base_dir,
+    try:
+        base_dir = '.'
+        context = Context(
+            runner=Runner(
+                config=Configuration(
+                    command_args=[],
+                    load_config=False,
+                    base_dir=base_dir,
+                )
             )
         )
-    )
 
-    assert not hasattr(context ,'grizzly')
-    assert environ.get('GRIZZLY_CONTEXT_ROOT', None) is None
+        assert not hasattr(context ,'grizzly')
+        assert environ.get('GRIZZLY_CONTEXT_ROOT', None) is None
 
-    before_feature(context)
+        before_feature(context)
 
-    assert hasattr(context, 'grizzly')
-    assert context.grizzly.__class__.__name__ == 'GrizzlyContext'
-    assert environ.get('GRIZZLY_CONTEXT_ROOT', None) == base_dir
+        assert hasattr(context, 'grizzly')
+        assert context.grizzly.__class__.__name__ == 'GrizzlyContext'
+        assert environ.get('GRIZZLY_CONTEXT_ROOT', None) == base_dir
 
-    context.grizzly = object()
+        context.grizzly = object()
 
-    before_feature(context)
+        before_feature(context)
 
-    assert hasattr(context, 'grizzly')
-    assert context.grizzly.__class__.__name__ == 'GrizzlyContext'
+        assert hasattr(context, 'grizzly')
+        assert context.grizzly.__class__.__name__ == 'GrizzlyContext'
 
-    assert hasattr(context, 'started')
+        assert hasattr(context, 'started')
+    finally:
+        try:
+            del environ['GRIZZLY_CONTEXT_ROOT']
+        except:
+            pass
 
 
 @pytest.mark.usefixtures('behave_context')

--- a/tests/test_grizzly/test_locust.py
+++ b/tests/test_grizzly/test_locust.py
@@ -516,7 +516,9 @@ def test_run_worker(behave_context: Context, capsys: CaptureFixture, mocker: Moc
         mocked_popen___init__,
     )
 
-    from grizzly.locust import subprocess as subprocess_spy
+    mocker.patch('grizzly.locust.gevent.subprocess.Popen.wait', autospec=True)
+
+    import subprocess as subprocess_spy
 
     messagequeue_process_spy = mocker.spy(subprocess_spy.Popen, '__init__')
 
@@ -645,7 +647,7 @@ def test_run_master(behave_context: Context, capsys: CaptureFixture, mocker: Moc
         mocked_popen___init__,
     )
 
-    from grizzly.locust import subprocess as subprocess_spy
+    import subprocess as subprocess_spy
 
     messagequeue_process_spy = mocker.spy(subprocess_spy.Popen, '__init__')
 

--- a/tests/test_grizzly/test_types.py
+++ b/tests/test_grizzly/test_types.py
@@ -234,6 +234,11 @@ class TestGrizzlyDict:
             t['AtomicDirectoryContents.test7'] = 'adirectory|repeat=True, random=True'
             assert t['AtomicDirectoryContents.test7'] == 'adirectory | repeat=True, random=True'
         finally:
+            try:
+                del environ['GRIZZLY_CONTEXT_ROOT']
+            except:
+                pass
+
             rmtree(test_context_root)
             cleanup()
 
@@ -265,6 +270,11 @@ class TestGrizzlyDict:
             t['AtomicCsvRow.test2'] = 'test.csv|repeat=True'
             assert t['AtomicCsvRow.test2'] == 'test.csv | repeat=True'
         finally:
+            try:
+                del environ['GRIZZLY_CONTEXT_ROOT']
+            except:
+                pass
+
             rmtree(test_context_root)
             cleanup()
 

--- a/tests/test_grizzly/testdata/test_utils.py
+++ b/tests/test_grizzly/testdata/test_utils.py
@@ -156,6 +156,11 @@ def test__get_variable_value_AtomicCsvRow(cleanup: Callable, tmpdir_factory: Tem
         assert value['test'] == {'header1': 'value3', 'header2': 'value4'}
         assert value['test'] is None
     finally:
+        try:
+            del environ['GRIZZLY_CONTEXT_ROOT']
+        except:
+            pass
+
         shutil.rmtree(test_context_root)
         cleanup()
 

--- a/tests/test_grizzly/testdata/variables/test_csv_row.py
+++ b/tests/test_grizzly/testdata/variables/test_csv_row.py
@@ -48,7 +48,7 @@ def test_atomiccsvrow__base_type__(tmpdir_factory: TempdirFactory) -> None:
 
         try:
             del os.environ['GRIZZLY_CONTEXT_ROOT']
-        except KeyError:
+        except:
             pass
 
 
@@ -58,7 +58,6 @@ class TestAtomicCsvRow:
         test_context = str(tmpdir_factory.mktemp('test_context').mkdir('requests'))
         test_context_root = os.path.dirname(test_context)
 
-        old_grizzly_context_root = os.environ.get('GRIZZLY_CONTEXT_ROOT', None)
         os.environ['GRIZZLY_CONTEXT_ROOT'] = test_context_root
 
         for count in range(1, 4):
@@ -212,10 +211,11 @@ class TestAtomicCsvRow:
             ]
         finally:
             shutil.rmtree(test_context_root)
-            if old_grizzly_context_root is not None:
-                os.environ['GRIZZLY_CONTEXT_ROOT'] = old_grizzly_context_root
-            else:
+
+            try:
                 del os.environ['GRIZZLY_CONTEXT_ROOT']
+            except:
+                pass
 
             cleanup()
 
@@ -224,7 +224,6 @@ class TestAtomicCsvRow:
         test_context = str(tmpdir_factory.mktemp('test_context').mkdir('requests'))
         test_context_root = os.path.dirname(test_context)
 
-        old_grizzly_context_root = os.environ.get('GRIZZLY_CONTEXT_ROOT', None)
         os.environ['GRIZZLY_CONTEXT_ROOT'] = test_context_root
 
         with open(os.path.join(test_context, 'test.csv'), 'w') as fd:
@@ -259,10 +258,11 @@ class TestAtomicCsvRow:
             AtomicCsvRow.destroy()
         finally:
             shutil.rmtree(test_context_root)
-            if old_grizzly_context_root is not None:
-                os.environ['GRIZZLY_CONTEXT_ROOT'] = old_grizzly_context_root
-            else:
+
+            try:
                 del os.environ['GRIZZLY_CONTEXT_ROOT']
+            except:
+                pass
 
             cleanup()
 

--- a/tests/test_grizzly/testdata/variables/test_directory_contents.py
+++ b/tests/test_grizzly/testdata/variables/test_directory_contents.py
@@ -45,7 +45,7 @@ def test_atomicdirectorycontents__base_type__(tmpdir_factory: TempdirFactory) ->
 
         try:
             del os.environ['GRIZZLY_CONTEXT_ROOT']
-        except KeyError:
+        except:
             pass
 
 class TestAtomicDirectoryContents:
@@ -192,10 +192,12 @@ class TestAtomicDirectoryContents:
             ]
         finally:
             shutil.rmtree(test_context_root)
-            if old_grizzly_context_root is not None:
-                os.environ['GRIZZLY_CONTEXT_ROOT'] = old_grizzly_context_root
-            else:
+
+            try:
                 del os.environ['GRIZZLY_CONTEXT_ROOT']
+            except:
+                pass
+
             cleanup()
 
     @pytest.mark.usefixtures('cleanup')
@@ -203,7 +205,6 @@ class TestAtomicDirectoryContents:
         test_context = str(tmpdir_factory.mktemp('test_context').mkdir('requests'))
         test_context_root = os.path.dirname(test_context)
 
-        old_grizzly_context_root = os.environ.get('GRIZZLY_CONTEXT_ROOT', None)
         os.environ['GRIZZLY_CONTEXT_ROOT'] = test_context_root
         try:
             try:
@@ -232,8 +233,9 @@ class TestAtomicDirectoryContents:
             AtomicDirectoryContents.destroy()
         finally:
             shutil.rmtree(test_context_root)
-            if old_grizzly_context_root is not None:
-                os.environ['GRIZZLY_CONTEXT_ROOT'] = old_grizzly_context_root
-            else:
+
+            try:
                 del os.environ['GRIZZLY_CONTEXT_ROOT']
+            except:
+                pass
             cleanup()

--- a/tests/test_grizzly/testdata/variables/test_directory_contents.py
+++ b/tests/test_grizzly/testdata/variables/test_directory_contents.py
@@ -54,7 +54,6 @@ class TestAtomicDirectoryContents:
         test_context = str(tmpdir_factory.mktemp('test_context').mkdir('requests'))
         test_context_root = os.path.dirname(test_context)
 
-        old_grizzly_context_root = os.environ.get('GRIZZLY_CONTEXT_ROOT', None)
         os.environ['GRIZZLY_CONTEXT_ROOT'] = test_context_root
 
         for directory in ['1-test', '2-test', '3-test']:

--- a/tests/test_grizzly_extras/async_message/test___init__.py
+++ b/tests/test_grizzly_extras/async_message/test___init__.py
@@ -117,25 +117,29 @@ class TestThreadLogger:
         test_context_root = path.dirname(str(test_context))
 
         try:
-            environ['GRIZZLY_CONTEXT_ROOT'] = test_context_root
-
             logger = ThreadLogger('test.logger')
-            logger.error('hello world')
-            logger.debug('no no')
+            logger.info('info')
+            logger.warning('warning')
+            logger.error('error')
+            logger.debug('debug')
 
             std = capsys.readouterr()
-            assert '] INFO : test.logger: level=INFO\n' in std.err
-            assert '] ERROR: test.logger: hello world\n' in std.err
-            assert '] DEBUG: test.logger: no no\n' not in std.err
+            assert '] INFO : test.logger: info\n' in std.err
+            assert '] ERROR: test.logger: error\n' in std.err
+            assert '] WARNING: test.logger: warning\n' in std.err
+            assert '] DEBUG: test.logger: debug\n' not in std.err
 
             log_files = listdir(str(test_context))
             assert len(log_files) == 0
 
+            environ['GRIZZLY_CONTEXT_ROOT'] = test_context_root
             environ['GRIZZLY_EXTRAS_LOGLEVEL'] = 'DEBUG'
 
             logger = ThreadLogger('test.logger')
-            logger.error('hello world')
-            logger.debug('no no')
+            logger.info('info')
+            logger.error('error')
+            logger.debug('debug')
+            logger.warning('warning')
 
             std = capsys.readouterr()
             log_files = listdir(str(test_context))
@@ -147,9 +151,10 @@ class TestThreadLogger:
                 file = fd.read()
 
             for sink in [std.err, file]:
-                assert '] INFO : test.logger: level=DEBUG\n' in sink
-                assert '] ERROR: test.logger: hello world\n' in sink
-                assert '] DEBUG: test.logger: no no\n' in sink
+                assert '] INFO : test.logger: info\n' in sink
+                assert '] ERROR: test.logger: error\n' in sink
+                assert '] WARNING: test.logger: warning\n' in sink
+                assert '] DEBUG: test.logger: debug\n' in sink
         finally:
             try:
                 del environ['GRIZZLY_CONTEXT_ROOT']

--- a/tests/test_grizzly_extras/async_message/test___init__.py
+++ b/tests/test_grizzly_extras/async_message/test___init__.py
@@ -1,5 +1,4 @@
 from typing import Optional, cast
-from json import dumps as jsondumps
 from os import environ, path, listdir
 from shutil import rmtree
 from platform import node as hostname
@@ -15,30 +14,9 @@ from grizzly_extras.async_message import (
     AsyncMessageResponse,
     AsyncMessageRequest,
     AsyncMessageHandler,
+    ThreadLogger,
     register,
-    configure_logger,
 )
-
-from grizzly_extras.transformer import JsonBytesEncoder
-
-class TestJsonBytesEncoder:
-    def test_default(self) -> None:
-        encoder = JsonBytesEncoder()
-
-        assert encoder.default(b'hello') == 'hello'
-        assert encoder.default(b'invalid \xe9 char') == 'invalid \xe9 char'
-
-        assert jsondumps({
-            'hello': b'world',
-            'invalid': b'\xe9 char',
-            'value': 'something',
-            'test': False,
-            'int': 1,
-            'empty': None,
-        }, cls=JsonBytesEncoder) == '{"hello": "world", "invalid": "\\u00e9 char", "value": "something", "test": false, "int": 1, "empty": null}'
-
-        with pytest.raises(TypeError):
-            encoder.default(None)
 
 
 class TestAsyncMessageHandler:
@@ -133,53 +111,54 @@ def test_register() -> None:
             pass
 
 
-def test_configure_logger(mocker: MockerFixture, tmpdir_factory: TempdirFactory, capsys: CaptureFixture) -> None:
-    test_context = tmpdir_factory.mktemp('test_context').mkdir('logs')
-    test_context_root = path.dirname(str(test_context))
-
-    try:
-        environ['GRIZZLY_CONTEXT_ROOT'] = test_context_root
-
-        logger = configure_logger('test.logger')
-        logger.error('hello world')
-        logger.debug('no no')
-
-        std = capsys.readouterr()
-        assert '] INFO : test.logger: level=INFO\n' in std.err
-        assert '] ERROR: test.logger: hello world\n' in std.err
-        assert '] DEBUG: test.logger: no no\n' not in std.err
-
-        log_files = listdir(str(test_context))
-        assert len(log_files) == 0
-
-        environ['GRIZZLY_EXTRAS_LOGLEVEL'] = 'DEBUG'
-
-        logger = configure_logger('test.logger')
-        logger.error('hello world')
-        logger.debug('no no')
-
-        std = capsys.readouterr()
-        log_files = listdir(str(test_context))
-        assert len(log_files) == 1
-        log_file = log_files[0]
-        assert log_file == f'async-messaged.{hostname()}.log'
-
-        with open(path.join(str(test_context), log_file)) as fd:
-            file = fd.read()
-
-        for sink in [std.err, file]:
-            assert '] INFO : test.logger: level=DEBUG\n' in sink
-            assert '] ERROR: test.logger: hello world\n' in sink
-            assert '] DEBUG: test.logger: no no\n' in sink
-    finally:
-        try:
-            del environ['GRIZZLY_CONTEXT_ROOT']
-        except:
-            pass
+class TestThreadLogger:
+    def test_logger(self, tmpdir_factory: TempdirFactory, capsys: CaptureFixture) -> None:
+        test_context = tmpdir_factory.mktemp('test_context').mkdir('logs')
+        test_context_root = path.dirname(str(test_context))
 
         try:
-            del environ['GRIZZLY_EXTRAS_LOGLEVEL']
-        except:
-            pass
+            environ['GRIZZLY_CONTEXT_ROOT'] = test_context_root
 
-        rmtree(test_context_root)
+            logger = ThreadLogger('test.logger')
+            logger.error('hello world')
+            logger.debug('no no')
+
+            std = capsys.readouterr()
+            assert '] INFO : test.logger: level=INFO\n' in std.err
+            assert '] ERROR: test.logger: hello world\n' in std.err
+            assert '] DEBUG: test.logger: no no\n' not in std.err
+
+            log_files = listdir(str(test_context))
+            assert len(log_files) == 0
+
+            environ['GRIZZLY_EXTRAS_LOGLEVEL'] = 'DEBUG'
+
+            logger = ThreadLogger('test.logger')
+            logger.error('hello world')
+            logger.debug('no no')
+
+            std = capsys.readouterr()
+            log_files = listdir(str(test_context))
+            assert len(log_files) == 1
+            log_file = log_files[0]
+            assert log_file.startswith(f'async-messaged.{hostname()}')
+
+            with open(path.join(str(test_context), log_file)) as fd:
+                file = fd.read()
+
+            for sink in [std.err, file]:
+                assert '] INFO : test.logger: level=DEBUG\n' in sink
+                assert '] ERROR: test.logger: hello world\n' in sink
+                assert '] DEBUG: test.logger: no no\n' in sink
+        finally:
+            try:
+                del environ['GRIZZLY_CONTEXT_ROOT']
+            except:
+                pass
+
+            try:
+                del environ['GRIZZLY_EXTRAS_LOGLEVEL']
+            except:
+                pass
+
+            rmtree(test_context_root)

--- a/tests/test_grizzly_extras/async_message/test_sb.py
+++ b/tests/test_grizzly_extras/async_message/test_sb.py
@@ -16,7 +16,7 @@ class TestAsyncServiceBusHandler:
     def test___init__(self, mocker: MockerFixture) -> None:
         spy = mocker.patch(
             'grizzly_extras.async_message.sb.logging.Logger.setLevel',
-            side_effect=[None],
+            side_effect=[None] * 10,
         )
 
         handler = AsyncServiceBusHandler('asdf-asdf-asdf')
@@ -25,9 +25,10 @@ class TestAsyncServiceBusHandler:
         assert handler._sender_cache == {}
         assert handler._receiver_cache == {}
 
-        assert spy.call_count == 1
-        args, _ = spy.call_args_list[0]
-        assert args[0] == logging.ERROR
+        assert spy.call_count == 3
+        assert spy.call_args_list[0][0][0] == logging.INFO  # ThreadLogger.__init__
+        assert spy.call_args_list[1][0][0] == logging.NOTSET  # ThreadLogger.__init__
+        assert spy.call_args_list[2][0][0] == logging.ERROR  # AsyncServiceBusHandler.__init__
 
     def test_from_message(self) -> None:
         assert AsyncServiceBusHandler.from_message(None) == (None, None,)

--- a/tests/test_grizzly_extras/async_message/test_sb.py
+++ b/tests/test_grizzly_extras/async_message/test_sb.py
@@ -1,5 +1,3 @@
-import logging
-
 from typing import cast
 from json import dumps as jsondumps
 
@@ -14,21 +12,11 @@ from grizzly_extras.async_message.sb import AsyncServiceBusHandler
 
 class TestAsyncServiceBusHandler:
     def test___init__(self, mocker: MockerFixture) -> None:
-        spy = mocker.patch(
-            'grizzly_extras.async_message.sb.logging.Logger.setLevel',
-            side_effect=[None] * 10,
-        )
-
         handler = AsyncServiceBusHandler('asdf-asdf-asdf')
         assert handler.worker == 'asdf-asdf-asdf'
         assert handler.message_wait is None
         assert handler._sender_cache == {}
         assert handler._receiver_cache == {}
-
-        assert spy.call_count == 3
-        assert spy.call_args_list[0][0][0] == logging.INFO  # ThreadLogger.__init__
-        assert spy.call_args_list[1][0][0] == logging.NOTSET  # ThreadLogger.__init__
-        assert spy.call_args_list[2][0][0] == logging.ERROR  # AsyncServiceBusHandler.__init__
 
     def test_from_message(self) -> None:
         assert AsyncServiceBusHandler.from_message(None) == (None, None,)


### PR DESCRIPTION
fixed a bug where a logging statement would block until aborted (^C). the reason being that grizzly started `async-messaged` with `subprocess.Popen` and `stdout=subprocess.PIPE`.

since stdout for the process never was read, the buffer would get full and the logging call would block indefinitely.

refactoring of the whole logging functionality for `grizzly_extras.async_message`.

cleaner shutdown of external processes started by grizzly.

fixed a leaking GRIZZLY_CONTEXT_ROOT environment variables caused by the fixture `locust_environment`.