### PR TITLE
twine: command not found

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -126,11 +126,13 @@ jobs:
         echo "::set-output name=version::${next_version}"
 
     - name: install python dependencies
+      id: install-python-deps
       run: |
-        pip install --upgrade wheel twine pip-tools
+        pip install --upgrade pip-tools
         ./script/pip-sync.bash ci
 
     - name: build and publish package
+      id: build-publish
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
@@ -149,6 +151,7 @@ jobs:
 
         python setup.py sdist bdist_wheel
         ls -l dist/grizzly?loadtester-${{ steps.version.outputs.version }}*
+        echo "$(twine --version)"
         if [[ "${{ github.event.inputs.dry-run }}" != "true" ]]; then
           twine upload dist/grizzly?loadtester-${{ steps.version.outputs.version }}*
         else
@@ -156,6 +159,7 @@ jobs:
         fi
 
     - name: create and push release tag
+      id: release-tag
       uses: actions-ecosystem/action-push-tag@v1
       if: github.event.inputs.dry-run != 'true'
       with:
@@ -163,6 +167,7 @@ jobs:
         message: 'Release ${{ steps.version.outputs.version }}'
 
     - name: build documentation
+      id: build-docs
       run: |
         pydoc-markdown --build --site-dir "$PWD/build/html"
 
@@ -170,6 +175,7 @@ jobs:
         cp -r docs/assets $PWD/build/html
 
     - name: deploy documentation
+      id: deploy-docs
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -83,6 +83,10 @@ behave==1.2.6 \
     --hash=sha256:b9662327aa53294c1351b0a9c369093ccec1d21026f050c3bd9b3e5cccf81a86 \
     --hash=sha256:ebda1a6c9e5bfe95c5f9f0a2794e01c7098b3dde86c10a95d8621c5907ff6f1c
     # via grizzly-loadtester (setup.py)
+bleach==4.1.0 \
+    --hash=sha256:0900d8b37eba61a802ee40ac0061f8c2b5dee29c1927dd1d233e075ebf5a71da \
+    --hash=sha256:4d2651ab93271d1129ac9cbc679f524565cc8a1b791909c4a51eac4446a15994
+    # via readme-renderer
 brotli==1.0.9 \
     --hash=sha256:12effe280b8ebfd389022aa65114e30407540ccb89b177d3fbc9a4f177c4bd5d \
     --hash=sha256:160c78292e98d21e73a4cc7f76a234390e516afcd982fa17e1422f7c6a9ce9c8 \
@@ -228,7 +232,12 @@ click==8.0.4 \
     # via
     #   flask
     #   mkdocs
+    #   pip-tools
     #   pydoc-markdown
+colorama==0.4.4 \
+    --hash=sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b \
+    --hash=sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2
+    # via twine
 configargparse==1.5.3 \
     --hash=sha256:18f6535a2db9f6e02bd5626cc7455eac3e96b9ab3d969d366f9aafd5c5c00fe7 \
     --hash=sha256:1b0b3cbf664ab59dada57123c81eff3d9737e0d11d8cf79e3d6eb10823f1739f
@@ -303,6 +312,7 @@ cryptography==36.0.2 \
     #   msal
     #   paramiko
     #   pyjwt
+    #   secretstorage
 databind==1.5.1 \
     --hash=sha256:0a28c887c1ce24f00e298a8d7b6b08eb3711cf43834990c39deb3257738f322f \
     --hash=sha256:8682a81cac265c6dfc9c8cca257fda63b812193cef0d731f42e866dbe2b7bf7a
@@ -320,9 +330,9 @@ databind-json==1.5.1 \
     # via
     #   databind
     #   docspec
-dataproperty==0.54.2 \
-    --hash=sha256:05496c90ed6cc172930bbab825c6f9515cb5bdc51d8c46eb25306d530654c976 \
-    --hash=sha256:df2fcf00e7a57f0a6089f686f847527eb3c91ded5c419daef6d06ee4bb1187b4
+dataproperty==0.55.0 \
+    --hash=sha256:73ccf10f8b123968210438a1a1aa859ea6d5a16b4e1f4d307da7a81b838e79fa \
+    --hash=sha256:a8f29175950f4b2c33a387aa3809130d87b9a8d3b92a916c906c49efdb566b32
     # via
     #   pytablewriter
     #   tabledata
@@ -350,6 +360,10 @@ docspec-python==2.0.0 \
 docstring-parser==0.11 \
     --hash=sha256:93b3f8f481c7d24e37c5d9f30293c89e2933fa209421c8abd731dd3ef0715ecb
     # via pydoc-markdown
+docutils==0.18.1 \
+    --hash=sha256:23010f129180089fbcd3bc08cfefccb3b890b0050e1ca00c867036e9d161b98c \
+    --hash=sha256:679987caf361a7539d76e584cbeddc311e3aee937877c87346f31debc63e9d06
+    # via readme-renderer
 flake8==4.0.1 \
     --hash=sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d \
     --hash=sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d
@@ -457,13 +471,13 @@ google-api-core==2.7.1 \
     --hash=sha256:6be1fc59e2a7ba9f66808bbc22f976f81e4c3e7ab20fa0620ce42686288787d0 \
     --hash=sha256:b0fa577e512f0c8e063386b974718b8614586a798c5894ed34bedf256d9dae24
     # via opencensus
