### PR TITLE
scenario statistics

### DIFF
--- a/example/features/example.feature
+++ b/example/features/example.feature
@@ -24,10 +24,10 @@ Feature: grizzly example
     And value for variable "author_endpoint" is "none"
 
     Then get request with name "1-get-book" from endpoint "/books/{{ AtomicCsvRow.books.book }}.json | content_type=json"
-    When response payload "$.number_of_pages" is not "{{ AtomicCsvRow.books.pages }}" fail scenario
-    When response payload "$.isbn_10[0]" is not "{{ AtomicCsvRow.books.isbn_10 }}" fail scenario
+    When response payload "$.number_of_pages" is not "{{ AtomicCsvRow.books.pages }}" fail request
+    When response payload "$.isbn_10[0]" is not "{{ AtomicCsvRow.books.isbn_10 }}" fail request
     Then save response payload "$.authors[0].key" in variable "author_endpoint"
 
     Then get request with name "2-get-author" from endpoint "{{ author_endpoint }}.json | content_type=json"
-    When response payload "$.name" is not "{{ AtomicCsvRow.books.author }}" fail scenario
+    When response payload "$.name" is not "{{ AtomicCsvRow.books.author }}" fail request
 

--- a/grizzly/context.py
+++ b/grizzly/context.py
@@ -150,6 +150,10 @@ class GrizzlyContextScenario:
         self._name = value
 
     @property
+    def locust_name(self) -> str:
+        return f'{self.identifier} {self.description}'
+
+    @property
     def class_name(self) -> str:
         if not self.name.endswith(f'_{self.identifier}'):
             return f'{self.name}_{self.identifier}'

