### PR TITLE
Feature/restart scenario

### DIFF
--- a/example/features/environment.py
+++ b/example/features/environment.py
@@ -12,6 +12,7 @@ from grizzly.environment import (
     before_step,
 )
 from grizzly.context import GrizzlyContext
+from locust.exception import StopUser
 
 def before_scenario(
     context: Context, scenario: Scenario, *args: Tuple[Any, ...], **kwargs: Dict[str, Any]
@@ -27,4 +28,4 @@ def before_scenario(
     grizzly_before_scenario(context, scenario, *args, **kwargs)
 
     grizzly = cast(GrizzlyContext, context.grizzly)
-    grizzly.scenario.stop_on_failure = True
+    grizzly.scenario.failure_exception = StopUser

--- a/grizzly/context.py
+++ b/grizzly/context.py
@@ -1,6 +1,6 @@
 import logging
 
-from typing import Optional, Dict, Any, Tuple, List, Union, Callable
+from typing import Optional, Dict, Any, Tuple, List, Union, Callable, Type
 from os import environ, path
 from hashlib import sha1 as sha1_hash
 from dataclasses import dataclass, field
@@ -117,7 +117,7 @@ class GrizzlyContextScenario:
     wait: GrizzlyContextScenarioWait = field(init=False, repr=False, hash=False, compare=False, default_factory=GrizzlyContextScenarioWait)
     tasks: List[GrizzlyTask] = field(init=False, repr=False, hash=False, compare=False, default_factory=list)
     validation: GrizzlyContextScenarioValidation = field(init=False, hash=False, compare=False, default_factory=GrizzlyContextScenarioValidation)
-    stop_on_failure: bool = field(init=False, default=False)
+    failure_exception: Optional[Type[Exception]] = field(init=False, default=None)
     orphan_templates: List[str] = field(init=False, repr=False, hash=False, compare=False, default_factory=list)
 
     @property

--- a/grizzly/exceptions.py
+++ b/grizzly/exceptions.py
@@ -16,3 +16,6 @@ class TransformerLocustError(StopUser):
     def __init__(self, message: Optional[str] = None) -> None:
         self.message = message
 
+
+class RestartScenario(Exception):
+    pass

--- a/grizzly/scenarios/iterator.py
+++ b/grizzly/scenarios/iterator.py
@@ -1,14 +1,64 @@
+import traceback
+
 from typing import Type
 
 from locust import task
 from locust.user.users import User
-from locust.exception import StopUser
+from locust.user.task import LOCUST_STATE_STOPPING
+from locust.exception import StopUser, InterruptTaskSet, RescheduleTaskImmediately, RescheduleTask
+from gevent.exceptions import GreenletExit
 
 from . import GrizzlyScenario
+from ..exceptions import RestartScenario
 
 class IteratorScenario(GrizzlyScenario):
     def __init__(self, parent: Type[User]) -> None:
         super().__init__(parent=parent)
+
+    def run(self) -> None:
+        try:
+            self.on_start()
+        except InterruptTaskSet as e:
+            if e.reschedule:
+                raise RescheduleTaskImmediately(e.reschedule).with_traceback(e.__traceback__)
+            else:
+                raise RescheduleTask(e.reschedule).with_traceback(e.__traceback__)
+
+        while True:
+            try:
+                if not self._task_queue:
+                    self.schedule_task(self.get_next_task())
+
+                try:
+                    if self.user._state == LOCUST_STATE_STOPPING:
+                        raise StopUser()
+                    self.execute_next_task()
+                except RescheduleTaskImmediately:
+                    pass
+                except RescheduleTask:
+                    self.wait()
+                else:
+                    self.wait()
+            except InterruptTaskSet as e:
+                self.on_stop()
+                if e.reschedule:
+                    raise RescheduleTaskImmediately(e.reschedule) from e
+                else:
+                    raise RescheduleTask(e.reschedule) from e
+            except RestartScenario:
+                # reset locust.user.sequential_task.SequentialTaskSet index pointer to first task
+                self._task_index = 0
+                self.wait()
+            except (StopUser, GreenletExit):
+                self.on_stop()
+                raise
+            except Exception as e:
+                self.user.environment.events.user_error.fire(user_instance=self, exception=e, tb=e.__traceback__)
+                if self.user.environment.catch_exceptions:
+                    self.logger.error("%s\n%s", e, traceback.format_exc())
+                    self.wait()
+                else:
+                    raise
 
     @task
     def iterator(self) -> None:

--- a/grizzly/steps/scenario/results.py
+++ b/grizzly/steps/scenario/results.py
@@ -11,7 +11,7 @@ from ...context import GrizzlyContext, GrizzlyContextScenarioResponseTimePercent
 def step_results_fail_ratio(context: Context, fail_ratio: int) -> None:
     '''Set how many percentages of requests that are allowed to fail before the whole scenario will be set as failed.
 
-    This step cannot be used in combination with `step_setup_enable_stop_on_failure`.
+    This step cannot be used in combination with `step_setup_stop_user_on_failure` or `step_setup_restart_scenario_on_failure`.
 
     Default behavior is not to validate the result for a scenario based on failed requests.
 
@@ -23,7 +23,7 @@ def step_results_fail_ratio(context: Context, fail_ratio: int) -> None:
         fail_ratio (int): percentage of requests that are allowed to fail
     '''
     grizzly = cast(GrizzlyContext, context.grizzly)
-    assert not grizzly.scenario.stop_on_failure, f"cannot use step 'fail ratio is greater than \"{fail_ratio}\" fail scenario' togheter with step 'stop on failure'"
+    assert grizzly.scenario.failure_exception is None, f"cannot use step 'fail ratio is greater than \"{fail_ratio}\" fail scenario' togheter with 'on failure' steps"
     grizzly.scenario.validation.fail_ratio = fail_ratio / 100.0
 
 

--- a/grizzly/steps/scenario/setup.py
+++ b/grizzly/steps/scenario/setup.py
@@ -5,10 +5,12 @@ import parse
 
 from behave.runner import Context
 from behave import register_type, given  # pylint: disable=no-name-in-module
+from locust.exception import StopUser
 
 from ...context import GrizzlyContext
 from ...testdata.utils import create_context_variable, resolve_variable
 from ...utils import merge_dicts
+from ...exceptions import RestartScenario
 
 
 @parse.with_pattern(r'(iteration[s]?)')
@@ -237,16 +239,30 @@ def step_setup_log_all_requests(context: Context) -> None:
     grizzly.scenario.context['log_all_requests'] = True
 
 
-@given(u'stop on first failure')
-def step_setup_enable_stop_on_failure(context: Context) -> None:
-    '''Stop a scenario at first failed request.
+@given(u'stop user on failure')
+def step_setup_stop_user_on_failure(context: Context) -> None:
+    '''Stop user if a request fails.
 
     Default behavior is to continue the scenario if a request fails.
 
     ```gherkin
-    And stop on first failure
+    And stop user on failure
     ```
     '''
     grizzly = cast(GrizzlyContext, context.grizzly)
-    grizzly.scenario.stop_on_failure = True
+    grizzly.scenario.failure_exception = StopUser
     context.config.stop = True
+
+
+@given(u'restart scenario on failure')
+def step_setup_restart_scenario_on_failure(context: Context) -> None:
+    '''Restart scenario, from first task, if a request fails.
+    Default behavior is to continue the scenario if a request fails.
+
+    ```gherkin
+    And restart scenario on failure
+    ```
+    '''
+    grizzly = cast(GrizzlyContext, context.grizzly)
+    grizzly.scenario.failure_exception = RestartScenario
+    context.config.stop = False

--- a/grizzly/task/getter/__init__.py
+++ b/grizzly/task/getter/__init__.py
@@ -44,8 +44,8 @@ class GetterOfTask(GrizzlyScenarioBase):
                 exception=exception,
             )
 
-        if exception is not None and parent.user._scenario.stop_on_failure:
-            raise StopUser()
+        if exception is not None and parent.user._scenario.failure_exception is not None:
+            raise parent.user._scenario.failure_exception()
 
 class getterof:
     available: Dict[str, Type[GetterOfTask]] = {}

--- a/grizzly/task/until.py
+++ b/grizzly/task/until.py
@@ -19,7 +19,6 @@ from time import perf_counter as time
 
 from jinja2 import Template
 from gevent import sleep as gsleep
-from locust.exception import StopUser
 from grizzly_extras.transformer import Transformer, TransformerContentType, transformer
 from grizzly_extras.arguments import get_unsupported_arguments, parse_arguments, split_value
 
@@ -119,7 +118,7 @@ class UntilRequestTask(GrizzlyTask):
                     exception=exception,
                 )
 
-                if exception is not None:
-                    raise StopUser()
+                if exception is not None and self.request.scenario.failure_exception is not None:
+                    raise self.request.scenario.failure_exception()
 
         return _implementation

--- a/grizzly/testdata/utils.py
+++ b/grizzly/testdata/utils.py
@@ -86,8 +86,6 @@ def transform(data: Dict[str, Any], objectify: Optional[bool] = True) -> Dict[st
                 try:
                     value = variable_instance[variable_name]
                 except Exception as e:
-                    import traceback
-                    traceback.print_exc()
                     exception = e
                     logger.error(str(e), exc_info=grizzly.state.verbose)
                 finally:

--- a/grizzly/users/blobstorage.py
+++ b/grizzly/users/blobstorage.py
@@ -102,7 +102,10 @@ class BlobStorageUser(ContextVariables):
                 exception=exception
             )
 
-            if exception is not None and request.scenario.stop_on_failure:
-                raise StopUser()
+            if exception is not None:
+                if isinstance(exception, NotImplementedError):
+                    raise StopUser()
+                elif request.scenario.failure_exception is not None:
+                    raise request.scenario.failure_exception()
 
             return {}, payload

--- a/grizzly/users/sftp.py
+++ b/grizzly/users/sftp.py
@@ -165,7 +165,10 @@ class SftpUser(ResponseHandler, RequestLogger, ContextVariables, FileRequests):
                 exception=exception,
             )
 
-            if exception is not None and request.scenario.stop_on_failure:
-                raise StopUser()
+            if exception is not None:
+                if isinstance(exception, NotImplementedError):
+                    raise StopUser()
+                elif request.scenario.failure_exception is not None:
+                    raise request.scenario.failure_exception()
 
             return None, payload

--- a/tests/test_grizzly/scenarios/test_iterator.py
+++ b/tests/test_grizzly/scenarios/test_iterator.py
@@ -167,3 +167,7 @@ class TestIterationScenario:
         assert user.context_variables['AtomicIntegerIncrementer'].messageID == 1337
         assert user.context_variables['AtomicCsvRow'].test.header1 == 'value1'
         assert user.context_variables['AtomicCsvRow'].test.header2 == 'value2'
+
+    @pytest.mark.usefixtures('grizzly_context')
+    def test_run(self, grizzly_context: Callable, mocker: MockerFixture) -> None:
+        assert 0, 'implement test case'

--- a/tests/test_grizzly/steps/background/test_setup.py
+++ b/tests/test_grizzly/steps/background/test_setup.py
@@ -8,6 +8,8 @@ from urllib.parse import urlparse
 
 from grizzly.steps import *  # pylint: disable=unused-wildcard-import
 from grizzly.context import GrizzlyContext
+from grizzly.exceptions import RestartScenario
+from locust.exception import StopUser
 
 from ...fixtures import behave_context, locust_environment  # pylint: disable=unused-import
 
@@ -86,18 +88,28 @@ def test_step_setup_save_statistics(behave_context: Context) -> None:
 
 
 @pytest.mark.usefixtures('behave_context')
-def test_step_setup_enable_stop_on_failure(behave_context: Context) -> None:
-    step_impl = step_setup_enable_stop_on_failure
-
+def test_step_setup_stop_user_on_failure(behave_context: Context) -> None:
     grizzly = cast(GrizzlyContext, behave_context.grizzly)
 
     assert not behave_context.config.stop
-    assert not grizzly.scenario.stop_on_failure
+    assert grizzly.scenario.failure_exception is None
 
-    step_impl(behave_context)
+    step_setup_stop_user_on_failure(behave_context)
 
     assert behave_context.config.stop
-    assert grizzly.scenario.stop_on_failure
+    assert grizzly.scenario.failure_exception == StopUser
+
+@pytest.mark.usefixtures('behave_context')
+def test_step_setup_restart_scenario_on_failure(behave_context: Context) -> None:
+    grizzly = cast(GrizzlyContext, behave_context.grizzly)
+
+    assert not behave_context.config.stop
+    assert grizzly.scenario.failure_exception is None
+
+    step_setup_restart_scenario_on_failure(behave_context)
+
+    assert not behave_context.config.stop
+    assert grizzly.scenario.failure_exception == RestartScenario
 
 
 @pytest.mark.usefixtures('behave_context')

--- a/tests/test_grizzly/task/test_until.py
+++ b/tests/test_grizzly/task/test_until.py
@@ -6,6 +6,7 @@ import pytest
 from pytest_mock import mocker, MockerFixture  # pylint: disable=unused-import
 
 from locust.exception import StopUser
+from grizzly.exceptions import RestartScenario
 from grizzly.types import RequestMethod
 from grizzly.task import UntilRequestTask, RequestTask
 from grizzly_extras.transformer import TransformerContentType, transformer
@@ -152,6 +153,7 @@ class TestUntilRequestTask:
             ],
         )
 
+        request.scenario.failure_exception = StopUser
         task = UntilRequestTask(request, '$.`this`[?status="ready"] | wait=10, retries=2')
         implementation = task.implementation()
 
@@ -181,7 +183,8 @@ class TestUntilRequestTask:
             ],
         )
 
-        with pytest.raises(StopUser):
+        request.scenario.failure_exception = RestartScenario
+        with pytest.raises(RestartScenario):
             implementation(tasks)
 
         assert fire_spy.call_count == 4

--- a/tests/test_grizzly/test_context.py
+++ b/tests/test_grizzly/test_context.py
@@ -291,7 +291,7 @@ class TestGrizzlyContextScenario:
         assert isinstance(scenario.wait, GrizzlyContextScenarioWait)
         assert scenario.tasks == []
         assert isinstance(scenario.validation, GrizzlyContextScenarioValidation)
-        assert not scenario.stop_on_failure
+        assert not scenario.failure_exception
 
         with pytest.raises(ValueError):
             hash_id = scenario.identifier

--- a/tests/test_grizzly/users/test_blobstorage.py
+++ b/tests/test_grizzly/users/test_blobstorage.py
@@ -19,6 +19,7 @@ from grizzly.types import RequestMethod
 from grizzly.context import GrizzlyContextScenario
 from grizzly.task import RequestTask
 from grizzly.testdata.utils import transform
+from grizzly.exceptions import RestartScenario
 
 from ..fixtures import grizzly_context, request_task  # pylint: disable=unused-import
 from ..helpers import ResultFailure, RequestEvent, RequestSilentFailureEvent
@@ -173,9 +174,14 @@ class TestBlobStorageUser:
         dummy_client.set_blobclient(dummy_blobclient)
         environment.events.request = RequestSilentFailureEvent()
 
-        request_error.scenario.stop_on_failure = False
-        user.request(request_error)
+        request_error.scenario.failure_exception = None
+        with pytest.raises(StopUser):
+            user.request(request_error)
 
-        request_error.scenario.stop_on_failure = True
+        request_error.scenario.failure_exception = StopUser
+        with pytest.raises(StopUser):
+            user.request(request_error)
+
+        request_error.scenario.failure_exception = RestartScenario
         with pytest.raises(StopUser):
             user.request(request_error)

--- a/tests/test_grizzly/users/test_restapi.py
+++ b/tests/test_grizzly/users/test_restapi.py
@@ -23,6 +23,7 @@ from grizzly.types import RequestMethod
 from grizzly.context import GrizzlyContextScenario
 from grizzly.task import RequestTask
 from grizzly.testdata.utils import transform
+from grizzly.exceptions import RestartScenario
 
 from ..fixtures import grizzly_context, request_task  # pylint: disable=unused-import
 from ..helpers import RequestSilentFailureEvent, RequestEvent, ResultSuccess
@@ -650,10 +651,16 @@ class TestRestApiUser:
 
         mock_client_post(status_code=400)
 
-        scenario.stop_on_failure = True
+        scenario.failure_exception = StopUser
 
         # status_code != 200, stop_on_failure = True
         with pytest.raises(StopUser):
+            user.request(request)
+
+        scenario.failure_exception = RestartScenario
+
+        # status_code != 200, stop_on_failure = True
+        with pytest.raises(RestartScenario):
             user.request(request)
 
         request.response.add_status_code(400)
@@ -662,7 +669,7 @@ class TestRestApiUser:
             user.request(request)
 
         request.response.add_status_code(-400)
-        scenario.stop_on_failure = False
+        scenario.failure_exception = None
 
         # status_code != 200, stop_on_failure = False
         metadata, payload = user.request(request)

--- a/tests/test_grizzly/users/test_servicebus.py
+++ b/tests/test_grizzly/users/test_servicebus.py
@@ -242,7 +242,7 @@ class TestServiceBusUser:
         task.source = 'hello'
         task.template = Template(task.source)
         scenario.add_task(task)
-        scenario.stop_on_failure = True
+        scenario.failure_exception = StopUser
         mocker.patch.object(user.zmq_client, 'disconnect', side_effect=[TypeError])
 
         with pytest.raises(StopUser):
@@ -275,7 +275,7 @@ class TestServiceBusUser:
         task.method = RequestMethod.SEND
 
         # unsuccessful response from async-messaged
-        scenario.stop_on_failure = False
+        scenario.failure_exception = None
 
         user.request(task)
         assert say_hello_spy.call_count == 2


### PR DESCRIPTION
Possibility to restart a scenario when a request fails, instead of just stopping the user and hence lowering the targeted intensity.

The old `And stop on first failure` expression has been removed and replaced with `And stop user on failure`.
A new expression `And restart scenario on failure` will result in restarting from task 1 (0) in `IteratorScenario`, and hence requesting
next iteration of testdata. If the specified number of iterations has been reached the user will stop.

Default behavior is the same as before, e.g. if none of the mentioned expressions has been specified in the scenario, it will just continue with next task if a request failed.