-google-auth==2.6.0 \
-    --hash=sha256:218ca03d7744ca0c8b6697b6083334be7df49b7bf76a69d555962fd1a7657b5f \
-    --hash=sha256:ad160fc1ea8f19e331a16a14a79f3d643d813a69534ba9611d2c80dc10439dad
+google-auth==2.6.2 \
+    --hash=sha256:3ba4d63cb29c1e6d5ffcc1c0623c03cf02ede6240a072f213084749574e691ab \
+    --hash=sha256:60d449f8142c742db760f4c0be39121bc8d9be855555d784c252deaca1ced3f5
     # via google-api-core
-googleapis-common-protos==1.55.0 \
-    --hash=sha256:183bb0356bd614c4330ad5158bc1c1bcf9bcf7f5e7f911317559fe209496eeee \
-    --hash=sha256:53eb313064738f45d5ac634155ae208e121c963659627b90dfcb61ef514c03e1
+googleapis-common-protos==1.56.0 \
+    --hash=sha256:4007500795bcfc269d279f0f7d253ae18d6dc1ff5d5a73613ffe452038b1ec5f \
+    --hash=sha256:60220c89b8bd5272159bed4929ecdc1243ae1f73437883a499a44a1cbc084086
     # via google-api-core
 greenlet==1.1.2 \
     --hash=sha256:0051c6f1f27cb756ffc0ffbac7d2cd48cb0362ac1736871399a739b2885134d3 \
@@ -530,8 +544,10 @@ importlib-metadata==4.11.3 \
     --hash=sha256:1208431ca90a8cca1a6b8af391bb53c1a2db74e5d1cef6ddced95d4b2062edc6 \
     --hash=sha256:ea4c597ebf37142f827b8f39299579e31685c31d3a438b59f469406afd0f2539
     # via
+    #   keyring
     #   markdown
     #   mkdocs
+    #   twine
 influxdb==5.3.1 \
     --hash=sha256:46f85e7b04ee4b3dee894672be6a295c94709003a7ddea8820deec2ac4d8b27a \
     --hash=sha256:65040a1f53d1a2a4f88a677e89e3a98189a7d30cf2ab61c318aaa89733280747
@@ -554,6 +570,12 @@ itsdangerous==2.1.1 \
     --hash=sha256:7b7d3023cd35d9cb0c1fd91392f8c95c6fa02c59bf8ad64b8849be3401b95afb \
     --hash=sha256:935642cd4b987cdbee7210080004033af76306757ff8b4c0a506a4b6e06f02cf
     # via flask
+jeepney==0.7.1 \
+    --hash=sha256:1b5a0ea5c0e7b166b2f5895b91a08c14de8915afda4407fb5022a195224958ac \
+    --hash=sha256:fa9e232dfa0c498bd0b8a3a73b8d8a31978304dcef0515adc859d4e096f96f4f
+    # via
+    #   keyring
+    #   secretstorage
 jinja2==3.0.3 \
     --hash=sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8 \
     --hash=sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7
@@ -568,6 +590,10 @@ jsonpath-ng==1.5.3 \
     --hash=sha256:a273b182a82c1256daab86a313b937059261b5c5f8c4fa3fc38b882b344dd567 \
     --hash=sha256:f75b95dbecb8a0f3b86fd2ead21c2b022c3f5770957492b9b6196ecccfeb10aa
     # via grizzly-loadtester (setup.py)
+keyring==23.5.0 \
+    --hash=sha256:9012508e141a80bd1c0b6778d5c610dd9f8c464d75ac6774248500503f972fb9 \
+    --hash=sha256:b0d28928ac3ec8e42ef4cc227822647a19f1d544f21f96457965dc01cf555261
+    # via twine
 lazy-object-proxy==1.7.1 \
     --hash=sha256:043651b6cb706eee4f91854da4a089816a6606c1428fd391573ef8cb642ae4f7 \
     --hash=sha256:07fa44286cda977bd4803b656ffc1c9b7e3bc7dff7d34263446aec8f8c96f88a \
@@ -839,9 +865,9 @@ mypy-extensions==0.4.3 \
     # via
     #   grizzly-loadtester (setup.py)
     #   mypy
-nr-util==0.8.6 \
-    --hash=sha256:2d3a1db0a0e724ec8bc11d3ab6e68e57be04bbb3f05f8b61d77b7e66487cf433 \
-    --hash=sha256:815b2716499ba6c575a686f3f123345988cc9731f4177f0a94497f5069f762f4
+nr-util==0.8.7 \
+    --hash=sha256:882123edc0b3275d2c6132e96bf8ef554b3c204ae4b37736f5f78da8d80b0592 \
+    --hash=sha256:d27e07755d7bc4c3adc042c9e792cdd1b03b9b85cde55a95068ebd4c37729f9b
     # via
     #   databind-core
     #   databind-json
@@ -867,12 +893,13 @@ packaging==21.3 \
     --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb \
     --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522
     # via
+    #   bleach
     #   mkdocs
     #   pytest
     #   typepy
-paramiko==2.10.2 \
-    --hash=sha256:abf71533ea9332079db7cbcc039066c3d7575eed2df10766fa03496c3bf78cf1 \
-    --hash=sha256:ff47cc35dd4c4af507d2bdc9d7def9f7fa89977212b4f926e14ac486e930f03a
+paramiko==2.10.3 \
+    --hash=sha256:ac6593479f2b47a9422eca076b22cff9f795495e6733a64723efc75dd8c92101 \
+    --hash=sha256:ddb1977853aef82804b35d72a0e597b244fa326c404c350bd00c5b01dbfee71a
     # via grizzly-loadtester (setup.py)
 parse==1.19.0 \
     --hash=sha256:9ff82852bcb65d139813e2a5197627a94966245c897796760a3a2a8eb66f020b