--- a/grizzly/environment.py
+++ b/grizzly/environment.py
@@ -45,6 +45,8 @@ def after_feature(context: Context, feature: Feature, *args: Tuple[Any, ...], **
         if return_code != 0:
             feature.set_status('failed')
 
+        # @TODO: check statistics for failed scenarios, and steps, and set them as failed in behave
+
     # the features duration is the sum of all scenarios duration, which is the sum of all steps duration
     try:
         duration = int(time() - context.start)
@@ -82,7 +84,7 @@ def before_scenario(context: Context, scenario: Scenario, *args: Tuple[Any, ...]
             # to get a nicer error message, the step should fail before it's executed, see before_step hook
             setattr(step, 'location_status', 'incorrect')
 
-    grizzly.add_scenario(scenario)
+    grizzly.scenarios.create(scenario)
 
 
 def after_scenario(context: Context, *args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> None:

--- a/grizzly/exceptions.py
+++ b/grizzly/exceptions.py
@@ -19,3 +19,7 @@ class TransformerLocustError(StopUser):
 
 class RestartScenario(Exception):
     pass
+
+
+class StopScenario(Exception):
+    pass

--- a/grizzly/locust.py
+++ b/grizzly/locust.py
@@ -12,6 +12,7 @@ from math import ceil
 import gevent
 
 from behave.runner import Context
+from behave.model import Status
 from locust.runners import MasterRunner, WorkerRunner, Runner
 from locust.env import Environment
 from locust.stats import (
@@ -28,7 +29,7 @@ from jinja2.exceptions import TemplateError
 
 from .listeners import init, init_statistics_listener, quitting, validate_result, spawning_complete, locust_test_start, locust_test_stop
 from .testdata.utils import initialize_testdata
-from .types import TestdataType
+from .types import RequestType, TestdataType
 from .context import GrizzlyContext
 from .tasks import GrizzlyTask
 from .users.base import GrizzlyUser
@@ -222,56 +223,58 @@ def setup_environment_listeners(context: Context, environment: Environment, task
 
 
 def print_scenario_summary(grizzly: GrizzlyContext) -> None:
-    def print_table_lines(max_length_iterations: int, max_length_description: int) -> None:
-        sys.stdout.write('-' * 5)
-        sys.stdout.write('-|-')
-        sys.stdout.write('-' * max_length_iterations)
-        sys.stdout.write('|-')
-        sys.stdout.write('-' * 6)
-        sys.stdout.write('-|-')
-        sys.stdout.write('-' * max_length_description)
-        sys.stdout.write('-|\n')
+    def create_separator(max_length_iterations: int, max_length_status: int, max_length_description: int) -> str:
+        separator: List[str] = []
+        separator.append('-' * 5)
+        separator.append('-|-')
+        separator.append('-' * max_length_iterations)
+        separator.append('|-')
+        separator.append('-' * max_length_status)
+        separator.append('-|-')
+        separator.append('-' * max_length_description)
+        separator.append('-|')
+
+        return ''.join(separator)
 
     rows: List[str] = []
     max_length_description = len('description')
-    max_length_iterations = len('#')
+    max_length_iterations = len('iter')
+    max_length_status = len('status')
 
     for scenario in grizzly.scenarios():
-        stat = grizzly.state.environment.stats.get(f'{scenario.identifier} {scenario.description}', 'SCEN')
-        description_length = len(scenario.description or 'unknown')
-        if description_length > max_length_description:
-            max_length_description = description_length
-
-        iterations_length = len(f'{stat.num_requests}/{scenario.iterations or 0}')
-        if iterations_length > max_length_iterations:
-            max_length_iterations = iterations_length
+        stat = grizzly.state.environment.stats.get(scenario.locust_name, RequestType.SCENARIO())
+        max_length_description = max(len(scenario.description or 'unknown'), max_length_description)
+        max_length_iterations = max(len(f'{stat.num_requests}/{scenario.iterations or 0}'), max_length_iterations)
+        max_length_status = max(len(Status.undefined.name) if stat.num_requests < 1 else len(Status.passed.name), max_length_status)
 
     for scenario in grizzly.scenarios():
-        stat = grizzly.state.environment.stats.get(f'{scenario.identifier} {scenario.description}', 'SCEN')
+        stat = grizzly.state.environment.stats.get(scenario.locust_name, RequestType.SCENARIO())
         if stat.num_requests > 0:
             if stat.num_failures == 0 and stat.num_requests == scenario.iterations:
-                status = 'passed'
+                status = Status.passed
             else:
-                status = 'failed'
+                status = Status.failed
         else:
-            status = 'inconc'
+            status = Status.undefined
 
         description = scenario.description or 'unknown'
-        row = '{:5}   {:>{}}  {:6}   {}'.format(
+        row = '{:5}   {:>{}}  {:{}}   {}'.format(
             scenario.identifier,
             f'{stat.num_requests}/{scenario.iterations}',
             max_length_iterations,
-            status,
+            status.name,
+            max_length_status,
             description,
         )
         rows.append(row)
 
     print('Scenario')
-    print('{:5}   {:>{}}  {:6}   {}'.format('ident', '#', max_length_iterations, 'status', 'description'))
-    print_table_lines(max_length_iterations, max_length_description)
+    print('{:5}   {:>{}}  {:{}}   {}'.format('ident', 'iter', max_length_iterations, 'status', max_length_status, 'description'))
+    separator = create_separator(max_length_iterations, max_length_status, max_length_description)
+    print(separator)
     for row in rows:
         print(row)
-    print_table_lines(max_length_iterations, max_length_description)
+    print(separator)
 
 
 def run(context: Context) -> int:

--- a/grizzly/scenarios/iterator.py
+++ b/grizzly/scenarios/iterator.py
@@ -1,14 +1,17 @@
 import traceback
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
+from time import perf_counter
+from json import dumps as jsondumps
 
 from locust import task
 from locust.user.task import LOCUST_STATE_STOPPING, LOCUST_STATE_RUNNING
 from locust.exception import StopUser, InterruptTaskSet, RescheduleTaskImmediately, RescheduleTask
+from locust.stats import StatsEntry
 from gevent.exceptions import GreenletExit
 
 from ..types import ScenarioState
-from ..exceptions import RestartScenario
+from ..exceptions import RestartScenario, StopScenario
 from . import GrizzlyScenario
 
 if TYPE_CHECKING:
@@ -18,8 +21,19 @@ if TYPE_CHECKING:
 class IteratorScenario(GrizzlyScenario):
     user: 'GrizzlyUser'
 
+    start: Optional[float]
+    name: str
+    task_count: int
+    request_type: str = 'SCEN'
+    stats: StatsEntry
+
     def __init__(self, parent: 'GrizzlyUser') -> None:
         super().__init__(parent=parent)
+
+        self.start = None
+        self.name = f'{self.user._scenario.identifier} {self.user._scenario.description}'
+        self.task_count = len(self.tasks)
+        self.stats = self.user.environment.stats.get(self.name, self.request_type)
 
     def run(self) -> None:  # type: ignore
         try:
@@ -36,24 +50,25 @@ class IteratorScenario(GrizzlyScenario):
                 if not self._task_queue:
                     self.schedule_task(self.get_next_task())
 
-                task_count = len(self.tasks)
-                current_task_index = (self._task_index % task_count)
+                current_task_index = (self._task_index % self.task_count)
 
                 try:
                     if self.user._state == LOCUST_STATE_STOPPING:
                         raise StopUser()
                     if self.user.scenario_state != ScenarioState.STOPPING:
-                        self.logger.debug(f'executing task {current_task_index+1} of {task_count}')
+                        self.logger.debug(f'executing task {current_task_index+1} of {self.task_count}')
                     self.execute_next_task()
                 except RescheduleTaskImmediately:
                     pass
                 except RescheduleTask:
                     self.wait()
                 except RestartScenario:
-                    self.logger.info(f'restarting scenario at task {current_task_index+1} of {task_count}')
+                    self.logger.info(f'restarting scenario at task {current_task_index+1} of {self.task_count}')
                     # move locust.user.sequential_task.SequentialTaskSet index pointer the number of tasks left until end, so it will start over
-                    tasks_left = task_count - current_task_index
+                    tasks_left = self.task_count - current_task_index
                     self._task_index += tasks_left
+
+                    self.stats.log_error(None)
                     self.wait()
                 else:
                     self.wait()
@@ -66,10 +81,24 @@ class IteratorScenario(GrizzlyScenario):
                         raise RescheduleTask(e.reschedule) from e
                 else:
                     self.wait()
-            except (StopUser, GreenletExit):
+            except (StopScenario, StopUser, GreenletExit) as e:
                 if self.user._scenario_state != ScenarioState.STOPPING:
+                    # unexpected exit of scenario, log as error
+                    if not isinstance(e, StopScenario):
+                        if self.start is not None:
+                            response_time = int((perf_counter() - self.start) * 1000)
+                        else:
+                            response_time = 0
+
+                        response_length = (self._task_index % self.task_count) + 1
+
+                        self.stats.log(response_time, response_length)
+                        self.stats.log_error(None)
+                    else:
+                        e = StopUser()
+
                     self.on_stop()
-                    raise
+                    raise e
                 else:
                     self.wait()
             except Exception as e:
@@ -82,11 +111,10 @@ class IteratorScenario(GrizzlyScenario):
 
     def wait(self) -> None:
         if self.user._scenario_state == ScenarioState.STOPPING:
-            task_count = len(self.tasks)
-            current_task_index = self._task_index % task_count
+            current_task_index = self._task_index % self.task_count
 
-            if current_task_index < task_count - 1:
-                self.logger.debug(f'not finished with scenario, currently at task {current_task_index+1} of {task_count}, let me be!')
+            if current_task_index < self.task_count - 1:
+                self.logger.debug(f'not finished with scenario, currently at task {current_task_index+1} of {self.task_count}, let me be!')
                 self.user._state = LOCUST_STATE_RUNNING
                 self._sleep(self.wait_time())
                 self.user._state = LOCUST_STATE_RUNNING
@@ -100,10 +128,38 @@ class IteratorScenario(GrizzlyScenario):
 
     @task
     def iterator(self) -> None:
+        if self.start is not None:
+            response_time = int((perf_counter() - self.start) * 1000)
+            self.user.environment.events.request.fire(
+                request_type=self.request_type,
+                name=self.name,
+                response_time=response_time,
+                response_length=self.task_count,
+                context=self.user._context,
+                exception=None,
+            )
+
+        # scenario timer
+        self.start = perf_counter()
+
+        # fetching testdata timer
+        start = perf_counter()
+
         remote_context = self.consumer.request(self.__class__.__name__)
 
         if remote_context is None:
             self.logger.debug('no iteration data available, stop scenario')
-            raise StopUser()
+            raise StopScenario()
+
+        response_time = int((perf_counter() - start) * 1000)
+
+        self.user.environment.events.request.fire(
+            request_type='TSTD',
+            name=self.name,
+            response_time=response_time,
+            response_length=len(jsondumps(remote_context)),
+            context=self.user._context,
+            exception=None,
+        )
 
         self.user.add_context(remote_context)

--- a/grizzly/steps/helpers.py
+++ b/grizzly/steps/helpers.py
@@ -98,7 +98,7 @@ def add_request_task(
     grizzly = cast(GrizzlyContext, context.grizzly)
 
     if grizzly.scenario.async_group is None:
-        tasks = grizzly.scenario.tasks
+        tasks = grizzly.scenario.tasks()
     else:
         tasks = cast(List[GrizzlyTask], grizzly.scenario.async_group.requests)
 
@@ -184,7 +184,7 @@ def _add_response_handler(
         raise ValueError(f'variable "{variable}" has not been declared')
 
     if grizzly.scenario.async_group is None:
-        tasks = grizzly.scenario.tasks
+        tasks = grizzly.scenario.tasks()
     else:
         tasks = cast(List[GrizzlyTask], grizzly.scenario.async_group.requests)
 

--- a/grizzly/steps/scenario/response.py
+++ b/grizzly/steps/scenario/response.py
@@ -103,23 +103,24 @@ def step_response_save(context: Context, target: ResponseTarget, expression: str
     add_save_handler(cast(GrizzlyContext, context.grizzly), target, expression, '.*', variable)
 
 
-@when(u'response {target:ResponseTarget} "{expression}" {condition:Condition} "{match_with}" fail scenario')
+@when(u'response {target:ResponseTarget} "{expression}" {condition:Condition} "{match_with}" fail request')
 def step_response_validate(context: Context, target: ResponseTarget, expression: str, condition: bool, match_with: str) -> None:
-    '''Fails the scenario based on the value of a response meta data (header) or payload (body).
+    '''Fails the request based on the value of a response meta data (header) or payload (body).
 
-    How the step will fail is based on step `And ... on failure`. If this step is not present, it will default to
-    stopping the user.
+    How the step will fail is based on step `And ... on failure`. If this step is not present, the default behaviour
+    is to continue the scenario.
+
 
     ```gherkin
     And restart scenario on failure
-    When response metadata "$.['content-type']" is not ".*application/json.*" fail scenario
-    When response metadata "$.['x-test-command']" is "abort" fail scenario
-    When response metadata "$.Authentication" is not "Bearer .*$" fail scenario
+    When response metadata "$.['content-type']" is not ".*application/json.*" fail request
+    When response metadata "$.['x-test-command']" is "abort" fail request
+    When response metadata "$.Authentication" is not "Bearer .*$" fail request
 
     And stop user on failure
-    When response payload "$.measurement.id" is not "cpu[0-9]+" fail scenario
-    When response payload "$.success" is "false" fail scenario
-    When response payload "/root/measurement[@id="cpu"]/success/text()" is "'false'" fail scenario
+    When response payload "$.measurement.id" is not "cpu[0-9]+" fail request
+    When response payload "$.success" is "false" fail request
+    When response payload "/root/measurement[@id="cpu"]/success/text()" is "'false'" fail request
     ```
 
     Args:

--- a/grizzly/steps/scenario/tasks.py
+++ b/grizzly/steps/scenario/tasks.py
@@ -67,7 +67,7 @@ def step_task_request_with_name_to_endpoint_until(context: Context, method: Requ
         for key, value in substitues.items():
             condition_rendered = condition_rendered.replace(f'{{{{ {key} }}}}', value)
 
-        grizzly.scenario.add_task(UntilRequestTask(
+        grizzly.scenario.tasks.add(UntilRequestTask(
             request=request_task,
             condition=condition_rendered,
         ))
@@ -282,7 +282,7 @@ def step_task_wait_seconds(context: Context, wait_time: float) -> None:
 
     assert wait_time > 0.0, 'wait time cannot be less than 0.0 seconds'
 
-    grizzly.scenario.add_task(WaitTask(time=wait_time))
+    grizzly.scenario.tasks.add(WaitTask(time=wait_time))
 
 
 @then(u'print message "{message}"')
@@ -299,7 +299,7 @@ def step_task_print_message(context: Context, message: str) -> None:
     '''
 
     grizzly = cast(GrizzlyContext, context.grizzly)
-    grizzly.scenario.add_task(LogMessage(message=message))
+    grizzly.scenario.tasks.add(LogMessage(message=message))
 
 
 @then(u'parse "{content}" as "{content_type:ContentType}" and save value of "{expression}" in variable "{variable}"')
@@ -325,7 +325,7 @@ def step_task_transform(context: Context, content: str, content_type: Transforme
     '''
 
     grizzly = cast(GrizzlyContext, context.grizzly)
-    grizzly.scenario.add_task(TransformerTask(
+    grizzly.scenario.tasks.add(TransformerTask(
         content=content,
         content_type=content_type,
         expression=expression,
@@ -355,7 +355,7 @@ def step_task_client_get_endpoint(context: Context, endpoint: str, variable: str
 
     task_client = get_task_client(endpoint)
 
-    grizzly.scenario.add_task(task_client(
+    grizzly.scenario.tasks.add(task_client(
         RequestDirection.FROM,
         endpoint,
         variable=variable,
@@ -388,7 +388,7 @@ def step_task_client_put_endpoint_file_destination(context: Context, source: str
 
     assert not is_template(source), 'source file cannot be a template'
 
-    grizzly.scenario.add_task(task_client(
+    grizzly.scenario.tasks.add(task_client(
         RequestDirection.TO,
         endpoint,
         source=source,
@@ -431,7 +431,7 @@ def step_task_date(context: Context, value: str, variable: str) -> None:
     grizzly = cast(GrizzlyContext, context.grizzly)
     assert variable in grizzly.state.variables, f'variable {variable} has not been initialized'
 
-    grizzly.scenario.add_task(DateTask(
+    grizzly.scenario.tasks.add(DateTask(
         value=value,
         variable=variable,
     ))
@@ -491,5 +491,5 @@ def step_task_async_group_close(context: Context) -> None:
     assert grizzly.scenario.async_group is not None, 'no async request group is open'
     assert len(grizzly.scenario.async_group.requests) > 0, f'there are no requests in async group "{grizzly.scenario.async_group.name}"'
 
-    grizzly.scenario.add_task(grizzly.scenario.async_group)
+    grizzly.scenario.tasks.add(grizzly.scenario.async_group)
     grizzly.scenario.async_group = None

--- a/grizzly/tasks/async_group.py
+++ b/grizzly/tasks/async_group.py
@@ -28,6 +28,7 @@ from time import perf_counter as time_perf_counter
 
 from . import GrizzlyTask, RequestTask, template
 from ..users.base import AsyncRequests
+from ..types import RequestType
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..context import GrizzlyContextScenario
@@ -110,7 +111,7 @@ class AsyncRequestGroupTask(GrizzlyTask):
                 response_time = int((time_perf_counter() - start) * 1000)
 
                 parent.user.environment.events.request.fire(
-                    request_type='ASYNC',
+                    request_type=RequestType.ASYNC_GROUP(),
                     name=f'{self.scenario.identifier} {self.name} ({len(self.requests)})',
                     response_time=response_time,
                     response_length=response_length,

--- a/grizzly/tasks/clients/__init__.py
+++ b/grizzly/tasks/clients/__init__.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 
 from ...context import GrizzlyContext, GrizzlyContextScenario
 from ...scenarios import GrizzlyScenario
-from ...types import RequestDirection
+from ...types import RequestType, RequestDirection
 from .. import GrizzlyTask, template
 
 
@@ -96,7 +96,7 @@ class ClientTask(GrizzlyTask):
             response_length = meta.get('response_length', None) or 0
             action = self.variable or meta.get('action', '')
             parent.user.environment.events.request.fire(
-                request_type='TASK',
+                request_type=RequestType.CLIENT_TASK(),
                 name=f'{parent.user._scenario.identifier} {self._short_name}{self._direction_arrow[self.direction]}{action}',
                 response_time=response_time,
                 response_length=response_length,

--- a/grizzly/tasks/until.py
+++ b/grizzly/tasks/until.py
@@ -24,6 +24,7 @@ from grizzly_extras.transformer import Transformer, TransformerContentType, Tran
 from grizzly_extras.arguments import get_unsupported_arguments, parse_arguments, split_value
 
 from ..context import GrizzlyContext
+from ..types import RequestType
 from .request import RequestTask
 from . import GrizzlyTask, template
 
@@ -147,7 +148,7 @@ class UntilRequestTask(GrizzlyTask):
                     ))
 
                 parent.user.environment.events.request.fire(
-                    request_type='UNTL',
+                    request_type=RequestType.UNTIL(),
                     name=task_name,
                     response_time=response_time,
                     response_length=response_length,

--- a/grizzly/testdata/ast.py
+++ b/grizzly/testdata/ast.py
@@ -47,7 +47,7 @@ def _parse_templates(templates: Dict[GrizzlyContextScenario, Set[str]]) -> Dict[
     variables: Dict[str, Set[str]] = {}
 
     for scenario, scenario_templates in templates.items():
-        scenario_name = scenario.get_name()
+        scenario_name = scenario.class_name
 
         if scenario_name not in variables:
             variables[scenario_name] = set()

--- a/grizzly/testdata/communication.py
+++ b/grizzly/testdata/communication.py
@@ -64,11 +64,11 @@ class TestdataConsumer:
                 message = self.socket.recv_json(flags=ZMQ_NOBLOCK)
                 break
             except ZMQAgain:
-                gsleep(0.1)  # let TestdataProducer greenlet execute
+                gsleep(0.1)  # let other greenlets execute
 
         if message['action'] == 'stop':
-            self.logger.debug('received stop command, stopping user')
-            raise StopUser()
+            self.logger.debug('received stop command')
+            return None
 
         if not message['action'] == 'consume':
             self.logger.error(f'unknown action "{message["action"]}" received, stopping user')

--- a/grizzly/testdata/communication.py
+++ b/grizzly/testdata/communication.py
@@ -160,7 +160,7 @@ class TestdataProducer:
                         try:
                             with self.semaphore:
                                 scenario_name = recv['scenario']
-                                scenario = self.grizzly.get_scenario(scenario_name)
+                                scenario = self.grizzly.scenarios.find_by_class_name(scenario_name)
 
                                 if scenario is not None:
                                     if scenario_name not in self.scenarios_iteration and scenario.iterations > 0:

--- a/grizzly/testdata/utils.py
+++ b/grizzly/testdata/utils.py
@@ -11,7 +11,7 @@ from locust.exception import StopUser
 
 from ..context import GrizzlyContext
 from ..tasks import GrizzlyTask
-from ..types import TestdataType, GrizzlyDictValueType, GrizzlyDict
+from ..types import RequestType, TestdataType, GrizzlyDictValueType, GrizzlyDict
 from ..utils import merge_dicts
 from .ast import get_template_variables
 
@@ -94,7 +94,7 @@ def transform(data: Dict[str, Any], objectify: Optional[bool] = True) -> Dict[st
                 finally:
                     response_time = int((time() - start_time) * 1000)
                     grizzly.state.environment.events.request.fire(
-                        request_type='VAR ',
+                        request_type=RequestType.VARIABLE(),
                         name=key,
                         response_time=response_time,
                         response_length=0,

--- a/grizzly/testdata/variables/messagequeue.py
+++ b/grizzly/testdata/variables/messagequeue.py
@@ -81,7 +81,7 @@ from grizzly_extras.async_message import AsyncMessageContext, AsyncMessageReques
 from grizzly_extras.arguments import split_value, parse_arguments
 from grizzly_extras.transformer import TransformerContentType
 
-from ...types import bool_typed, AtomicVariable
+from ...types import RequestType, bool_typed, AtomicVariable
 from ...context import GrizzlyContext
 from ..utils import resolve_variable
 
@@ -331,7 +331,7 @@ class AtomicMessageQueue(AtomicVariable[str]):
             # first request, connect to async-messaged
             if self._settings[variable].get('worker', None) is None:
                 request = {
-                    'action': 'CONN',
+                    'action': RequestType.CONNECT(),
                     'context': self._settings[variable]['context'],
                 }
 

--- a/grizzly/testdata/variables/servicebus.py
+++ b/grizzly/testdata/variables/servicebus.py
@@ -92,7 +92,7 @@ from grizzly_extras.async_message import AsyncMessageContext, AsyncMessageReques
 from grizzly_extras.arguments import split_value, parse_arguments, get_unsupported_arguments
 from grizzly_extras.transformer import TransformerContentType
 
-from ...types import AtomicVariable, bool_typed
+from ...types import AtomicVariable, RequestType, bool_typed
 from ...context import GrizzlyContext
 from ..utils import resolve_variable
 
@@ -340,7 +340,7 @@ class AtomicServiceBus(AtomicVariable[str]):
         response: Optional[AsyncMessageResponse] = None
         request: AsyncMessageRequest = {
             'worker': settings['worker'],
-            'action': 'HELLO',
+            'action': RequestType.HELLO.name,
             'context': context,
         }
 

--- a/grizzly/types.py
+++ b/grizzly/types.py
@@ -67,6 +67,47 @@ class RequestMethod(Enum, AdvancedEnum, settings=NoAlias):
         return self.value
 
 
+class RequestType(Enum, AdvancedEnum, settings=NoAlias):
+    SCENARIO = 'SCEN'
+    TESTDATA = 'TSTD'
+    UNTIL = 'UNTL'
+    VARIABLE = 'VAR'
+    ASYNC_GROUP = 'ASYNC'
+    CLIENT_TASK = 'CLTSK'
+    HELLO = 'HELO'
+    RECEIVE = 'RECV'
+    CONNECT = 'CONN'
+
+    def __call__(self) -> str:
+        return str(self)
+
+    def __str__(self) -> str:
+        return self.value
+
+    @classmethod
+    def from_method(cls, request_type: RequestMethod) -> str:
+        method_name = cast(Optional[RequestType], getattr(cls, request_type.name, None))
+        if method_name is not None:
+            return method_name.value
+
+        return request_type.name
+
+    @classmethod
+    def from_string(cls, key: str) -> str:
+        attribute = cast(Optional[RequestType], getattr(cls, key, None))
+        if attribute is not None:
+            return attribute.value
+
+        if key in [e.value for e in cls]:
+            return key
+
+        attribute = cast(Optional[RequestMethod], getattr(RequestMethod, key, None))
+        if attribute is not None:
+            return attribute.name
+
+        raise AttributeError(f'{key} does not exist')
+
+
 GrizzlyResponseContextManager = Union[RequestsResponseContextManager, FastResponseContextManager]
 
 GrizzlyResponse = Tuple[Optional[Dict[str, Any]], Optional[Any]]

--- a/grizzly/users/messagequeue.py
+++ b/grizzly/users/messagequeue.py
@@ -113,7 +113,7 @@ from gevent import sleep as gsleep
 from grizzly_extras.async_message import AsyncMessageContext, AsyncMessageRequest, AsyncMessageResponse, AsyncMessageError
 from grizzly_extras.arguments import get_unsupported_arguments, parse_arguments
 
-from ..types import GrizzlyResponse, RequestDirection
+from ..types import GrizzlyResponse, RequestDirection, RequestType
 from ..tasks import RequestTask
 from ..utils import merge_dicts
 from .base import GrizzlyUser, ResponseHandler, RequestLogger
@@ -284,7 +284,7 @@ class MessageQueueUser(ResponseHandler, RequestLogger, GrizzlyUser):
                         exception = e
                 finally:
                     self.environment.events.request.fire(
-                        request_type=f'mq:{am_request["action"][:4]}',
+                        request_type=RequestType.from_string(am_request['action']),
                         name=name,
                         response_time=total_time,
                         response_length=response.get('response_length', None) or 0,
@@ -312,7 +312,7 @@ class MessageQueueUser(ResponseHandler, RequestLogger, GrizzlyUser):
         # connect to queue manager at first request
         if self.worker_id is None:
             with action_context({
-                'action': 'CONN',
+                'action': RequestType.CONNECT(),
                 'context': self.am_context
             }, self.am_context['connection']) as action:
                 action.update({

--- a/grizzly/users/restapi.py
+++ b/grizzly/users/restapi.py
@@ -71,7 +71,7 @@ from locust.env import Environment
 
 import requests
 
-from ..types import GrizzlyResponse, WrappedFunc, GrizzlyResponseContextManager
+from ..types import GrizzlyResponse, RequestType, WrappedFunc, GrizzlyResponseContextManager
 from ..utils import merge_dicts
 from ..types import RequestMethod
 from ..tasks import RequestTask
@@ -618,7 +618,7 @@ class RestApiUser(ResponseHandler, RequestLogger, GrizzlyUser, HttpRequests, Asy
             except json.decoder.JSONDecodeError as exception:
                 # so that locust treats it as a failure
                 self.environment.events.request.fire(
-                    request_type=request.method.name,
+                    request_type=RequestType.from_method(request.method),
                     name=name,
                     response_time=0,
                     response_length=0,

--- a/grizzly/users/servicebus.py
+++ b/grizzly/users/servicebus.py
@@ -82,7 +82,7 @@ from gevent import sleep as gsleep
 from grizzly_extras.async_message import AsyncMessageContext, AsyncMessageResponse, AsyncMessageRequest, AsyncMessageError
 from grizzly_extras.arguments import parse_arguments, get_unsupported_arguments
 
-from ..types import RequestMethod, RequestDirection, GrizzlyResponse
+from ..types import RequestMethod, RequestDirection, GrizzlyResponse, RequestType
 from ..tasks import RequestTask
 from ..utils import merge_dicts
 from .base import GrizzlyUser, ResponseHandler, RequestLogger
@@ -192,7 +192,7 @@ class ServiceBusUser(ResponseHandler, RequestLogger, GrizzlyUser):
 
         request: AsyncMessageRequest = {
             'worker': self.worker_id,
-            'action': 'HELLO',
+            'action': RequestType.HELLO.name,
             'context': context,
         }
 
@@ -297,9 +297,8 @@ class ServiceBusUser(ResponseHandler, RequestLogger, GrizzlyUser):
                 if exception is None:
                     exception = e
             finally:
-                action_name = self.get_request_method(task)
                 self.environment.events.request.fire(
-                    request_type=f'sb:{action_name}',
+                    request_type=RequestType.from_method(task.method),
                     name=name,
                     response_time=response_time,
                     response_length=(response or {}).get('response_length', None) or 0,

--- a/grizzly/users/sftp.py
+++ b/grizzly/users/sftp.py
@@ -40,7 +40,7 @@ from locust.env import Environment
 from .base import GrizzlyUser, FileRequests, ResponseHandler, RequestLogger
 from ..utils import merge_dicts
 from ..clients import SftpClientSession
-from ..types import RequestMethod, GrizzlyResponse
+from ..types import RequestMethod, GrizzlyResponse, RequestType
 from ..tasks import RequestTask
 
 
@@ -158,7 +158,7 @@ class SftpUser(ResponseHandler, RequestLogger, GrizzlyUser, FileRequests):
                     exception = e
 
             self.environment.events.request.fire(
-                request_type=f'sftp:{request.method.name[:4]}',
+                request_type=RequestType.from_method(request.method),
                 name=name,
                 response_time=response_time,
                 response_length=response_length,

--- a/grizzly/utils.py
+++ b/grizzly/utils.py
@@ -10,8 +10,7 @@ from collections.abc import Mapping
 from copy import deepcopy
 
 from behave.runner import Context
-from behave.model import Scenario
-from behave.model_core import Status
+from behave.model import Scenario, Status
 from locust import between
 
 from .context import GrizzlyContextScenario
@@ -55,7 +54,7 @@ class catch:
             try:
                 return func(context, *args, **kwargs)
             except exception_type as e:
-                context._set_root_attribute('failed', True)
+                context._set_root_attribute(Status.failed.name, True)
 
                 if len(args) > 0:
                     if isinstance(args[0], Scenario):

--- a/tests/e2e/steps/scenario/test_response.py
+++ b/tests/e2e/steps/scenario/test_response.py
@@ -170,7 +170,7 @@ def test_e2e_step_response_validate(behave_context_fixture: BehaveContextFixture
     feature_file = behave_context_fixture.test_steps(
         scenario=[
             f'Then get request with name "{target.name.lower()}-handler" from endpoint "/api/test | content_type=json"',
-            f'When response {target.name.lower()} "$.hello.world" {condition} "foo[bar]?" fail scenario',
+            f'When response {target.name.lower()} "$.hello.world" {condition} "foo[bar]?" fail request',
         ],
         identifier=target.name,
     )

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -370,6 +370,7 @@ class GrizzlyFixture:
             user_classes=[user_type],
         )
 
+        self.request_task.request.scenario.description = self.request_task.request.scenario.name
         self.request_task.request.name = scenario_type.__name__
 
         user_type.host = host

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -243,6 +243,9 @@ class BehaveFixture:
     def grizzly(self) -> GrizzlyContext:
         return cast(GrizzlyContext, self.context.grizzly)
 
+    def create_scenario(self, name: str) -> Scenario:
+        return Scenario(filename=None, line=None, keyword='', name=name)
+
     def __enter__(self) -> 'BehaveFixture':
         runner = Runner(
             config=Configuration(
@@ -348,7 +351,7 @@ class GrizzlyFixture:
     def __enter__(self) -> 'GrizzlyFixture':
         environ['GRIZZLY_CONTEXT_ROOT'] = path.abspath(path.join(self.request_task.context_root, '..'))
         self.grizzly = GrizzlyContext()
-        self.grizzly._scenarios = [self.request_task.request.scenario]
+        self.grizzly.scenarios.append(self.request_task.request.scenario)
 
         return self
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -320,7 +320,7 @@ class RequestTaskFixture:
         request.scenario.context['host'] = 'http://example.com'
         request.scenario.behave = None
 
-        request.scenario.add_task(request)
+        request.scenario.tasks.add(request)
 
         self.context_root = request_path
         self.request = request

--- a/tests/test_grizzly/listeners/test___init__.py
+++ b/tests/test_grizzly/listeners/test___init__.py
@@ -231,7 +231,8 @@ def test_init_statistics_listener(mocker: MockerFixture, locust_fixture: LocustF
 def test_locust_test_start(listener_test: Environment) -> None:
     try:
         grizzly = GrizzlyContext()
-        grizzly.add_scenario('Test Scenario')
+        scenario = Scenario(filename=None, line=None, keyword='', name='Test Scenario')
+        grizzly.scenarios.create(scenario)
         grizzly.scenario.iterations = -1
         runner = MasterRunner(listener_test, '0.0.0.0', 5555)
         listener_test.runner = runner
@@ -357,7 +358,7 @@ def test_validate_result(mocker: MockerFixture, listener_test: Environment, capl
 
     # scenario name must match with the name that the pickled stats object was dumped from
     scenario = Scenario(None, None, '', 'do some posts')
-    grizzly.add_scenario(scenario)
+    grizzly.scenarios.create(scenario)
 
     # fail ratio
     listener_test.process_exit_code = 0

--- a/tests/test_grizzly/listeners/test___init__.py
+++ b/tests/test_grizzly/listeners/test___init__.py
@@ -12,7 +12,7 @@ from locust.env import Environment
 from locust.runners import LocalRunner, MasterRunner, WorkerRunner
 from locust.rpc.protocol import Message
 from locust.stats import RequestStats
-from behave.model import Scenario
+from behave.model import Scenario, Status
 
 from grizzly.listeners import (
     _init_testdata_producer,
@@ -44,10 +44,6 @@ def mocked_TestdataProducer___init__(self: Any, testdata: Any, address: str, env
     setattr(self, 'environment', environment)
 
 
-def mocked_noop(*args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> None:
-    pass
-
-
 @pytest.fixture
 def listener_test(mocker: MockerFixture, locust_fixture: LocustFixture) -> Generator[Environment, None, None]:
     mocker.patch(
@@ -62,17 +58,17 @@ def listener_test(mocker: MockerFixture, locust_fixture: LocustFixture) -> Gener
 
     mocker.patch(
         'zmq.sugar.socket.Socket.bind',
-        mocked_noop,
+        return_value=None,
     )
 
     mocker.patch(
         'zmq.sugar.socket.Socket.connect',
-        mocked_noop,
+        return_value=None,
     )
 
     mocker.patch(
         'zmq.sugar.socket.Socket.send',
-        mocked_noop,
+        return_value=None,
     )
 
     yield locust_fixture.env
@@ -172,12 +168,12 @@ def test_init_statistics_listener(mocker: MockerFixture, locust_fixture: LocustF
     # Influx -- short circuit
     mocker.patch(
         'grizzly.listeners.influxdb.InfluxDb.connect',
-        mocked_noop,
+        return_value=None,
     )
 
     mocker.patch(
         'grizzly.listeners.influxdb.InfluxDbListener.run',
-        mocked_noop,
+        return_value=None,
     )
 
     # ApplicationInsight -- short circuit
@@ -278,7 +274,7 @@ def test_spawning_complete() -> None:
 def test_quitting(mocker: MockerFixture, listener_test: Environment) -> None:
     mocker.patch(
         'grizzly.testdata.communication.TestdataProducer.stop',
-        mocked_noop,
+        return_value=None,
     )
 
     runner: Optional[MasterRunner] = None
@@ -365,17 +361,17 @@ def test_validate_result(mocker: MockerFixture, listener_test: Environment, capl
     grizzly.scenario.validation.fail_ratio = 0.1
 
     assert listener_test.process_exit_code == 0
-    assert grizzly.scenario.behave.status == 'passed'
+    assert grizzly.scenario.behave.status == Status.passed
 
     with caplog.at_level(logging.ERROR):
         validate_result_wrapper(listener_test)
 
     assert 'failed due to' in caplog.text
     assert listener_test.process_exit_code == 1
-    assert grizzly.scenario.behave.status == 'failed'
+    assert grizzly.scenario.behave.status == Status.failed
 
     grizzly.scenario.validation.fail_ratio = None
-    grizzly.scenario.behave.set_status('passed')
+    grizzly.scenario.behave.set_status(Status.passed)
     caplog.clear()
 
     # avg response time
@@ -383,17 +379,17 @@ def test_validate_result(mocker: MockerFixture, listener_test: Environment, capl
     grizzly.scenario.validation.avg_response_time = 2
 
     assert listener_test.process_exit_code == 0
-    assert grizzly.scenario.behave.status == 'passed'
+    assert grizzly.scenario.behave.status == Status.passed
 
     with caplog.at_level(logging.ERROR):
         validate_result_wrapper(listener_test)
 
     assert 'failed due to' in caplog.text
     assert listener_test.process_exit_code == 1
-    assert grizzly.scenario.behave.status == 'failed'
+    assert grizzly.scenario.behave.status == Status.failed
 
     grizzly.scenario.validation.avg_response_time = None
-    grizzly.scenario.behave.set_status('passed')
+    grizzly.scenario.behave.set_status(Status.passed)
     caplog.clear()
 
     # response time percentile
@@ -401,17 +397,17 @@ def test_validate_result(mocker: MockerFixture, listener_test: Environment, capl
     grizzly.scenario.validation.response_time_percentile = GrizzlyContextScenarioResponseTimePercentile(2, 0.99)
 
     assert listener_test.process_exit_code == 0
-    assert grizzly.scenario.behave.status == 'passed'
+    assert grizzly.scenario.behave.status == Status.passed
 
     with caplog.at_level(logging.ERROR):
         validate_result_wrapper(listener_test)
 
     assert 'failed due to' in caplog.text
     assert listener_test.process_exit_code == 1
-    assert grizzly.scenario.behave.status == 'failed'
+    assert grizzly.scenario.behave.status == Status.failed
 
     grizzly.scenario.validation.response_time_percentile = None
-    grizzly.scenario.behave.set_status('passed')
+    grizzly.scenario.behave.set_status(Status.passed)
 
 
 def test_grizzly_worker_quit_non_worker(locust_fixture: LocustFixture, caplog: LogCaptureFixture) -> None:

--- a/tests/test_grizzly/steps/scenario/test_response.py
+++ b/tests/test_grizzly/steps/scenario/test_response.py
@@ -247,7 +247,7 @@ def test_step_response_allow_status_codes(behave_fixture: BehaveFixture) -> None
 
     request = RequestTask(RequestMethod.SEND, name='test', endpoint='/api/test')
     grizzly.scenarios.create(behave_fixture.create_scenario('test'))
-    grizzly.scenario.add_task(request)
+    grizzly.scenario.tasks.add(request)
 
     step_response_allow_status_codes(behave, '-200')
     assert request.response.status_codes == []
@@ -275,7 +275,7 @@ def test_step_response_allow_status_codes_table(behave_fixture: BehaveFixture) -
 
     request = RequestTask(RequestMethod.SEND, name='test', endpoint='/api/test')
     grizzly.scenarios.create(behave_fixture.create_scenario('test'))
-    grizzly.scenario.add_task(request)
+    grizzly.scenario.tasks.add(request)
 
     # more rows in data table then there are requests
     with pytest.raises(AssertionError) as ae:
@@ -283,7 +283,7 @@ def test_step_response_allow_status_codes_table(behave_fixture: BehaveFixture) -
     assert 'data table has more rows than there are requests' in str(ae)
 
     request = RequestTask(RequestMethod.GET, name='test-get', endpoint='/api/test')
-    grizzly.scenario.add_task(request)
+    grizzly.scenario.tasks.add(request)
 
     # data table column "code" does not exist
     with pytest.raises(AssertionError) as ae:
@@ -291,7 +291,7 @@ def test_step_response_allow_status_codes_table(behave_fixture: BehaveFixture) -
     assert 'data table does not have column "status"' in str(ae)
 
     request = RequestTask(RequestMethod.GET, name='no-code', endpoint='/api/test')
-    grizzly.scenario.tasks.insert(0, request)
+    grizzly.scenario.tasks.add(request, pos=0)
 
     rows = []
     '''
@@ -318,7 +318,7 @@ def test_step_response_content_type(behave_fixture: BehaveFixture) -> None:
         step_response_content_type(behave, TransformerContentType.JSON)
     assert 'There are no requests in the scenario' in str(ae)
 
-    grizzly.scenario.add_task(WaitTask(time=1.0))
+    grizzly.scenario.tasks.add(WaitTask(time=1.0))
 
     with pytest.raises(AssertionError) as ae:
         step_response_content_type(behave, TransformerContentType.JSON)
@@ -328,7 +328,7 @@ def test_step_response_content_type(behave_fixture: BehaveFixture) -> None:
 
     assert request.response.content_type == TransformerContentType.UNDEFINED
 
-    grizzly.scenario.add_task(request)
+    grizzly.scenario.tasks.add(request)
 
     for content_type in TransformerContentType:
         if content_type == TransformerContentType.UNDEFINED:
@@ -345,7 +345,7 @@ def test_step_response_content_type(behave_fixture: BehaveFixture) -> None:
     assert request.response.content_type == TransformerContentType.XML
     assert request.endpoint == 'queue:INCOMING.MESSAGE'
 
-    grizzly.scenario.add_task(request)
+    grizzly.scenario.tasks.add(request)
 
     for content_type in TransformerContentType:
         if content_type == TransformerContentType.UNDEFINED:

--- a/tests/test_grizzly/steps/scenario/test_response.py
+++ b/tests/test_grizzly/steps/scenario/test_response.py
@@ -246,7 +246,7 @@ def test_step_response_allow_status_codes(behave_fixture: BehaveFixture) -> None
     assert 'there are no requests in the scenario' in str(ve)
 
     request = RequestTask(RequestMethod.SEND, name='test', endpoint='/api/test')
-    grizzly.add_scenario('test')
+    grizzly.scenarios.create(behave_fixture.create_scenario('test'))
     grizzly.scenario.add_task(request)
 
     step_response_allow_status_codes(behave, '-200')
@@ -274,7 +274,7 @@ def test_step_response_allow_status_codes_table(behave_fixture: BehaveFixture) -
     assert 'there are no requests in the scenario' in str(ae)
 
     request = RequestTask(RequestMethod.SEND, name='test', endpoint='/api/test')
-    grizzly.add_scenario('test')
+    grizzly.scenarios.create(behave_fixture.create_scenario('test'))
     grizzly.scenario.add_task(request)
 
     # more rows in data table then there are requests

--- a/tests/test_grizzly/tasks/clients/test_blobstorage.py
+++ b/tests/test_grizzly/tasks/clients/test_blobstorage.py
@@ -169,7 +169,7 @@ class TestBlobStorageClientTask:
 
             assert request_fire_spy.call_count == 1
             _, kwargs = request_fire_spy.call_args_list[-1]
-            assert kwargs.get('request_type', None) == 'TASK'
+            assert kwargs.get('request_type', None) == 'CLTSK'
             assert kwargs.get('name', None) == f'{scenario.user._scenario.identifier} BlobStorage->my-container'
             assert kwargs.get('response_time', None) >= 0.0
             assert kwargs.get('response_length') == len('source.json')
@@ -209,7 +209,7 @@ class TestBlobStorageClientTask:
 
             assert request_fire_spy.call_count == 2
             _, kwargs = request_fire_spy.call_args_list[-1]
-            assert kwargs.get('request_type', None) == 'TASK'
+            assert kwargs.get('request_type', None) == 'CLTSK'
             assert kwargs.get('name', None) == f'{scenario.user._scenario.identifier} BlobStorage->my-container'
             assert kwargs.get('response_time', None) >= 0.0
             assert kwargs.get('response_length') == len('this is my hello world test!')
@@ -231,7 +231,7 @@ class TestBlobStorageClientTask:
 
             assert request_fire_spy.call_count == 3
             _, kwargs = request_fire_spy.call_args_list[-1]
-            assert kwargs.get('request_type', None) == 'TASK'
+            assert kwargs.get('request_type', None) == 'CLTSK'
             assert kwargs.get('name', None) == f'{scenario.user._scenario.identifier} BlobStorage->my-container'
             assert kwargs.get('response_time', None) >= 0.0
             assert kwargs.get('response_length') == len('this is my hello world test!')

--- a/tests/test_grizzly/tasks/clients/test_http.py
+++ b/tests/test_grizzly/tasks/clients/test_http.py
@@ -66,7 +66,7 @@ class TestHttpClientTask:
 
         assert request_fire_spy.call_count == 1
         _, kwargs = request_fire_spy.call_args_list[-1]
-        assert kwargs.get('request_type', None) == 'TASK'
+        assert kwargs.get('request_type', None) == 'CLTSK'
         assert kwargs.get('name', None) == f'{scenario.user._scenario.identifier} Http<-test'
         assert kwargs.get('response_time', None) >= 0.0
         assert kwargs.get('response_length') == len(jsondumps({'hello': 'world'}))
@@ -84,7 +84,7 @@ class TestHttpClientTask:
 
         assert request_fire_spy.call_count == 2
         _, kwargs = request_fire_spy.call_args_list[-1]
-        assert kwargs.get('request_type', None) == 'TASK'
+        assert kwargs.get('request_type', None) == 'CLTSK'
         assert kwargs.get('name', None) == f'{scenario.user._scenario.identifier} Http<-test'
         assert kwargs.get('response_time', None) >= 0.0
         assert kwargs.get('response_length') == 0
@@ -108,7 +108,7 @@ class TestHttpClientTask:
 
         assert request_fire_spy.call_count == 4
         _, kwargs = request_fire_spy.call_args_list[-1]
-        assert kwargs.get('request_type', None) == 'TASK'
+        assert kwargs.get('request_type', None) == 'CLTSK'
         assert kwargs.get('name', None) == f'{scenario.user._scenario.identifier} Http<-test'
         assert kwargs.get('response_time', None) >= 0.0
         assert kwargs.get('response_length') == 0

--- a/tests/test_grizzly/test_context.py
+++ b/tests/test_grizzly/test_context.py
@@ -333,7 +333,7 @@ class TestGrizzlyContextScenario:
         scenario.user.class_name = 'TestUser'
         request = request_task.request
 
-        scenario.add_task(request)
+        scenario.tasks.add(request)
 
         assert scenario.tasks == [request]
         assert isinstance(scenario.tasks[-1], RequestTask) and scenario.tasks[-1].scenario is scenario
@@ -342,14 +342,14 @@ class TestGrizzlyContextScenario:
         second_request.source = '{"hello": "world!"}'
         assert isinstance(second_request.template, Template)
 
-        scenario.add_task(second_request)
+        scenario.tasks.add(second_request)
         assert scenario.tasks == [request, second_request]
         assert isinstance(scenario.tasks[-1], RequestTask) and scenario.tasks[-1].scenario is scenario
 
         wait_task = WaitTask(time=1.337)
-        scenario.add_task(wait_task)
+        scenario.tasks.add(wait_task)
         assert scenario.tasks == [request, second_request, wait_task]
 
         log_task = LogMessage(message='hello general')
-        scenario.add_task(log_task)
+        scenario.tasks.add(log_task)
         assert scenario.tasks == [request, second_request, wait_task, log_task]

--- a/tests/test_grizzly/test_environment.py
+++ b/tests/test_grizzly/test_environment.py
@@ -177,7 +177,7 @@ def test_before_scenario(behave_fixture: BehaveFixture, mocker: MockerFixture) -
     assert getattr(behave.scenario.steps[3], 'location_status', None) is None
 
     grizzly.state.background_section_done = True
-    grizzly._scenarios = []
+    grizzly.scenarios.clear()
 
     before_scenario(behave, behave.scenario)
 

--- a/tests/test_grizzly/test_environment.py
+++ b/tests/test_grizzly/test_environment.py
@@ -7,7 +7,7 @@ import pytest
 from pytest_mock import MockerFixture
 from behave.runner import Context, Runner
 from behave.configuration import Configuration
-from behave.model import Feature, Step
+from behave.model import Feature, Step, Status
 
 from grizzly.environment import before_feature, after_feature, before_scenario, after_scenario, before_step, after_step
 from grizzly.context import GrizzlyContext
@@ -78,12 +78,12 @@ def test_after_feature(behave_fixture: BehaveFixture, mocker: MockerFixture) -> 
     )
 
     # do not start locust if feature failed
-    feature.set_status('failed')
+    feature.set_status(Status.failed)
 
     after_feature(behave, feature)
 
     # start locust only if it's not a dry run and the feature passed
-    feature.set_status('passed')
+    feature.set_status(Status.passed)
 
     with pytest.raises(LocustRunning):
         after_feature(behave, feature)
@@ -96,11 +96,11 @@ def test_after_feature(behave_fixture: BehaveFixture, mocker: MockerFixture) -> 
         locustrun_return_not_0,
     )
 
-    assert feature.status == 'passed'
+    assert feature.status == Status.passed
 
     after_feature(behave, feature)
 
-    assert feature.status == 'failed'
+    assert feature.status == Status.failed
 
     assert feature.duration == 0.0
     behave.start = time_monotonic() - 1.0

--- a/tests/test_grizzly/test_locust.py
+++ b/tests/test_grizzly/test_locust.py
@@ -172,9 +172,9 @@ def test_setup_locust_scenarios(behave_fixture: BehaveFixture) -> None:
     assert 'no tasks has been added to' in str(ae)
 
     task = RequestTask(RequestMethod.GET, 'test-1', '/api/v1/test/1')
-    grizzly.scenario.add_task(task)
-    grizzly.scenario.add_task(WaitTask(time=1.5))
-    grizzly.scenario.add_task(LogMessage(message='test message'))
+    grizzly.scenario.tasks.add(task)
+    grizzly.scenario.tasks.add(WaitTask(time=1.5))
+    grizzly.scenario.tasks.add(LogMessage(message='test message'))
 
     # incorrect user type
     grizzly.scenario.user.class_name = 'NonExistingUser'
@@ -239,7 +239,7 @@ def test_setup_locust_scenarios_user_distribution(behave_fixture: BehaveFixture,
         scenario = Scenario(filename=None, line=None, keyword='', name=f'Test-{(index + 1)}')
         grizzly.scenarios.create(scenario)
         grizzly.scenario.context['host'] = 'http://localhost:8003'
-        grizzly.scenario.add_task(LogMessage(message='foo bar'))
+        grizzly.scenario.tasks.add(LogMessage(message='foo bar'))
         grizzly.scenario.user.class_name = 'RestApiUser'
         grizzly.scenario.user.weight = distribution[index]
 
@@ -625,9 +625,9 @@ def test_run_worker(behave_fixture: BehaveFixture, capsys: CaptureFixture, mocke
     grizzly.scenarios.create(behave_fixture.create_scenario('test-non-mq'))
     grizzly.scenario.user.class_name = 'RestApiUser'
     grizzly.scenario.context['host'] = 'https://test.example.org'
-    grizzly.scenario.add_task(WaitTask(time=1.5))
+    grizzly.scenario.tasks.add(WaitTask(time=1.5))
     task = RequestTask(RequestMethod.GET, 'test-1', '/api/v1/test/1')
-    grizzly.scenario.add_task(task)
+    grizzly.scenario.tasks.add(task)
 
     assert run(behave) == 1
     assert 'failed to connect to the locust master' in capsys.readouterr().err
@@ -638,7 +638,7 @@ def test_run_worker(behave_fixture: BehaveFixture, capsys: CaptureFixture, mocke
         grizzly.scenarios.create(behave_fixture.create_scenario('test-mq'))
         grizzly.scenario.user.class_name = 'MessageQueueUser'
         grizzly.scenario.context['host'] = 'mq://mq.example.org?QueueManager=QM01&Channel=TEST.CONN'
-        grizzly.scenario.add_task(RequestTask(RequestMethod.PUT, 'test-2', 'TEST.QUEUE'))
+        grizzly.scenario.tasks.add(RequestTask(RequestMethod.PUT, 'test-2', 'TEST.QUEUE'))
 
         with pytest.raises(AssertionError) as ae:
             run(behave)
@@ -664,7 +664,7 @@ def test_run_worker(behave_fixture: BehaveFixture, capsys: CaptureFixture, mocke
 
         task.endpoint = '/api/v1/{{ AtomicMessageQueue.test }}'
 
-        grizzly.scenario.add_task(task)
+        grizzly.scenario.tasks.add(task)
 
         assert run(behave) == 1
         assert 'failed to connect to the locust master' in capsys.readouterr().err
@@ -765,9 +765,9 @@ def test_run_master(behave_fixture: BehaveFixture, capsys: CaptureFixture, mocke
     grizzly.scenarios.create(behave_fixture.create_scenario('test'))
     grizzly.scenario.user.class_name = 'RestApiUser'
     grizzly.scenario.context['host'] = 'https://test.example.org'
-    grizzly.scenario.add_task(WaitTask(time=1.5))
+    grizzly.scenario.tasks.add(WaitTask(time=1.5))
     task = RequestTask(RequestMethod.GET, 'test-1', '/api/v1/test/1')
-    grizzly.scenario.add_task(task)
+    grizzly.scenario.tasks.add(task)
     grizzly.setup.spawn_rate = 1
 
     grizzly.setup.timespan = 'adsf'
@@ -798,7 +798,7 @@ def test_run_master(behave_fixture: BehaveFixture, capsys: CaptureFixture, mocke
 
         task.endpoint = '/api/v1/{{ AtomicMessageQueue.test }}'
 
-        grizzly.scenario.add_task(task)
+        grizzly.scenario.tasks.add(task)
 
         with pytest.raises(AssertionError) as ae:
             run(behave)

--- a/tests/test_grizzly/test_locust.py
+++ b/tests/test_grizzly/test_locust.py
@@ -488,30 +488,40 @@ def test_print_scenario_summary(behave_fixture: BehaveFixture, capsys: CaptureFi
     summary = capsys.readouterr().out
     print(summary)
     assert '''Scenario
-ident   #  description
-------|--|-------------|
-001     1  test-1
-------|--|-------------|
+ident     #  status   description
+------|----|--------|-------------|
+001     0/1  inconc   test-1
+------|----|--------|-------------|
 ''' == summary
     capsys.readouterr()
 
     grizzly.scenarios.create(behave_fixture.create_scenario('test-2-test-2-test-2-test-2'))
     grizzly.scenario.iterations = 4
+    stat = grizzly.state.environment.stats.get(f'{grizzly.scenario.identifier} {grizzly.scenario.name}', 'SCEN')
+    stat.num_failures = 1
+    stat.num_requests = 3
+
+    stat = grizzly.state.environment.stats.get(f'{grizzly.scenarios[-2].identifier} {grizzly.scenarios[-2].name}', 'SCEN')
+    stat.num_failures = 0
+    stat.num_requests = 1
 
     print_scenario_summary(grizzly)
 
     summary = capsys.readouterr().out
     print(summary)
     assert '''Scenario
-ident   #  description
-------|--|-----------------------------|
-001     1  test-1
-002     4  test-2-test-2-test-2-test-2
-------|--|-----------------------------|
+ident     #  status   description
+------|----|--------|-----------------------------|
+001     1/1  passed   test-1
+002     3/4  failed   test-2-test-2-test-2-test-2
+------|----|--------|-----------------------------|
 ''' == summary
     capsys.readouterr()
 
     grizzly.scenarios.create(behave_fixture.create_scenario('#3'))
+    stat = grizzly.state.environment.stats.get(f'{grizzly.scenario.identifier} {grizzly.scenario.name}', 'SCEN')
+    stat.num_failures = 0
+    stat.num_requests = 998
 
     grizzly.scenario.iterations = 999
 
@@ -521,12 +531,12 @@ ident   #  description
     print(summary)
 
     assert '''Scenario
-ident     #  description
-------|----|-----------------------------|
-001       1  test-1
-002       4  test-2-test-2-test-2-test-2
-003     999  #3
-------|----|-----------------------------|
+ident         #  status   description
+------|--------|--------|-----------------------------|
+001         1/1  passed   test-1
+002         3/4  failed   test-2-test-2-test-2-test-2
+003     998/999  failed   #3
+------|--------|--------|-----------------------------|
 ''' == summary
     capsys.readouterr()
 
@@ -540,13 +550,13 @@ ident     #  description
     print(summary)
 
     assert '''Scenario
-ident       #  description
-------|------|-----------------------------|
-001         1  test-1
-002         4  test-2-test-2-test-2-test-2
-003       999  #3
-004     99999  foo bar hello world
-------|------|-----------------------------|
+ident         #  status   description
+------|--------|--------|-----------------------------|
+001         1/1  passed   test-1
+002         3/4  failed   test-2-test-2-test-2-test-2
+003     998/999  failed   #3
+004     0/99999  inconc   foo bar hello world
+------|--------|--------|-----------------------------|
 ''' == summary
     capsys.readouterr()
 

--- a/tests/test_grizzly/test_locust.py
+++ b/tests/test_grizzly/test_locust.py
@@ -26,7 +26,7 @@ from grizzly.locust import (
     setup_locust_scenarios,
     setup_resource_limits,
 )
-from grizzly.types import RequestMethod
+from grizzly.types import RequestMethod, RequestType
 from grizzly.context import GrizzlyContext, GrizzlyContextScenario
 from grizzly.tasks import GrizzlyTask, LogMessage, RequestTask, WaitTask
 from grizzly.users import RestApiUser, MessageQueueUser
@@ -488,20 +488,20 @@ def test_print_scenario_summary(behave_fixture: BehaveFixture, capsys: CaptureFi
     summary = capsys.readouterr().out
     print(summary)
     assert '''Scenario
-ident     #  status   description
-------|----|--------|-------------|
-001     0/1  inconc   test-1
-------|----|--------|-------------|
+ident   iter  status      description
+------|-----|-----------|-------------|
+001      0/1  undefined   test-1
+------|-----|-----------|-------------|
 ''' == summary
     capsys.readouterr()
 
     grizzly.scenarios.create(behave_fixture.create_scenario('test-2-test-2-test-2-test-2'))
     grizzly.scenario.iterations = 4
-    stat = grizzly.state.environment.stats.get(f'{grizzly.scenario.identifier} {grizzly.scenario.name}', 'SCEN')
+    stat = grizzly.state.environment.stats.get(grizzly.scenario.locust_name, RequestType.SCENARIO())
     stat.num_failures = 1
     stat.num_requests = 3
 
-    stat = grizzly.state.environment.stats.get(f'{grizzly.scenarios[-2].identifier} {grizzly.scenarios[-2].name}', 'SCEN')
+    stat = grizzly.state.environment.stats.get(grizzly.scenarios[-2].locust_name, RequestType.SCENARIO())
     stat.num_failures = 0
     stat.num_requests = 1
 
@@ -510,16 +510,16 @@ ident     #  status   description
     summary = capsys.readouterr().out
     print(summary)
     assert '''Scenario
-ident     #  status   description
-------|----|--------|-----------------------------|
-001     1/1  passed   test-1
-002     3/4  failed   test-2-test-2-test-2-test-2
-------|----|--------|-----------------------------|
+ident   iter  status   description
+------|-----|--------|-----------------------------|
+001      1/1  passed   test-1
+002      3/4  failed   test-2-test-2-test-2-test-2
+------|-----|--------|-----------------------------|
 ''' == summary
     capsys.readouterr()
 
     grizzly.scenarios.create(behave_fixture.create_scenario('#3'))
-    stat = grizzly.state.environment.stats.get(f'{grizzly.scenario.identifier} {grizzly.scenario.name}', 'SCEN')
+    stat = grizzly.state.environment.stats.get(grizzly.scenario.locust_name, RequestType.SCENARIO())
     stat.num_failures = 0
     stat.num_requests = 998
 
@@ -531,7 +531,7 @@ ident     #  status   description
     print(summary)
 
     assert '''Scenario
-ident         #  status   description
+ident      iter  status   description
 ------|--------|--------|-----------------------------|
 001         1/1  passed   test-1
 002         3/4  failed   test-2-test-2-test-2-test-2
@@ -550,13 +550,13 @@ ident         #  status   description
     print(summary)
 
     assert '''Scenario
-ident         #  status   description
-------|--------|--------|-----------------------------|
-001         1/1  passed   test-1
-002         3/4  failed   test-2-test-2-test-2-test-2
-003     998/999  failed   #3
-004     0/99999  inconc   foo bar hello world
-------|--------|--------|-----------------------------|
+ident      iter  status      description
+------|--------|-----------|-----------------------------|
+001         1/1  passed      test-1
+002         3/4  failed      test-2-test-2-test-2-test-2
+003     998/999  failed      #3
+004     0/99999  undefined   foo bar hello world
+------|--------|-----------|-----------------------------|
 ''' == summary
     capsys.readouterr()
 

--- a/tests/test_grizzly/test_types.py
+++ b/tests/test_grizzly/test_types.py
@@ -5,7 +5,7 @@ import pytest
 
 from _pytest.tmpdir import TempPathFactory
 
-from grizzly.types import RequestDirection, RequestMethod, bool_typed, int_rounded_float_typed, AtomicVariable, GrizzlyDict
+from grizzly.types import RequestType, RequestDirection, RequestMethod, bool_typed, int_rounded_float_typed, AtomicVariable, GrizzlyDict
 
 from ..fixtures import AtomicVariableCleanupFixture
 
@@ -26,6 +26,39 @@ class TestRequestDirection:
                 assert method in RequestDirection.TO.methods
             else:
                 pytest.fail(f'{method.name} does not have a direction registered')
+
+
+class TestRequestType:
+    def test___str__(self) -> None:
+        for custom_type in RequestType:
+            assert str(custom_type) == custom_type.value
+
+    @pytest.mark.parametrize('input,expected', [
+        (RequestMethod.GET, 'GET',),
+        (RequestMethod.RECEIVE, 'RECV',),
+        (RequestMethod.PUT, 'PUT',),
+        (RequestMethod.SEND, 'SEND',),
+    ])
+    def test_from_method(self, input: RequestMethod, expected: str) -> None:
+        assert RequestType.from_method(input) == expected
+
+    @pytest.mark.parametrize('input,expected', [
+        (e.name, e.value,) for e in RequestType
+    ] + [
+        (e.name, e.name,) for e in RequestMethod if getattr(RequestType, e.name, None) is None
+    ] + [
+        (e.value, e.value,) for e in RequestType
+    ])
+    def test_from_string(self, input: str, expected: str) -> None:
+        assert RequestType.from_string(input) == expected
+
+        with pytest.raises(AttributeError) as ae:
+            RequestType.from_string('foobar')
+        assert str(ae.value) == 'foobar does not exist'
+
+    @pytest.mark.parametrize('input', [e for e in RequestType])
+    def test___call___and___str__(self, input: RequestType) -> None:
+        assert input() == input.value == str(input)
 
 
 class TestRequestMethod:

--- a/tests/test_grizzly/test_utils.py
+++ b/tests/test_grizzly/test_utils.py
@@ -92,7 +92,7 @@ def test_catch(behave_fixture: BehaveFixture) -> None:
 
     assert behave.failed
     assert behave_scenario.status == Status.failed
-    behave._set_root_attribute('failed', False)
+    behave._set_root_attribute(Status.failed.name, False)
     behave_scenario.set_status(Status.undefined)
 
     @catch(ValueError)
@@ -104,7 +104,7 @@ def test_catch(behave_fixture: BehaveFixture) -> None:
 
     assert not behave.failed
     assert not behave_scenario.status == Status.failed
-    behave._set_root_attribute('failed', False)
+    behave._set_root_attribute(Status.failed.name, False)
     behave_scenario.set_status(Status.undefined)
 
     @catch(ValueError)

--- a/tests/test_grizzly/testdata/test_ast.py
+++ b/tests/test_grizzly/testdata/test_ast.py
@@ -24,7 +24,7 @@ def test__parse_template(request_task: RequestTaskFixture) -> None:
     request.source = jsondumps(source)
     scenario = GrizzlyContextScenario(1)
     scenario.name = 'TestScenario'
-    scenario.add_task(request)
+    scenario.tasks.add(request)
 
     templates = {scenario: set(request.get_templates())}
 
@@ -50,19 +50,19 @@ def test_get_template_variables() -> None:
     scenario.name = 'TestScenario'
     scenario.context['host'] = 'http://test.nu'
     scenario.user.class_name = 'TestUser'
-    scenario.add_task(
+    scenario.tasks.add(
         RequestTask(RequestMethod.POST, name='Test POST request', endpoint='/api/test/post')
     )
     task = cast(RequestTask, scenario.tasks[-1])
     task.source = '{{ AtomicRandomString.test }}'
 
-    scenario.add_task(
+    scenario.tasks.add(
         RequestTask(RequestMethod.GET, name='{{ env }} GET request', endpoint='/api/{{ env }}/get')
     )
     task = cast(RequestTask, scenario.tasks[-1])
     task.source = '{{ AtomicIntegerIncrementer.test }}'
 
-    scenario.add_task(
+    scenario.tasks.add(
         LogMessage(message='{{ foo }}')
     )
 

--- a/tests/test_grizzly/testdata/test_ast.py
+++ b/tests/test_grizzly/testdata/test_ast.py
@@ -70,7 +70,7 @@ def test_get_template_variables() -> None:
 
     expected_scenario_name = '_'.join([scenario.name, scenario.identifier])
 
-    assert scenario.get_name() == expected_scenario_name
+    assert scenario.class_name == expected_scenario_name
     assert expected_scenario_name in variables
     assert 'AtomicRandomString.test' in variables[expected_scenario_name]
     assert 'AtomicIntegerIncrementer.test' in variables[expected_scenario_name]

--- a/tests/test_grizzly/testdata/test_communication.py
+++ b/tests/test_grizzly/testdata/test_communication.py
@@ -407,9 +407,8 @@ class TestTestdataConsumer:
             }, 'stop')
 
             with caplog.at_level(logging.DEBUG):
-                with pytest.raises(StopUser):
-                    consumer.request('test')
-            assert 'received stop command, stopping user' in caplog.text
+                assert consumer.request('test') is None
+            assert caplog.messages[-1] == 'received stop command'
 
             caplog.clear()
 

--- a/tests/test_grizzly/testdata/test_communication.py
+++ b/tests/test_grizzly/testdata/test_communication.py
@@ -95,8 +95,8 @@ class TestTestdataProducer:
 
             request.source = json.dumps(source)
 
-            grizzly.scenario.add_task(request)
-            grizzly.scenario.add_task(LogMessage(message='hello {{ world }}'))
+            grizzly.scenario.tasks.add(request)
+            grizzly.scenario.tasks.add(LogMessage(message='hello {{ world }}'))
 
             testdata, external_dependencies = initialize_testdata(grizzly.scenario.tasks)
 
@@ -214,8 +214,8 @@ class TestTestdataProducer:
             grizzly.scenario.iterations = 0
             grizzly.scenario.user.class_name = 'TestUser'
             grizzly.scenario.context['host'] = 'http://test.nu'
-            grizzly.scenario.add_task(request)
-            grizzly.scenario.add_task(LogMessage(message='are you {{ sure }}'))
+            grizzly.scenario.tasks.add(request)
+            grizzly.scenario.tasks.add(LogMessage(message='are you {{ sure }}'))
 
             testdata, external_dependencies = initialize_testdata(grizzly.scenario.tasks)
 

--- a/tests/test_grizzly/testdata/test_utils.py
+++ b/tests/test_grizzly/testdata/test_utils.py
@@ -13,6 +13,7 @@ from _pytest.tmpdir import TempPathFactory
 from pytest_mock import MockerFixture
 from _pytest.logging import LogCaptureFixture
 from locust.exception import StopUser
+from behave.model import Scenario
 
 from grizzly.context import GrizzlyContext
 from grizzly.tasks import LogMessage, DateTask, TransformerTask, UntilRequestTask
@@ -193,7 +194,7 @@ def test_initialize_testdata_with_tasks(
         scenario.orphan_templates.append('hello {{ orphan }} template')
         testdata, external_dependencies = initialize_testdata(scenario.tasks)
 
-        scenario_name = scenario.get_name()
+        scenario_name = scenario.class_name
 
         assert external_dependencies == set()
         assert scenario_name in testdata
@@ -245,7 +246,8 @@ def test_initialize_testdata_with_payload_context(grizzly_fixture: GrizzlyFixtur
         source['result']['File'] = '{{ AtomicDirectoryContents.test }}'
 
         grizzly = cast(GrizzlyContext, behave.grizzly)
-        grizzly.add_scenario(scenario.__class__.__name__)
+        behave_scenario = Scenario(filename=None, line=None, keyword='', name=scenario.__class__.__name__)
+        grizzly.scenarios.create(behave_scenario)
         grizzly.state.variables['messageID'] = 123
         grizzly.state.variables['AtomicIntegerIncrementer.messageID'] = 456
         grizzly.state.variables['AtomicCsvRow.test'] = 'test.csv'
@@ -270,7 +272,7 @@ def test_initialize_testdata_with_payload_context(grizzly_fixture: GrizzlyFixtur
 
         testdata, external_dependencies = initialize_testdata(grizzly.scenario.tasks)
 
-        scenario_name = grizzly.scenario.get_name()
+        scenario_name = grizzly.scenario.class_name
 
         assert scenario_name in testdata
         assert external_dependencies == set(['async-messaged'])

--- a/tests/test_grizzly/testdata/test_utils.py
+++ b/tests/test_grizzly/testdata/test_utils.py
@@ -181,16 +181,16 @@ def test_initialize_testdata_with_tasks(
         request.endpoint = '/api/{{ endpoint_part }}/test'
         request.response.content_type = TransformerContentType.JSON
         scenario = request.scenario
-        scenario.add_task(request)
-        scenario.add_task(LogMessage(message='{{ message }}'))
-        scenario.add_task(DateTask(variable='date_task', value='{{ date_task_date }} | timezone="{{ timezone }}", offset="-{{ days }}D"'))
-        scenario.add_task(TransformerTask(
+        scenario.tasks.add(request)
+        scenario.tasks.add(LogMessage(message='{{ message }}'))
+        scenario.tasks.add(DateTask(variable='date_task', value='{{ date_task_date }} | timezone="{{ timezone }}", offset="-{{ days }}D"'))
+        scenario.tasks.add(TransformerTask(
             expression='$.expression',
             variable='transformer_task',
             content='hello this is the {{ content }}!',
             content_type=TransformerContentType.JSON,
         ))
-        scenario.add_task(UntilRequestTask(request=request, condition='{{ condition }}'))
+        scenario.tasks.add(UntilRequestTask(request=request, condition='{{ condition }}'))
         scenario.orphan_templates.append('hello {{ orphan }} template')
         testdata, external_dependencies = initialize_testdata(scenario.tasks)
 
@@ -268,7 +268,7 @@ def test_initialize_testdata_with_payload_context(grizzly_fixture: GrizzlyFixtur
 
         request.source = jsondumps(source)
 
-        grizzly.scenario.add_task(request)
+        grizzly.scenario.tasks.add(request)
 
         testdata, external_dependencies = initialize_testdata(grizzly.scenario.tasks)
 

--- a/tests/test_grizzly/users/test_blobstorage.py
+++ b/tests/test_grizzly/users/test_blobstorage.py
@@ -133,7 +133,7 @@ class TestBlobStorageUser:
         assert request_event.call_count == 1
         _, kwargs = request_event.call_args_list[-1]
 
-        assert kwargs.get('request_type', None) == 'bs:RECV'
+        assert kwargs.get('request_type', None) == 'RECV'
         assert kwargs.get('name', None) == f'{request.scenario.identifier} {request.scenario.name}'
         assert kwargs.get('response_time', -1) > -1
         assert kwargs.get('response_length', None) == 0

--- a/tests/test_grizzly/users/test_blobstorage.py
+++ b/tests/test_grizzly/users/test_blobstorage.py
@@ -43,7 +43,7 @@ def blob_storage_scenario(grizzly_fixture: GrizzlyFixture) -> BlobStorageScenari
 
     request.method = RequestMethod.SEND
 
-    scenario.add_task(request)
+    scenario.tasks.add(request)
 
     return cast(BlobStorageUser, user), scenario, environment
 

--- a/tests/test_grizzly/users/test_messagequeue.py
+++ b/tests/test_grizzly/users/test_messagequeue.py
@@ -49,7 +49,7 @@ def mq_user(grizzly_fixture: GrizzlyFixture) -> MqScenarioFixture:
     request.method = RequestMethod.SEND
     request.scenario = scenario
 
-    scenario.add_task(request)
+    scenario.tasks.add(request)
 
     return cast(MessageQueueUser, user), scenario, environment
 
@@ -212,7 +212,7 @@ class TestMessageQueueUser:
         scenario = GrizzlyContextScenario(3)
         scenario.name = 'test'
         scenario.failure_exception = StopUser
-        scenario.add_task(request)
+        scenario.tasks.add(request)
 
         with pytest.raises(StopUser):
             user.request(request)
@@ -252,7 +252,7 @@ class TestMessageQueueUser:
             scenario = GrizzlyContextScenario(1)
             scenario.name = 'test'
             scenario.failure_exception = StopUser
-            scenario.add_task(request)
+            scenario.tasks.add(request)
 
             MessageQueueUser.host = f'mq://{self.real_stuff["host"]}/?QueueManager={self.real_stuff["queue_manager"]}&Channel={self.real_stuff["channel"]}'
             user = MessageQueueUser(locust_fixture.env)
@@ -306,7 +306,7 @@ class TestMessageQueueUser:
             scenario = GrizzlyContextScenario(1)
             scenario.name = 'test'
             scenario.failure_exception = StopUser
-            scenario.add_task(request)
+            scenario.tasks.add(request)
 
             MessageQueueUser.host = f'mq://{self.real_stuff["host"]}/?QueueManager={self.real_stuff["queue_manager"]}&Channel={self.real_stuff["channel"]}'
             user = MessageQueueUser(locust_fixture.env)
@@ -393,7 +393,7 @@ class TestMessageQueueUser:
         request.endpoint = 'queue:test-queue'
         request.method = RequestMethod.GET
         request.source = None
-        scenario.add_task(request)
+        scenario.tasks.add(request)
 
         user.add_context(remote_variables)
 

--- a/tests/test_grizzly/users/test_messagequeue.py
+++ b/tests/test_grizzly/users/test_messagequeue.py
@@ -190,7 +190,7 @@ class TestMessageQueueUser:
             properties = list(kwargs.keys())
             # self.environment.events.request.fire
             if properties == ['request_type', 'name', 'response_time', 'response_length', 'context', 'exception']:
-                assert kwargs['request_type'] == 'mq:CONN'
+                assert kwargs['request_type'] == 'CONN'
                 assert kwargs['name'] == user.am_context.get('connection', None)
                 assert kwargs['response_time'] >= 0
                 assert kwargs['response_length'] == 0
@@ -401,12 +401,12 @@ class TestMessageQueueUser:
 
         assert request_event_spy.call_count == 2
         _, kwargs = request_event_spy.call_args_list[0]
-        assert kwargs['request_type'] == 'mq:CONN'
+        assert kwargs['request_type'] == 'CONN'
         assert kwargs['exception'] is None
         assert kwargs['response_length'] == 0
 
         _, kwargs = request_event_spy.call_args_list[1]
-        assert kwargs['request_type'] == 'mq:GET'
+        assert kwargs['request_type'] == 'GET'
         assert kwargs['exception'] is None
         assert kwargs['response_length'] == len(test_payload)
 
@@ -456,7 +456,7 @@ class TestMessageQueueUser:
         assert user.context_variables['payload_variable'] == ''
         assert request_event_spy.call_count == 1
         _, kwargs = request_event_spy.call_args_list[0]
-        assert kwargs['request_type'] == 'mq:GET'
+        assert kwargs['request_type'] == 'GET'
         assert isinstance(kwargs['exception'], ResponseHandlerError)
 
         assert response_event_spy.call_count == 1
@@ -740,12 +740,12 @@ class TestMessageQueueUser:
 
         assert request_event_spy.call_count == 2
         _, kwargs = request_event_spy.call_args_list[0]
-        assert kwargs['request_type'] == 'mq:CONN'
+        assert kwargs['request_type'] == 'CONN'
         assert kwargs['exception'] is None
         assert kwargs['response_length'] == 0
 
         _, kwargs = request_event_spy.call_args_list[1]
-        assert kwargs['request_type'] == 'mq:SEND'
+        assert kwargs['request_type'] == 'SEND'
         assert kwargs['exception'] is None
         assert kwargs['response_length'] == len(payload)
 

--- a/tests/test_grizzly/users/test_messagequeue.py
+++ b/tests/test_grizzly/users/test_messagequeue.py
@@ -359,7 +359,7 @@ class TestMessageQueueUser:
         )
 
         grizzly = GrizzlyContext()
-        grizzly._scenarios = [scenario]
+        grizzly.scenarios.append(scenario)
 
         user._context = {
             'auth': {

--- a/tests/test_grizzly/users/test_restapi.py
+++ b/tests/test_grizzly/users/test_restapi.py
@@ -46,7 +46,7 @@ def restapi_user(grizzly_fixture: GrizzlyFixture) -> RestApiScenarioFixture:
 
     request = grizzly_fixture.request_task.request
 
-    scenario.add_task(request)
+    scenario.tasks.add(request)
 
     return cast(RestApiUser, user), scenario
 
@@ -86,7 +86,7 @@ def test_refresh_token_client(restapi_user: RestApiScenarioFixture, mocker: Mock
         auth_client_context = auth_context['client']
         request_task = RequestTask(RequestMethod.POST, name='test-request', endpoint='/api/test')
         scenario.tasks.clear()
-        scenario.add_task(request_task)
+        scenario.tasks.add(request_task)
 
         # no authentication for api, request will be called which raises NotRefreshed
         assert user._context['auth']['url'] is None
@@ -165,7 +165,7 @@ def test_refresh_token_user(restapi_user: RestApiScenarioFixture, mocker: Mocker
         auth_user_context = auth_context['user']
         request_task = RequestTask(RequestMethod.POST, name='test-request', endpoint='/api/test')
         scenario.tasks.clear()
-        scenario.add_task(request_task)
+        scenario.tasks.add(request_task)
 
         # no authentication for api, request will be called which raises NotRefreshed
         assert auth_user_context['username'] is None

--- a/tests/test_grizzly/users/test_servicebus.py
+++ b/tests/test_grizzly/users/test_servicebus.py
@@ -258,7 +258,7 @@ class TestServiceBusUser:
         assert isinstance(kwargs.get('exception', None), NotImplementedError)
 
         _, kwargs = request_fire_spy.call_args_list[0]
-        assert kwargs.get('request_type', None) == 'sb:PUT'
+        assert kwargs.get('request_type', None) == 'PUT'
         assert kwargs.get('name', None) == f'{scenario.identifier} {task.name}'
         assert kwargs.get('response_time', None) >= 0.0
         assert kwargs.get('response_length', None) == 0
@@ -289,7 +289,7 @@ class TestServiceBusUser:
         assert isinstance(kwargs.get('exception', None), AsyncMessageError)
 
         _, kwargs = request_fire_spy.call_args_list[1]
-        assert kwargs.get('request_type', None) == 'sb:SEND'
+        assert kwargs.get('request_type', None) == 'SEND'
         assert kwargs.get('name', None) == f'{scenario.identifier} {task.name}'
         assert kwargs.get('response_time', None) >= 0.0
         assert kwargs.get('response_length', None) == 0
@@ -343,7 +343,7 @@ class TestServiceBusUser:
         assert kwargs.get('exception', '') is None
 
         _, kwargs = request_fire_spy.call_args_list[2]
-        assert kwargs.get('request_type', None) == 'sb:RECV'
+        assert kwargs.get('request_type', None) == 'RECV'
         assert kwargs.get('name', None) == f'{scenario.identifier} {task.name}'
         assert kwargs.get('response_time', None) >= 0.0
         assert kwargs.get('response_length', None) == 133
@@ -397,7 +397,7 @@ class TestServiceBusUser:
         assert kwargs.get('exception', '') is None
 
         _, kwargs = request_fire_spy.call_args_list[3]
-        assert kwargs.get('request_type', None) == 'sb:RECV'
+        assert kwargs.get('request_type', None) == 'RECV'
         assert kwargs.get('name', None) == f'{scenario.identifier} {task.name}'
         assert kwargs.get('response_time', None) >= 0.0
         assert kwargs.get('response_length', None) == 133

--- a/tests/test_grizzly/users/test_servicebus.py
+++ b/tests/test_grizzly/users/test_servicebus.py
@@ -73,10 +73,10 @@ class TestServiceBusUser:
             scenario.name = 'test'
             scenario.user.class_name = 'ServiceBusUser'
 
-            scenario.add_task(WaitTask(time=1.54))
-            scenario.add_task(RequestTask(RequestMethod.SEND, name='test-send', endpoint='{{ endpoint }}'))
-            scenario.add_task(RequestTask(RequestMethod.RECEIVE, name='test-receive', endpoint='queue:test-queue'))
-            scenario.add_task(RequestTask(RequestMethod.SEND, name='test-send', endpoint='topic:test-topic'))
+            scenario.tasks.add(WaitTask(time=1.54))
+            scenario.tasks.add(RequestTask(RequestMethod.SEND, name='test-send', endpoint='{{ endpoint }}'))
+            scenario.tasks.add(RequestTask(RequestMethod.RECEIVE, name='test-receive', endpoint='queue:test-queue'))
+            scenario.tasks.add(RequestTask(RequestMethod.SEND, name='test-send', endpoint='topic:test-topic'))
 
             ServiceBusUser.host = 'Endpoint=sb://sb.example.org/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc123def456ghi789='
             ServiceBusUser._scenario = scenario
@@ -110,7 +110,7 @@ class TestServiceBusUser:
         task = RequestTask(RequestMethod.SEND, name='test-send', endpoint='queue:"{{ queue_name }}"')
         scenario = GrizzlyContextScenario(1)
         scenario.name = 'test'
-        scenario.add_task(task)
+        scenario.tasks.add(task)
 
         with caplog.at_level(logging.WARNING):
             user.say_hello(task, task.endpoint)
@@ -145,7 +145,7 @@ class TestServiceBusUser:
         assert args[3] == 'sender=topic:test-topic'
 
         task = RequestTask(RequestMethod.RECEIVE, name='test-recv', endpoint='topic:test-topic, subscription:test-subscription')
-        scenario.add_task(task)
+        scenario.tasks.add(task)
 
         user.say_hello(task, task.endpoint)
 
@@ -236,7 +236,7 @@ class TestServiceBusUser:
         # unsupported request method
         task = RequestTask(RequestMethod.PUT, name='test-send', endpoint='queue:test-queue')
         task.source = 'hello'
-        scenario.add_task(task)
+        scenario.tasks.add(task)
         scenario.failure_exception = StopUser
         mocker.patch.object(user.zmq_client, 'disconnect', side_effect=[TypeError])
 

--- a/tests/test_grizzly/users/test_sftp.py
+++ b/tests/test_grizzly/users/test_sftp.py
@@ -111,7 +111,7 @@ class TestSftpUser:
             assert fire_spy.call_count == 1
             _, kwargs = fire_spy.call_args_list[-1]
 
-            assert kwargs.get('request_type', None) == 'sftp:SEND'
+            assert kwargs.get('request_type', None) == 'SEND'
             assert kwargs.get('name', None) == f'{request.scenario.identifier} test'
             assert kwargs.get('response_time', None) == 0
             assert kwargs.get('response_length', None) == 0
@@ -127,7 +127,7 @@ class TestSftpUser:
             assert fire_spy.call_count == 2
             _, kwargs = fire_spy.call_args_list[-1]
 
-            assert kwargs.get('request_type', None) == 'sftp:SEND'
+            assert kwargs.get('request_type', None) == 'SEND'
             assert kwargs.get('name', None) == f'{request.scenario.identifier} test'
             assert kwargs.get('response_time', None) == 0
             assert kwargs.get('response_length', None) == 0
@@ -143,7 +143,7 @@ class TestSftpUser:
             assert fire_spy.call_count == 3
             _, kwargs = fire_spy.call_args_list[-1]
 
-            assert kwargs.get('request_type', None) == 'sftp:SEND'
+            assert kwargs.get('request_type', None) == 'SEND'
             assert kwargs.get('name', None) == f'{request.scenario.identifier} test'
             assert kwargs.get('response_time', None) == 0
             assert kwargs.get('response_length', None) == 0
@@ -220,7 +220,7 @@ class TestSftpUser:
             assert fire_spy.call_count == 7
             _, kwargs = fire_spy.call_args_list[-1]
 
-            assert kwargs.get('request_type', None) == 'sftp:PUT'
+            assert kwargs.get('request_type', None) == 'PUT'
             assert kwargs.get('name', None) == f'{request.scenario.identifier} test'
             assert kwargs.get('response_time', None) == 0
             assert kwargs.get('response_length', None) == 100


### PR DESCRIPTION
new request type "SCEN", which is the total flow/scenario run time.
new request type "TSTD", which is the time it took to request testdata.

with this in place, it was possible to set failure status of scenarios and steps in behave statistics/summary and include actual number of executed iterations per scenario, and the status of the scenarios in the scenario summary printed at the end of a run.

Also, step `When response ... fail scenario` and been changed to the more correct `When response ... fail requests`, then how that failure is handled depends on `grizzly.scenario.failure_exception`.