### PR TITLE
support for templating in arguments in condition

### DIFF
--- a/grizzly/tasks/__init__.py
+++ b/grizzly/tasks/__init__.py
@@ -19,6 +19,7 @@ class GrizzlyTasks(GrizzlyTasksBase):
 
     def __init__(self, parent: Type[User]) -> None:
         super().__init__(parent=parent)
+        self.grizzly = GrizzlyContext()
 
     @classmethod
     def add_scenario_task(cls, task: GrizzlyTask) -> None:


### PR DESCRIPTION
support variables/templating for arguments `retries` and `wait` in `UntilTask`.