@@ -887,10 +914,22 @@ pathvalidate==2.5.0 \
     --hash=sha256:119ba36be7e9a405d704c7b7aea4b871c757c53c9adc0ed64f40be1ed8da2781 \
     --hash=sha256:e5b2747ad557363e8f4124f0553d68878b12ecabd77bcca7e7312d5346d20262
     # via pytablewriter
+pep517==0.12.0 \
+    --hash=sha256:931378d93d11b298cf511dd634cf5ea4cb249a28ef84160b3247ee9afb4e8ab0 \
+    --hash=sha256:dd884c326898e2c6e11f9e0b64940606a93eb10ea022a2e067959f3a110cf161
+    # via pip-tools
 pip-licenses==3.5.3 \
     --hash=sha256:59c148d6a03784bf945d232c0dc0e9de4272a3675acaa0361ad7712398ca86ba \
     --hash=sha256:f44860e00957b791c6c6005a3328f2d5eaeee96ddb8e7d87d4b0aa25b02252e4
     # via grizzly-loadtester (setup.py)
+pip-tools==6.5.1 \
+    --hash=sha256:80f1cfc7156e4a4465b1a46a6bb3599587909537db1a149cf3a6b73eed979ee4 \
+    --hash=sha256:80f562aa699fc76a424539697e0bef41e490a050e57a6a21468531981a9d419e
+    # via grizzly-loadtester (setup.py)
+pkginfo==1.8.2 \
+    --hash=sha256:542e0d0b6750e2e21c20179803e40ab50598d8066d51097a0e382cba9eb02bff \
+    --hash=sha256:c24c487c6a7f72c66e816ab1796b96ac6c3d14d49338293d2141664330b55ffc
+    # via twine
 platformdirs==2.5.1 \
     --hash=sha256:7535e70dfa32e84d4b34996ea99c5e432fa29a708d0f4e394bbcb2a8faa4f16d \
     --hash=sha256:bcae7cab893c2d310a711b70b24efb93334febe65f8de776ee320b517471e227
@@ -1009,7 +1048,9 @@ pyflakes==2.4.0 \
 pygments==2.11.2 \
     --hash=sha256:44238f1b60a76d78fc8ca0528ee429702aae011c265fe6a8dd8b63049ae41c65 \
     --hash=sha256:4e426f72023d88d03b2fa258de560726ce890ff3b630f88c21cbb8b2503b8c6a
-    # via mkdocs-material
+    # via
+    #   mkdocs-material
+    #   readme-renderer
 pyjwt[crypto]==2.3.0 \
     --hash=sha256:b888b4d56f06f6dcd777210c334e69c737be74755d3e5e9ee3fe67dc18a0ee41 \
     --hash=sha256:e0c4bb8d9f0af0c7f5b1ec4c5036309617d03d56932877f2f7a0beeb5318322f
@@ -1018,9 +1059,9 @@ pylint==2.12.2 \
     --hash=sha256:9d945a73640e1fec07ee34b42f5669b770c759acd536ec7b16d7e4b87a9c9ff9 \
     --hash=sha256:daabda3f7ed9d1c60f52d563b1b854632fd90035bcf01443e234d3dc794e3b74
     # via grizzly-loadtester (setup.py)
-pymdown-extensions==9.2 \
-    --hash=sha256:ed8f69a18bc158f00cbf03abc536b88b6e541b7e699156501e767c48f81d8850 \
-    --hash=sha256:f2fa7d9317c672a419868c893c20a28fb7ed7fc60d4ec4774c35e01398ab330c
+pymdown-extensions==9.3 \
+    --hash=sha256:a80553b243d3ed2d6c27723bcd64ca9887e560e6f4808baa96f36e93061eaf90 \
+    --hash=sha256:b37461a181c1c8103cfe1660081726a0361a8294cbfda88e5b02cefe976f0546
     # via mkdocs-material
 pynacl==1.5.0 \
     --hash=sha256:06b8f6fa7f5de8d5d2f7573fe8c863c051225a27b61e6860fd047b1775807858 \
@@ -1038,13 +1079,13 @@ pyparsing==3.0.7 \
     --hash=sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea \
     --hash=sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484
     # via packaging
-pytablewriter==0.64.1 \
-    --hash=sha256:2954d0dd2ac2dd74eaf4a41301017cb7cbc56962d7751a5d78ae4a4127417eb8 \
-    --hash=sha256:aee3ce93ac910d105e27e83b20d8dcb3d66702ddd9a2a5a65acbfe502d3d7072
+pytablewriter==0.64.2 \
+    --hash=sha256:99409d401d6ef5f06d1bc40f265a8e3053afe4cbfbaf709f71124076afb40dbb \
+    --hash=sha256:c46d1ddc40ef4d084213a86f8626cee33b3aa0119535aa8555da64cb5b65e382
     # via grizzly-loadtester (setup.py)
-pytest==7.1.0 \
-    --hash=sha256:b555252a95bbb2a37a97b5ac2eb050c436f7989993565f5e0c9128fcaacadd0e \
-    --hash=sha256:f1089d218cfcc63a212c42896f1b7fbf096874d045e1988186861a1a87d27b47
+pytest==7.1.1 \
+    --hash=sha256:841132caef6b1ad17a9afde46dc4f6cfa59a05f9555aae5151f73bdf2820ca63 \
+    --hash=sha256:92f723789a8fdd7180b6b06483874feca4c48a5c76968e03bb3e7f806a1869ea
     # via
     #   grizzly-loadtester (setup.py)
     #   pytest-cov
@@ -1070,9 +1111,9 @@ python-dateutil==2.8.2 \
     #   grizzly-loadtester (setup.py)
     #   influxdb
     #   typepy
-pytz==2021.3 \
-    --hash=sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c \
-    --hash=sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326
+pytz==2022.1 \
+    --hash=sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7 \
+    --hash=sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c
     # via
     #   grizzly-loadtester (setup.py)
     #   influxdb
@@ -1171,6 +1212,10 @@ pyzmq==22.3.0 \
     # via
     #   grizzly-loadtester (setup.py)
     #   locust
+readme-renderer==34.0 \
+    --hash=sha256:262510fe6aae81ed4e94d8b169077f325614c0b1a45916a80442c6576264a9c2 \
+    --hash=sha256:dfb4d17f21706d145f7473e0b61ca245ba58e810cf9b2209a48239677f82e5b0
+    # via twine
 requests==2.27.1 \
     --hash=sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61 \
     --hash=sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d
@@ -1184,10 +1229,20 @@ requests==2.27.1 \
     #   opencensus-ext-azure
     #   pydoc-markdown
     #   requests-oauthlib
+    #   requests-toolbelt
+    #   twine
 requests-oauthlib==1.3.1 \
     --hash=sha256:2577c501a2fb8d05a304c09d090d6e47c306fef15809d102b327cf8364bddab5 \
     --hash=sha256:75beac4a47881eeb94d5ea5d6ad31ef88856affe2332b9aafb52c6452ccf0d7a
     # via msrest
+requests-toolbelt==0.9.1 \
+    --hash=sha256:380606e1d10dc85c3bd47bf5a6095f815ec007be7a8b69c878507068df059e6f \
+    --hash=sha256:968089d4584ad4ad7c171454f0a5c6dac23971e9472521ea3b6d49d610aa6fc0
+    # via twine
+rfc3986==2.0.0 \
+    --hash=sha256:50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd \
+    --hash=sha256:97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c
+    # via twine
 roundrobin==0.0.2 \
     --hash=sha256:ac30cb78570a36bb0ce0db7b907af9394ec7a5610ece2ede072280e8dd867caa
     # via locust
@@ -1195,6 +1250,10 @@ rsa==4.8 \
     --hash=sha256:5c6bd9dc7a543b7fe4304a631f8a8a3b674e2bbfc49c2ae96200cdbe55df6b17 \
     --hash=sha256:95c5d300c4e879ee69708c428ba566c59478fd653cc3a22243eeb8ed846950bb
     # via google-auth
+secretstorage==3.3.1 \
+    --hash=sha256:422d82c36172d88d6a0ed5afdec956514b189ddbfb72fefab0c8a1cee4eaf71f \
+    --hash=sha256:fd666c51a6bf200643495a04abb261f83229dcb6fd8472ec393df7ffc8b6f195
+    # via keyring
 setproctitle==1.2.2 \
     --hash=sha256:077943272d0490b3f43d17379432d5e49c263f608fdf4cf624b419db762ca72b \
     --hash=sha256:0d160d46c8f3567e0aa27b26b1f36e03122e3de475aacacc14a92b8fe45b648a \
@@ -1228,6 +1287,7 @@ six==1.16.0 \
     #   azure-servicebus
     #   bcrypt
     #   behave
+    #   bleach
     #   flask-cors
     #   geventhttpclient
     #   google-auth
@@ -1256,12 +1316,21 @@ tomli==2.0.1 \
     # via
     #   coverage
     #   mypy
+    #   pep517
     #   pydoc-markdown
     #   pytest
 tomli-w==1.0.0 \
     --hash=sha256:9f2a07e8be30a0729e533ec968016807069991ae2fd921a78d42f429ae5f4463 \
     --hash=sha256:f463434305e0336248cac9c2dc8076b707d8a12d019dd349f5c1e382dd1ae1b9
     # via pydoc-markdown
+tqdm==4.63.0 \
+    --hash=sha256:1d9835ede8e394bb8c9dcbffbca02d717217113adc679236873eeaac5bc0b3cd \
+    --hash=sha256:e643e071046f17139dea55b880dc9b33822ce21613b4a4f5ea57f202833dbc29
+    # via twine
+twine==3.8.0 \
+    --hash=sha256:8efa52658e0ae770686a13b675569328f1fba9837e5de1867bfe5f46a9aefe19 \
+    --hash=sha256:d0550fca9dc19f3d5e8eadfce0c227294df0a2a951251a4385797c8a6198b7c8
+    # via grizzly-loadtester (setup.py)
 typepy[datetime]==1.3.0 \
     --hash=sha256:96788530614083164993d1443959f6c58e6bb8e2da839812ddf462c203e4b84c \
     --hash=sha256:cf1913982969cf6348152c4a5feec08e324addd99670999e57cdb3ad87a61e9a
@@ -1289,9 +1358,9 @@ types-python-dateutil==2.8.10 \
     --hash=sha256:1f6d2305513d54da353a9dde7ed8a9ef46e8987377291612a0e2b9aac2d2b875 \
     --hash=sha256:6bcf3aae7242e5793bafd7b2bcfb4e255eb7b2b3144acd0df0e182dce58ccad3
     # via grizzly-loadtester (setup.py)
-types-pytz==2021.3.5 \
-    --hash=sha256:8831f689379ac9e2a62668157381379ed74b3702980e08e71f8673c179c4e3c7 \
-    --hash=sha256:fef8de238ee95135952229a2a23bfb87bd63d5a6c8598106a46cfcf48f069ea8
+types-pytz==2021.3.6 \
+    --hash=sha256:6805c72d51118923c5bf98633c39593d5b464d2ab49a803440e2d7ab6b8920df \
+    --hash=sha256:74547fd90d8d8ab4f1eedf3a344a7d186d97486973895f81221a712e1e2cd993
     # via
     #   grizzly-loadtester (setup.py)
     #   types-tzlocal
@@ -1299,9 +1368,9 @@ types-pyyaml==5.4.12 \
     --hash=sha256:3f4daa754357491625ae8c3a39c9e1b0d7cd5632bc4e1c35e7a7f75a64aa124b \
     --hash=sha256:e06083f85375a5678e4c19452ed6467ce2167b71db222313e1792cb8fc76859a
     # via grizzly-loadtester (setup.py)
-types-requests==2.27.13 \
-    --hash=sha256:5d6f77f3c7565659bdb7b7bce1d33d1abb7d0b056138cac714860e13da2f19df \
-    --hash=sha256:cf0646031dd6307113b37814f743c04f0707a3357378c2bb1326f848412f5ba9
+types-requests==2.27.14 \
+    --hash=sha256:04579ee164f7c2659be46950e3c2f8d51a081ad252ef1b01d4b12faba5c3810b \
+    --hash=sha256:c01838abfe3e8a83ba68346cd373afff97594c19c15c922ddee4a0e80ba7e329
     # via grizzly-loadtester (setup.py)
 types-tzlocal==4.1.0 \
     --hash=sha256:baeff03c7fc3fefb05e6e635aaffebd5b1a171200c74dd77d2918ee0e79ddedd \
@@ -1325,9 +1394,9 @@ typing-extensions==3.10.0.2 \
     #   mypy
     #   nr-util
     #   pylint
-tzdata==2021.5 \
-    --hash=sha256:3eee491e22ebfe1e5cfcc97a4137cd70f092ce59144d81f8924a844de05ba8f5 \
-    --hash=sha256:68dbe41afd01b867894bbdfd54fa03f468cfa4f0086bfb4adcd8de8f24f3ee21
+tzdata==2022.1 \
+    --hash=sha256:238e70234214138ed7b4e8a0fab0e5e13872edab3be586ab8198c407620e2ab9 \
+    --hash=sha256:8b536a8ec63dc0751342b3984193a3118f8fca2afe25752bb9b7fffd398552d3
     # via pytz-deprecation-shim
 tzlocal==4.1 \
     --hash=sha256:0f28015ac68a5c067210400a9197fc5d36ba9bc3f8eaf1da3cbd59acdfed9e09 \
@@ -1363,7 +1432,9 @@ uamqp==1.5.2 \
 urllib3==1.26.9 \
     --hash=sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14 \
     --hash=sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e
-    # via requests
+    # via
+    #   requests
+    #   twine
 watchdog==2.1.6 \
     --hash=sha256:25fb5240b195d17de949588628fdf93032ebf163524ef08933db0ea1f99bd685 \
     --hash=sha256:3386b367e950a11b0568062b70cc026c6f645428a698d33d39e013aaeda4cc04 \
@@ -1391,6 +1462,10 @@ watchdog==2.1.6 \
     # via
     #   mkdocs
     #   pydoc-markdown
+webencodings==0.5.1 \
+    --hash=sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78 \
+    --hash=sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923
+    # via bleach
 werkzeug==2.0.3 \
     --hash=sha256:1421ebfc7648a39a5c58c601b154165d05cf47a3cd0ccb70857cbdacf6c8f2b8 \
     --hash=sha256:b863f8ff057c522164b6067c9e28b041161b4be5ba4d0daceeaa50a163822d3c
@@ -1400,7 +1475,10 @@ werkzeug==2.0.3 \
 wheel==0.37.1 \
     --hash=sha256:4bdcd7d840138086126cd09254dc6195fb4fc6f01c050a1d7236f2630db1d22a \
     --hash=sha256:e9a504e793efbca1b8e0e9cb979a249cf4a0a7b5b8c9e8b65a5e39d49529c1c4
-    # via astunparse
+    # via
+    #   astunparse
+    #   grizzly-loadtester (setup.py)
+    #   pip-tools
 wrapt==1.13.3 \
     --hash=sha256:086218a72ec7d986a3eddb7707c8c4526d677c7b35e355875a0fe2918b059179 \
     --hash=sha256:0877fe981fd76b183711d767500e6b3111378ed2043c145e21816ee589d91096 \
@@ -1523,12 +1601,17 @@ zope-interface==5.4.0 \
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
+pip==22.0.4 \
+    --hash=sha256:b3a9de2c6ef801e9247d1527a4b16f92f2cc141cd1489f3fffaf6a9e96729764 \
+    --hash=sha256:c6aca0f2f081363f689f041d90dab2a07a9a07fb840284db2218117a52da800b
+    # via pip-tools
 setuptools==60.10.0 \
     --hash=sha256:6599055eeb23bfef457d5605d33a4d68804266e6cb430b0fb12417c5efeae36c \
     --hash=sha256:782ef48d58982ddb49920c11a0c5c9c0b02e7d7d1c2ad0aa44e1a1e133051c96
     # via
     #   astroid
     #   gevent
+    #   pip-tools
     #   pytablewriter
     #   zope-event
     #   zope-interface

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -320,9 +320,9 @@ databind-json==1.5.1 \
     # via
     #   databind
     #   docspec
-dataproperty==0.54.2 \
-    --hash=sha256:05496c90ed6cc172930bbab825c6f9515cb5bdc51d8c46eb25306d530654c976 \
-    --hash=sha256:df2fcf00e7a57f0a6089f686f847527eb3c91ded5c419daef6d06ee4bb1187b4
+dataproperty==0.55.0 \
+    --hash=sha256:73ccf10f8b123968210438a1a1aa859ea6d5a16b4e1f4d307da7a81b838e79fa \
+    --hash=sha256:a8f29175950f4b2c33a387aa3809130d87b9a8d3b92a916c906c49efdb566b32
     # via
     #   pytablewriter
     #   tabledata
@@ -457,13 +457,13 @@ google-api-core==2.7.1 \
     --hash=sha256:6be1fc59e2a7ba9f66808bbc22f976f81e4c3e7ab20fa0620ce42686288787d0 \
     --hash=sha256:b0fa577e512f0c8e063386b974718b8614586a798c5894ed34bedf256d9dae24
     # via opencensus
-google-auth==2.6.0 \
-    --hash=sha256:218ca03d7744ca0c8b6697b6083334be7df49b7bf76a69d555962fd1a7657b5f \
-    --hash=sha256:ad160fc1ea8f19e331a16a14a79f3d643d813a69534ba9611d2c80dc10439dad
+google-auth==2.6.2 \
+    --hash=sha256:3ba4d63cb29c1e6d5ffcc1c0623c03cf02ede6240a072f213084749574e691ab \
+    --hash=sha256:60d449f8142c742db760f4c0be39121bc8d9be855555d784c252deaca1ced3f5
     # via google-api-core
-googleapis-common-protos==1.55.0 \
-    --hash=sha256:183bb0356bd614c4330ad5158bc1c1bcf9bcf7f5e7f911317559fe209496eeee \
-    --hash=sha256:53eb313064738f45d5ac634155ae208e121c963659627b90dfcb61ef514c03e1
+googleapis-common-protos==1.56.0 \
+    --hash=sha256:4007500795bcfc269d279f0f7d253ae18d6dc1ff5d5a73613ffe452038b1ec5f \
+    --hash=sha256:60220c89b8bd5272159bed4929ecdc1243ae1f73437883a499a44a1cbc084086
     # via google-api-core
 greenlet==1.1.2 \
     --hash=sha256:0051c6f1f27cb756ffc0ffbac7d2cd48cb0362ac1736871399a739b2885134d3 \
@@ -839,9 +839,9 @@ mypy-extensions==0.4.3 \
     # via
     #   grizzly-loadtester (setup.py)
     #   mypy
-nr-util==0.8.6 \
-    --hash=sha256:2d3a1db0a0e724ec8bc11d3ab6e68e57be04bbb3f05f8b61d77b7e66487cf433 \
-    --hash=sha256:815b2716499ba6c575a686f3f123345988cc9731f4177f0a94497f5069f762f4
+nr-util==0.8.7 \
+    --hash=sha256:882123edc0b3275d2c6132e96bf8ef554b3c204ae4b37736f5f78da8d80b0592 \
+    --hash=sha256:d27e07755d7bc4c3adc042c9e792cdd1b03b9b85cde55a95068ebd4c37729f9b
     # via
     #   databind-core
     #   databind-json
@@ -870,9 +870,9 @@ packaging==21.3 \
     #   mkdocs
     #   pytest
     #   typepy
-paramiko==2.10.2 \
-    --hash=sha256:abf71533ea9332079db7cbcc039066c3d7575eed2df10766fa03496c3bf78cf1 \
-    --hash=sha256:ff47cc35dd4c4af507d2bdc9d7def9f7fa89977212b4f926e14ac486e930f03a
+paramiko==2.10.3 \
+    --hash=sha256:ac6593479f2b47a9422eca076b22cff9f795495e6733a64723efc75dd8c92101 \
+    --hash=sha256:ddb1977853aef82804b35d72a0e597b244fa326c404c350bd00c5b01dbfee71a
     # via grizzly-loadtester (setup.py)
 parse==1.19.0 \
     --hash=sha256:9ff82852bcb65d139813e2a5197627a94966245c897796760a3a2a8eb66f020b
@@ -1018,9 +1018,9 @@ pylint==2.12.2 \
     --hash=sha256:9d945a73640e1fec07ee34b42f5669b770c759acd536ec7b16d7e4b87a9c9ff9 \
     --hash=sha256:daabda3f7ed9d1c60f52d563b1b854632fd90035bcf01443e234d3dc794e3b74
     # via grizzly-loadtester (setup.py)
-pymdown-extensions==9.2 \
-    --hash=sha256:ed8f69a18bc158f00cbf03abc536b88b6e541b7e699156501e767c48f81d8850 \
-    --hash=sha256:f2fa7d9317c672a419868c893c20a28fb7ed7fc60d4ec4774c35e01398ab330c
+pymdown-extensions==9.3 \
+    --hash=sha256:a80553b243d3ed2d6c27723bcd64ca9887e560e6f4808baa96f36e93061eaf90 \
+    --hash=sha256:b37461a181c1c8103cfe1660081726a0361a8294cbfda88e5b02cefe976f0546
     # via mkdocs-material
 pymqi==1.12.0 \
     --hash=sha256:ca18659242f34ff3484b454fd872036a87b285c214e0907353c815e12e46cb75
@@ -1041,13 +1041,13 @@ pyparsing==3.0.7 \
     --hash=sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea \
     --hash=sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484
     # via packaging
-pytablewriter==0.64.1 \
-    --hash=sha256:2954d0dd2ac2dd74eaf4a41301017cb7cbc56962d7751a5d78ae4a4127417eb8 \
-    --hash=sha256:aee3ce93ac910d105e27e83b20d8dcb3d66702ddd9a2a5a65acbfe502d3d7072
+pytablewriter==0.64.2 \
+    --hash=sha256:99409d401d6ef5f06d1bc40f265a8e3053afe4cbfbaf709f71124076afb40dbb \
+    --hash=sha256:c46d1ddc40ef4d084213a86f8626cee33b3aa0119535aa8555da64cb5b65e382
     # via grizzly-loadtester (setup.py)
-pytest==7.1.0 \
-    --hash=sha256:b555252a95bbb2a37a97b5ac2eb050c436f7989993565f5e0c9128fcaacadd0e \
-    --hash=sha256:f1089d218cfcc63a212c42896f1b7fbf096874d045e1988186861a1a87d27b47
+pytest==7.1.1 \
+    --hash=sha256:841132caef6b1ad17a9afde46dc4f6cfa59a05f9555aae5151f73bdf2820ca63 \
+    --hash=sha256:92f723789a8fdd7180b6b06483874feca4c48a5c76968e03bb3e7f806a1869ea
     # via
     #   grizzly-loadtester (setup.py)
     #   pytest-cov
@@ -1073,9 +1073,9 @@ python-dateutil==2.8.2 \
     #   grizzly-loadtester (setup.py)
     #   influxdb
     #   typepy
-pytz==2021.3 \
-    --hash=sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c \
-    --hash=sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326
+pytz==2022.1 \
+    --hash=sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7 \
+    --hash=sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c
     # via
     #   grizzly-loadtester (setup.py)
     #   influxdb
@@ -1292,9 +1292,9 @@ types-python-dateutil==2.8.10 \
     --hash=sha256:1f6d2305513d54da353a9dde7ed8a9ef46e8987377291612a0e2b9aac2d2b875 \
     --hash=sha256:6bcf3aae7242e5793bafd7b2bcfb4e255eb7b2b3144acd0df0e182dce58ccad3
     # via grizzly-loadtester (setup.py)
-types-pytz==2021.3.5 \
-    --hash=sha256:8831f689379ac9e2a62668157381379ed74b3702980e08e71f8673c179c4e3c7 \
-    --hash=sha256:fef8de238ee95135952229a2a23bfb87bd63d5a6c8598106a46cfcf48f069ea8
+types-pytz==2021.3.6 \
+    --hash=sha256:6805c72d51118923c5bf98633c39593d5b464d2ab49a803440e2d7ab6b8920df \
+    --hash=sha256:74547fd90d8d8ab4f1eedf3a344a7d186d97486973895f81221a712e1e2cd993
     # via
     #   grizzly-loadtester (setup.py)
     #   types-tzlocal
@@ -1302,9 +1302,9 @@ types-pyyaml==5.4.12 \
     --hash=sha256:3f4daa754357491625ae8c3a39c9e1b0d7cd5632bc4e1c35e7a7f75a64aa124b \
     --hash=sha256:e06083f85375a5678e4c19452ed6467ce2167b71db222313e1792cb8fc76859a
     # via grizzly-loadtester (setup.py)
-types-requests==2.27.13 \
-    --hash=sha256:5d6f77f3c7565659bdb7b7bce1d33d1abb7d0b056138cac714860e13da2f19df \
-    --hash=sha256:cf0646031dd6307113b37814f743c04f0707a3357378c2bb1326f848412f5ba9
+types-requests==2.27.14 \
+    --hash=sha256:04579ee164f7c2659be46950e3c2f8d51a081ad252ef1b01d4b12faba5c3810b \
+    --hash=sha256:c01838abfe3e8a83ba68346cd373afff97594c19c15c922ddee4a0e80ba7e329
     # via grizzly-loadtester (setup.py)
 types-tzlocal==4.1.0 \
     --hash=sha256:baeff03c7fc3fefb05e6e635aaffebd5b1a171200c74dd77d2918ee0e79ddedd \
@@ -1328,9 +1328,9 @@ typing-extensions==3.10.0.2 \
     #   mypy
     #   nr-util
     #   pylint
-tzdata==2021.5 \
-    --hash=sha256:3eee491e22ebfe1e5cfcc97a4137cd70f092ce59144d81f8924a844de05ba8f5 \
-    --hash=sha256:68dbe41afd01b867894bbdfd54fa03f468cfa4f0086bfb4adcd8de8f24f3ee21
+tzdata==2022.1 \
+    --hash=sha256:238e70234214138ed7b4e8a0fab0e5e13872edab3be586ab8198c407620e2ab9 \
+    --hash=sha256:8b536a8ec63dc0751342b3984193a3118f8fca2afe25752bb9b7fffd398552d3
     # via pytz-deprecation-shim
 tzlocal==4.1 \
     --hash=sha256:0f28015ac68a5c067210400a9197fc5d36ba9bc3f8eaf1da3cbd59acdfed9e09 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -344,13 +344,13 @@ google-api-core==2.7.1 \
     --hash=sha256:6be1fc59e2a7ba9f66808bbc22f976f81e4c3e7ab20fa0620ce42686288787d0 \
     --hash=sha256:b0fa577e512f0c8e063386b974718b8614586a798c5894ed34bedf256d9dae24
     # via opencensus
-google-auth==2.6.0 \
-    --hash=sha256:218ca03d7744ca0c8b6697b6083334be7df49b7bf76a69d555962fd1a7657b5f \
-    --hash=sha256:ad160fc1ea8f19e331a16a14a79f3d643d813a69534ba9611d2c80dc10439dad
+google-auth==2.6.2 \
+    --hash=sha256:3ba4d63cb29c1e6d5ffcc1c0623c03cf02ede6240a072f213084749574e691ab \
+    --hash=sha256:60d449f8142c742db760f4c0be39121bc8d9be855555d784c252deaca1ced3f5
     # via google-api-core
-googleapis-common-protos==1.55.0 \
-    --hash=sha256:183bb0356bd614c4330ad5158bc1c1bcf9bcf7f5e7f911317559fe209496eeee \
-    --hash=sha256:53eb313064738f45d5ac634155ae208e121c963659627b90dfcb61ef514c03e1
+googleapis-common-protos==1.56.0 \
+    --hash=sha256:4007500795bcfc269d279f0f7d253ae18d6dc1ff5d5a73613ffe452038b1ec5f \
+    --hash=sha256:60220c89b8bd5272159bed4929ecdc1243ae1f73437883a499a44a1cbc084086
     # via google-api-core
 greenlet==1.1.2 \
     --hash=sha256:0051c6f1f27cb756ffc0ffbac7d2cd48cb0362ac1736871399a739b2885134d3 \
@@ -621,9 +621,9 @@ opencensus-ext-azure==1.1.3 \
     --hash=sha256:70ad2601ef24e655d1fd5e6e53f57599f919ca2b943c5371c8a794da379a5fe8 \
     --hash=sha256:fba89a747dfee7ddc1a23875ba0b7e77f5ae73540336079901ffcd7d6141d5dc
     # via grizzly-loadtester (setup.py)
-paramiko==2.10.2 \
-    --hash=sha256:abf71533ea9332079db7cbcc039066c3d7575eed2df10766fa03496c3bf78cf1 \
-    --hash=sha256:ff47cc35dd4c4af507d2bdc9d7def9f7fa89977212b4f926e14ac486e930f03a
+paramiko==2.10.3 \
+    --hash=sha256:ac6593479f2b47a9422eca076b22cff9f795495e6733a64723efc75dd8c92101 \
+    --hash=sha256:ddb1977853aef82804b35d72a0e597b244fa326c404c350bd00c5b01dbfee71a
     # via grizzly-loadtester (setup.py)
 parse==1.19.0 \
     --hash=sha256:9ff82852bcb65d139813e2a5197627a94966245c897796760a3a2a8eb66f020b
@@ -744,9 +744,9 @@ python-dateutil==2.8.2 \
     # via
     #   grizzly-loadtester (setup.py)
     #   influxdb
-pytz==2021.3 \
-    --hash=sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c \
-    --hash=sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326
+pytz==2022.1 \
+    --hash=sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7 \
+    --hash=sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c
     # via
     #   grizzly-loadtester (setup.py)
     #   influxdb
@@ -908,9 +908,9 @@ typing-extensions==4.1.1 \
     #   azure-servicebus
     #   grizzly-loadtester (setup.py)
     #   locust
-tzdata==2021.5 \
-    --hash=sha256:3eee491e22ebfe1e5cfcc97a4137cd70f092ce59144d81f8924a844de05ba8f5 \
-    --hash=sha256:68dbe41afd01b867894bbdfd54fa03f468cfa4f0086bfb4adcd8de8f24f3ee21
+tzdata==2022.1 \
+    --hash=sha256:238e70234214138ed7b4e8a0fab0e5e13872edab3be586ab8198c407620e2ab9 \
+    --hash=sha256:8b536a8ec63dc0751342b3984193a3118f8fca2afe25752bb9b7fffd398552d3
     # via pytz-deprecation-shim
 tzlocal==4.1 \
     --hash=sha256:0f28015ac68a5c067210400a9197fc5d36ba9bc3f8eaf1da3cbd59acdfed9e09 \

--- a/script/pip-compile.py
+++ b/script/pip-compile.py
@@ -185,7 +185,7 @@ def compile() -> int:
 
     targets: Dict[str, Tuple[str, ...]] = {
         'requirements.txt': (),
-        'requirements-ci.txt': ('dev',),
+        'requirements-ci.txt': ('dev', 'ci',),
         'requirements-dev.txt': ('dev', 'mq',),
     }
 

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,11 @@ setup(
             'types-tzlocal>=4.0.0',
             'types-Jinja2>=2.0.0',
         ],
+        'ci': [
+            'twine>=3.8.0',
+            'wheel>=0.37.1',
+            'pip-tools>=6.5.0',
+        ]
     },
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
when installed separately from ci dependencies in requirements-ci.txt

added ci extras_require section with dependencies that the ci workflow
depends on.

pip-tools still has to be installed first, since pip-sync.bash script depends on it.