### PR TITLE
possibility to register custom locust message types and handlers

### DIFF
--- a/example/features/environment.py
+++ b/example/features/environment.py
@@ -15,7 +15,7 @@ from grizzly.context import GrizzlyContext
 from grizzly.types import MessageDirection
 from locust.exception import StopUser
 
-from steps.custom import callback_server_client
+from steps.custom import callback_server_client  # pylint: disable=import-error
 
 
 def before_feature(context: Context, *args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> None:

--- a/example/features/environment.py
+++ b/example/features/environment.py
@@ -15,7 +15,7 @@ from grizzly.context import GrizzlyContext
 from grizzly.types import MessageDirection
 from locust.exception import StopUser
 
-from steps.custom import callback_example_message
+from steps.custom import callback_server_client
 
 
 def before_feature(context: Context, *args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> None:
@@ -27,7 +27,7 @@ def before_feature(context: Context, *args: Tuple[Any, ...], **kwargs: Dict[str,
 
     grizzly = cast(GrizzlyContext, context.grizzly)
 
-    grizzly.setup.locust.messages.register(MessageDirection.SERVER_CLIENT, 'example_message', callback_example_message)
+    grizzly.setup.locust.messages.register(MessageDirection.SERVER_CLIENT, 'server_client', callback_server_client)
 
 
 def before_scenario(

--- a/example/features/environment.py
+++ b/example/features/environment.py
@@ -5,14 +5,29 @@ from behave.model import Scenario
 
 # pylint: disable=unused-import
 from grizzly.environment import (  # noqa: F401
-    before_feature,
+    before_feature as grizzly_before_feature,
     after_feature,
     before_scenario as grizzly_before_scenario,
     after_scenario,
     before_step,
 )
 from grizzly.context import GrizzlyContext
+from grizzly.types import MessageDirection
 from locust.exception import StopUser
+
+from steps.custom import callback_example_message
+
+
+def before_feature(context: Context, *args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> None:
+    '''
+    Overloads before_feature from grizzly, to register custom message types and their callbacks,
+    which must be done before after_feature is called
+    '''
+    grizzly_before_feature(context, *args, **kwargs)
+
+    grizzly = cast(GrizzlyContext, context.grizzly)
+
+    grizzly.setup.locust.messages.register(MessageDirection.SERVER_CLIENT, 'example_message', callback_example_message)
 
 
 def before_scenario(

--- a/example/features/example.feature
+++ b/example/features/example.feature
@@ -2,21 +2,23 @@ Feature: grizzly example
   Background: common configuration
     Given "3" users
     And spawn rate is "1" user per second
+    And add callback "steps.custom.callback_client_server" for message type "client_server" from client to server
 
   Scenario: dog facts api
     Given a user of type "RestApi" load testing "$conf::facts.dog.host"
-    And repeat for "1" iteration
+    And repeat for "2" iterations
     And value for variable "AtomicRandomInteger.dog_facts_count" is "1..5"
     # custom step
     And also log successful requests
     Then get request with name "get-dog-facts" from endpoint "/api/v1/resources/dogs?number={{ AtomicRandomInteger.dog_facts_count }}"
-    Then send message to server
+    And send message "{'server': 'client'}"
 
   Scenario: cat facts api
     Given a user of type "steps.custom.User" load testing "$conf::facts.cat.host"
     And repeat for "1" iteration
     And value for variable "AtomicRandomInteger.cat_facts_count" is "1..5"
     Then get request with name "get-cat-facts" from endpoint "/facts?limit={{ AtomicRandomInteger.cat_facts_count }}"
+    And send message "{'client': 'server'}"
 
   Scenario: book api
     Given a user of type "RestApi" load testing "$conf::facts.book.host"

--- a/example/features/example.feature
+++ b/example/features/example.feature
@@ -10,9 +10,10 @@ Feature: grizzly example
     # custom step
     And also log successful requests
     Then get request with name "get-dog-facts" from endpoint "/api/v1/resources/dogs?number={{ AtomicRandomInteger.dog_facts_count }}"
+    Then send message to server
 
   Scenario: cat facts api
-    Given a user of type "RestApi" load testing "$conf::facts.cat.host"
+    Given a user of type "steps.custom.User" load testing "$conf::facts.cat.host"
     And repeat for "1" iteration
     And value for variable "AtomicRandomInteger.cat_facts_count" is "1..5"
     Then get request with name "get-cat-facts" from endpoint "/facts?limit={{ AtomicRandomInteger.cat_facts_count }}"

--- a/example/features/steps/custom.py
+++ b/example/features/steps/custom.py
@@ -1,9 +1,10 @@
+from json import loads as jsonloads
 from typing import Any, Callable, Dict
 
 from grizzly.scenarios import GrizzlyScenario
 from grizzly.users import RestApiUser
 from grizzly.tasks import RequestTask, GrizzlyTask
-from grizzly.types import GrizzlyResponse, Message, Environment, MasterRunner, LocalRunner
+from grizzly.types import GrizzlyResponse, Message, Environment, MasterRunner, WorkerRunner, LocalRunner
 
 
 class User(RestApiUser):
@@ -14,15 +15,29 @@ class User(RestApiUser):
 
 
 class Task(GrizzlyTask):
+    data: Dict[str, str]
+
+    def __init__(self, data: str) -> None:
+        self.data = jsonloads(data.replace("'", '"'))
+
     def __call__(self) -> Callable[[GrizzlyScenario], Any]:
         def implementation(parent: GrizzlyScenario) -> Any:
-            if isinstance(parent.grizzly.state.locust, (MasterRunner, LocalRunner,)):
-                parent.logger.info('sending "example_message" from SERVER')
-                parent.grizzly.state.locust.send_message('example_message', {'hello': 'world'})
+            if isinstance(parent.grizzly.state.locust, (MasterRunner, LocalRunner,)) and self.data.get('server', None) is not None:
+                parent.logger.info('sending "server_client" from SERVER')
+                parent.grizzly.state.locust.send_message('server_client', self.data)
+
+            if isinstance(parent.grizzly.state.locust, (WorkerRunner, LocalRunner,)) and self.data.get('client', None) is not None:
+                parent.logger.info('sending "client_server" from CLIENT')
+                parent.grizzly.state.locust.send_message('client_server', self.data)
 
         return implementation
 
 
-def callback_example_message(environment: Environment, msg: Message, **kwargs: Dict[str, Any]) -> None:
+def callback_server_client(environment: Environment, msg: Message, **kwargs: Dict[str, Any]) -> None:
     import logging
     logging.info(f'received from SERVER: {msg.node_id=}, {msg.data=}')
+
+
+def callback_client_server(environment: Environment, msg: Message) -> None:
+    import logging
+    logging.info(f'received from CLIENT: {msg.node_id=}, {msg.data=}')

--- a/example/features/steps/custom.py
+++ b/example/features/steps/custom.py
@@ -1,0 +1,28 @@
+from typing import Any, Callable, Dict
+
+from grizzly.scenarios import GrizzlyScenario
+from grizzly.users import RestApiUser
+from grizzly.tasks import RequestTask, GrizzlyTask
+from grizzly.types import GrizzlyResponse, Message, Environment, MasterRunner, LocalRunner
+
+
+class User(RestApiUser):
+    def request(self, request: RequestTask) -> GrizzlyResponse:
+        self.logger.info(f'executing custom.User.request for {request.name} and {request.endpoint}')
+
+        return super().request(request)
+
+
+class Task(GrizzlyTask):
+    def __call__(self) -> Callable[[GrizzlyScenario], Any]:
+        def implementation(parent: GrizzlyScenario) -> Any:
+            if isinstance(parent.grizzly.state.locust, (MasterRunner, LocalRunner,)):
+                parent.logger.info('sending "example_message" from SERVER')
+                parent.grizzly.state.locust.send_message('example_message', {'hello': 'world'})
+
+        return implementation
+
+
+def callback_example_message(environment: Environment, msg: Message, **kwargs: Dict[str, Any]) -> None:
+    import logging
+    logging.info(f'received from SERVER: {msg.node_id=}, {msg.data=}')

--- a/example/features/steps/steps.py
+++ b/example/features/steps/steps.py
@@ -30,11 +30,11 @@ def step_log_all_requests(context: Context) -> None:
     grizzly.scenario.context = merge_dicts(grizzly.scenario.context, context_variable)
 
 
-@then(u'send message to server')
-def setp_send_message_to_server(context: Context) -> None:
+@then(u'send message "{data}"')
+def step_send_message(context: Context, data: str) -> None:
     '''This step adds task steps.custom.Task to the scenario, which sends a message of type
     "example_message" from the server to the client, which will trigger the callback registered
     in `before_feature` in the projects `environment.py`.
     '''
     grizzly = cast(GrizzlyContext, context.grizzly)
-    grizzly.scenario.tasks.add(Task())
+    grizzly.scenario.tasks.add(Task(data))

--- a/example/features/steps/steps.py
+++ b/example/features/steps/steps.py
@@ -1,12 +1,14 @@
 from typing import cast
 
 from behave.runner import Context
-from behave import given  # pylint: disable=no-name-in-module
+from behave import given, then  # pylint: disable=no-name-in-module
 
 from grizzly.steps import *  # pylint: disable=unused-wildcard-import  # noqa: F401
 from grizzly.context import GrizzlyContext
 from grizzly.utils import merge_dicts
 from grizzly.testdata.utils import create_context_variable
+
+from steps.custom import Task
 
 
 @given(u'also log successful requests')
@@ -26,3 +28,13 @@ def step_log_all_requests(context: Context) -> None:
     grizzly = cast(GrizzlyContext, context.grizzly)
     context_variable = create_context_variable(grizzly, 'log_all_requests', 'True')
     grizzly.scenario.context = merge_dicts(grizzly.scenario.context, context_variable)
+
+
+@then(u'send message to server')
+def setp_send_message_to_server(context: Context) -> None:
+    '''This step adds task steps.custom.Task to the scenario, which sends a message of type
+    "example_message" from the server to the client, which will trigger the callback registered
+    in `before_feature` in the projects `environment.py`.
+    '''
+    grizzly = cast(GrizzlyContext, context.grizzly)
+    grizzly.scenario.tasks.add(Task())

--- a/example/features/steps/steps.py
+++ b/example/features/steps/steps.py
@@ -8,7 +8,7 @@ from grizzly.context import GrizzlyContext
 from grizzly.utils import merge_dicts
 from grizzly.testdata.utils import create_context_variable
 
-from steps.custom import Task
+from steps.custom import Task  # pylint: disable=import-error
 
 
 @given(u'also log successful requests')

--- a/grizzly/context.py
+++ b/grizzly/context.py
@@ -9,7 +9,7 @@ import yaml
 from behave.model import Scenario
 from locust.runners import Runner
 
-from .types import GrizzlyDict
+from .types import GrizzlyDict, MessageCallback, MessageDirection
 
 if TYPE_CHECKING:  # pragma: no cover
     from .tasks import GrizzlyTask, AsyncRequestGroupTask
@@ -168,6 +168,22 @@ class GrizzlyContextScenario:
         )
 
 
+class GrizzlyContextSetupLocustMessages(Dict[MessageDirection, Dict[str, MessageCallback]]):
+    def register(self, direction: MessageDirection, message_type: str, callback: MessageCallback) -> None:
+        if direction not in self:
+            self[direction] = {}
+
+        if message_type not in self[direction]:
+            self[direction][message_type] = callback
+        else:
+            raise AttributeError(f'message type {message_type} was already registered in direction {direction.name}')
+
+
+@dataclass
+class GrizzlyContextSetupLocust:
+    messages: GrizzlyContextSetupLocustMessages = field(default_factory=GrizzlyContextSetupLocustMessages)
+
+
 @dataclass
 class GrizzlyContextSetup:
     log_level: str = field(init=False, default='INFO')
@@ -179,6 +195,8 @@ class GrizzlyContextSetup:
     timespan: Optional[str] = field(init=False, default=None)
 
     statistics_url: Optional[str] = field(init=False, default=None)
+
+    locust: GrizzlyContextSetupLocust = field(init=False, default_factory=GrizzlyContextSetupLocust)
 
 
 class GrizzlyContextScenarios(List[GrizzlyContextScenario]):

--- a/grizzly/context.py
+++ b/grizzly/context.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 import yaml
 
 from behave.model import Scenario
-from locust.env import Environment
+from locust.runners import Runner
 
 from .types import GrizzlyDict
 
@@ -61,7 +61,7 @@ class GrizzlyContextState:
     configuration: Dict[str, Any] = field(init=False, default_factory=load_configuration_file)
     alias: Dict[str, str] = field(init=False, default_factory=dict)
     verbose: bool = field(default=False)
-    environment: Environment = field(init=False, repr=False)
+    locust: Runner = field(init=False, repr=False)
 
 
 @dataclass

--- a/grizzly/environment.py
+++ b/grizzly/environment.py
@@ -47,7 +47,7 @@ def after_feature(context: Context, feature: Feature, *args: Tuple[Any, ...], **
             feature.set_status(Status.failed)
 
         grizzly = cast(GrizzlyContext, context.grizzly)
-        stats = grizzly.state.environment.stats
+        stats = grizzly.state.locust.environment.stats
 
         for behave_scenario in cast(List[Scenario], feature.scenarios):
             grizzly_scenario = grizzly.scenarios.find_by_description(behave_scenario.name)

--- a/grizzly/environment.py
+++ b/grizzly/environment.py
@@ -16,7 +16,7 @@ from .utils import catch, fail_direct, in_correct_section
 from .types import RequestType
 
 
-def before_feature(context: Context, *_args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> None:
+def before_feature(context: Context, *args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> None:
     # identify as grizzly, instead of behave
     proc.setproctitle('grizzly')
 

--- a/grizzly/listeners/__init__.py
+++ b/grizzly/listeners/__init__.py
@@ -65,11 +65,11 @@ def init(grizzly: GrizzlyContext, testdata: Optional[TestdataType] = None) -> Ca
             runner.register_message('grizzly_worker_quit', grizzly_worker_quit)
 
         if not isinstance(runner, MasterRunner):
-            for message_type, callback in grizzly.setup.locust.messages.get(MessageDirection.FROM_MASTER, {}).items():
+            for message_type, callback in grizzly.setup.locust.messages.get(MessageDirection.SERVER_CLIENT, {}).items():
                 runner.register_message(message_type, callback)
 
         if not isinstance(runner, WorkerRunner):
-            for message_type, callback in grizzly.setup.locust.messages.get(MessageDirection.TO_MASTER, {}).items():
+            for message_type, callback in grizzly.setup.locust.messages.get(MessageDirection.CLIENT_SERVER, {}).items():
                 runner.register_message(message_type, callback)
 
     return cast(Callable[[Runner, KwArg(Dict[str, Any])], None], ginit)

--- a/grizzly/listeners/__init__.py
+++ b/grizzly/listeners/__init__.py
@@ -20,7 +20,7 @@ from locust.stats import (
 from behave.model import Status
 
 from ..context import GrizzlyContext
-from ..types import RequestType, TestdataType
+from ..types import MessageDirection, RequestType, TestdataType
 from ..testdata.communication import TestdataProducer
 
 producer: Optional[TestdataProducer] = None
@@ -41,7 +41,7 @@ def _init_testdata_producer(port: str, testdata: TestdataType, environment: Envi
     return gtestdata_producer
 
 
-def init(testdata: Optional[TestdataType] = None) -> Callable[[Runner, KwArg(Dict[str, Any])], None]:
+def init(grizzly: GrizzlyContext, testdata: Optional[TestdataType] = None) -> Callable[[Runner, KwArg(Dict[str, Any])], None]:
     def ginit(runner: Runner, **_kwargs: Dict[str, Any]) -> None:
         producer_port = environ.get('TESTDATA_PRODUCER_PORT', '5555')
         if not isinstance(runner, MasterRunner):
@@ -63,6 +63,14 @@ def init(testdata: Optional[TestdataType] = None) -> Callable[[Runner, KwArg(Dic
         else:
             logger.debug('registered message "grizzly_worker_quit"')
             runner.register_message('grizzly_worker_quit', grizzly_worker_quit)
+
+        if not isinstance(runner, MasterRunner):
+            for message_type, callback in grizzly.setup.locust.messages.get(MessageDirection.FROM_MASTER, {}).items():
+                runner.register_message(message_type, callback)
+
+        if not isinstance(runner, WorkerRunner):
+            for message_type, callback in grizzly.setup.locust.messages.get(MessageDirection.TO_MASTER, {}).items():
+                runner.register_message(message_type, callback)
 
     return cast(Callable[[Runner, KwArg(Dict[str, Any])], None], ginit)
 

--- a/grizzly/locust.py
+++ b/grizzly/locust.py
@@ -206,7 +206,7 @@ def setup_environment_listeners(context: Context, environment: Environment, task
 
         environment.events.quitting.add_listener(quitting)
 
-    environment.events.init.add_listener(init(testdata))
+    environment.events.init.add_listener(init(grizzly, testdata))
     environment.events.test_start.add_listener(locust_test_start(grizzly))
     environment.events.test_stop.add_listener(locust_test_stop)
 

--- a/grizzly/testdata/utils.py
+++ b/grizzly/testdata/utils.py
@@ -93,7 +93,7 @@ def transform(data: Dict[str, Any], objectify: Optional[bool] = True) -> Dict[st
                     logger.error(str(e), exc_info=grizzly.state.verbose)
                 finally:
                     response_time = int((time() - start_time) * 1000)
-                    grizzly.state.environment.events.request.fire(
+                    grizzly.state.locust.environment.events.request.fire(
                         request_type=RequestType.VARIABLE(),
                         name=key,
                         response_time=response_time,

--- a/grizzly/types.py
+++ b/grizzly/types.py
@@ -25,6 +25,13 @@ class MessageDirection(Enum):
     CLIENT_SERVER = 0
     SERVER_CLIENT = 1
 
+    @classmethod
+    def from_string(cls, value: str) -> 'MessageDirection':
+        try:
+            return cls[value.upper()]
+        except KeyError as e:
+            raise ValueError(f'"{value.upper()}" is not a valid value of {cls.__name__}') from e
+
 
 class ResponseTarget(Enum):
     METADATA = 0
@@ -49,7 +56,7 @@ class RequestDirection(Enum):
     @classmethod
     def from_string(cls, value: str) -> 'RequestDirection':
         try:
-            return RequestDirection[value.upper()]
+            return cls[value.upper()]
         except KeyError as e:
             raise ValueError(f'"{value.upper()}" is not a valid value of {cls.__name__}') from e
 

--- a/grizzly/types.py
+++ b/grizzly/types.py
@@ -10,16 +10,20 @@ from locust.clients import ResponseContextManager as RequestsResponseContextMana
 from locust.contrib.fasthttp import ResponseContextManager as FastResponseContextManager
 from locust.env import Environment
 from locust.rpc.protocol import Message
+from locust.runners import WorkerRunner, MasterRunner, LocalRunner
 
 __all__ = [
     'Message',
     'Environment',
+    'WorkerRunner',
+    'MasterRunner',
+    'LocalRunner',
 ]
 
 
 class MessageDirection(Enum):
-    TO_MASTER = 0
-    FROM_MASTER = 1
+    CLIENT_SERVER = 0
+    SERVER_CLIENT = 1
 
 
 class ResponseTarget(Enum):

--- a/grizzly/types.py
+++ b/grizzly/types.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from typing import Callable, Optional, Tuple, Any, Union, Dict, TypeVar, List, Type, Generic, Set, cast
+from mypy_extensions import KwArg, Arg
 from importlib import import_module
 
 from aenum import Enum as AdvancedEnum, NoAlias
@@ -7,6 +8,18 @@ from gevent.lock import Semaphore
 
 from locust.clients import ResponseContextManager as RequestsResponseContextManager
 from locust.contrib.fasthttp import ResponseContextManager as FastResponseContextManager
+from locust.env import Environment
+from locust.rpc.protocol import Message
+
+__all__ = [
+    'Message',
+    'Environment',
+]
+
+
+class MessageDirection(Enum):
+    TO_MASTER = 0
+    FROM_MASTER = 1
 
 
 class ResponseTarget(Enum):
@@ -117,6 +130,8 @@ HandlerContextType = Union[GrizzlyResponseContextManager, GrizzlyResponse]
 TestdataType = Dict[str, Dict[str, Any]]
 
 GrizzlyDictValueType = Union[str, float, int, bool]
+
+MessageCallback = Callable[[Arg(Environment, 'environment'), Arg(Message, 'msg'), KwArg(Dict[str, Any])], None]  # noqa: F821
 
 WrappedFunc = TypeVar('WrappedFunc', bound=Callable[..., Any])
 

--- a/tests/e2e/test_example.py
+++ b/tests/e2e/test_example.py
@@ -39,7 +39,20 @@ def test_e2e_example(webserver: Webserver) -> None:
             assert 'WARNING' not in result
             assert '1 feature passed, 0 failed, 0 skipped' in result
             assert '3 scenarios passed, 0 failed, 0 skipped' in result
-            assert '21 steps passed, 0 failed, 0 skipped, 0 undefined' in result
+            assert '22 steps passed, 0 failed, 0 skipped, 0 undefined' in result
+
+            assert '''Scenario
+ident   iter  status   description
+------|-----|--------|---------------|
+001      1/1  passed   dog facts api
+002      1/1  passed   cat facts api
+003      1/1  passed   book api
+------|-----|--------|---------------|''' in result
+
+            assert 'executing custom.User.request for get-cat-facts and /facts?limit=' in result
+
+            assert 'sending "example_message" from SERVER' in result
+            assert "received from SERVER: msg.node_id='local', msg.data={'hello': 'world'}" in result
     except:
         if result is not None:
             print(result)

--- a/tests/e2e/test_example.py
+++ b/tests/e2e/test_example.py
@@ -39,20 +39,22 @@ def test_e2e_example(webserver: Webserver) -> None:
             assert 'WARNING' not in result
             assert '1 feature passed, 0 failed, 0 skipped' in result
             assert '3 scenarios passed, 0 failed, 0 skipped' in result
-            assert '22 steps passed, 0 failed, 0 skipped, 0 undefined' in result
+            assert '24 steps passed, 0 failed, 0 skipped, 0 undefined' in result
 
             assert '''Scenario
 ident   iter  status   description
 ------|-----|--------|---------------|
-001      1/1  passed   dog facts api
+001      2/2  passed   dog facts api
 002      1/1  passed   cat facts api
 003      1/1  passed   book api
 ------|-----|--------|---------------|''' in result
 
             assert 'executing custom.User.request for get-cat-facts and /facts?limit=' in result
 
-            assert 'sending "example_message" from SERVER' in result
-            assert "received from SERVER: msg.node_id='local', msg.data={'hello': 'world'}" in result
+            assert 'sending "server_client" from SERVER' in result
+            assert "received from SERVER: msg.node_id='local', msg.data={'server': 'client'}" in result
+            assert 'sending "client_server" from CLIENT' in result
+            assert "received from CLIENT: msg.node_id='local', msg.data={'client': 'server'}" in result
     except:
         if result is not None:
             print(result)

--- a/tests/e2e/test_failure.py
+++ b/tests/e2e/test_failure.py
@@ -12,7 +12,7 @@ def test_e2e_failure(behave_context_fixture: BehaveContextFixture, webserver: We
     def after_feature(context: Context, feature: Feature) -> None:
         grizzly = cast(GrizzlyContext, context.grizzly)
 
-        stats = grizzly.state.environment.stats
+        stats = grizzly.state.locust.environment.stats
 
         expectations = [
             # failure exception is StopUser, abort user/scenario when there's a failure

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -10,9 +10,20 @@ from locust import task
 from locust.event import EventHook
 
 from grizzly.users.base import GrizzlyUser
-from grizzly.types import GrizzlyResponse, RequestMethod
+from grizzly.types import GrizzlyResponse, RequestMethod, Message, Environment
 from grizzly.tasks import RequestTask
 from grizzly.scenarios import GrizzlyScenario
+
+
+message_callback_not_a_method = True
+
+
+def message_callback(environment: Environment, msg: Message) -> None:
+    pass
+
+
+def message_callback_incorrect_sig(msg: Message, environment: Environment) -> Message:
+    pass
 
 
 class RequestCalled(Exception):

--- a/tests/test_grizzly/listeners/test___init__.py
+++ b/tests/test_grizzly/listeners/test___init__.py
@@ -122,8 +122,8 @@ def test_init_master(listener_test: Environment, caplog: LogCaptureFixture, griz
         def callback_ack(environment: Environment, msg: Message, **kwargs: Dict[str, Any]) -> None:
             pass
 
-        grizzly.setup.locust.messages.register(MessageDirection.TO_MASTER, 'test_message', callback)
-        grizzly.setup.locust.messages.register(MessageDirection.FROM_MASTER, 'test_message_ack', callback_ack)
+        grizzly.setup.locust.messages.register(MessageDirection.CLIENT_SERVER, 'test_message', callback)
+        grizzly.setup.locust.messages.register(MessageDirection.SERVER_CLIENT, 'test_message_ack', callback_ack)
 
         init_function = init(grizzly, {})
 
@@ -162,8 +162,8 @@ def test_init_worker(listener_test: Environment, grizzly_fixture: GrizzlyFixture
         def callback_ack(environment: Environment, msg: Message, **kwargs: Dict[str, Any]) -> None:
             pass
 
-        grizzly.setup.locust.messages.register(MessageDirection.TO_MASTER, 'test_message', callback)
-        grizzly.setup.locust.messages.register(MessageDirection.FROM_MASTER, 'test_message_ack', callback_ack)
+        grizzly.setup.locust.messages.register(MessageDirection.CLIENT_SERVER, 'test_message', callback)
+        grizzly.setup.locust.messages.register(MessageDirection.SERVER_CLIENT, 'test_message_ack', callback_ack)
 
         init_function(runner)
 
@@ -208,8 +208,8 @@ def test_init_local(listener_test: Environment, grizzly_fixture: GrizzlyFixture)
         def callback_ack(environment: Environment, msg: Message, **kwargs: Dict[str, Any]) -> None:
             pass
 
-        grizzly.setup.locust.messages.register(MessageDirection.TO_MASTER, 'test_message', callback)
-        grizzly.setup.locust.messages.register(MessageDirection.FROM_MASTER, 'test_message_ack', callback_ack)
+        grizzly.setup.locust.messages.register(MessageDirection.CLIENT_SERVER, 'test_message', callback)
+        grizzly.setup.locust.messages.register(MessageDirection.SERVER_CLIENT, 'test_message_ack', callback_ack)
 
         init_function(runner)
 

--- a/tests/test_grizzly/test_locust.py
+++ b/tests/test_grizzly/test_locust.py
@@ -347,6 +347,7 @@ def test_setup_environment_listeners(behave_fixture: BehaveFixture, mocker: Mock
         shape_class=None,
         events=events,
     )
+    grizzly.state.locust.environment = environment
 
     noop_zmq('grizzly.testdata.variables.messagequeue')
 
@@ -380,7 +381,7 @@ def test_setup_environment_listeners(behave_fixture: BehaveFixture, mocker: Mock
         assert len(environment.events.spawning_complete._handlers) == 1
         assert len(environment.events.quitting._handlers) == 0
         assert external_dependencies == set()
-        assert grizzly.state.environment is environment
+        assert grizzly.state.locust.environment is environment
 
         grizzly.setup.statistics_url = None
         grizzly.state.variables['AtomicIntegerIncrementer.value'] = '1 | step=10'
@@ -497,11 +498,11 @@ ident   iter  status      description
 
     grizzly.scenarios.create(behave_fixture.create_scenario('test-2-test-2-test-2-test-2'))
     grizzly.scenario.iterations = 4
-    stat = grizzly.state.environment.stats.get(grizzly.scenario.locust_name, RequestType.SCENARIO())
+    stat = grizzly.state.locust.environment.stats.get(grizzly.scenario.locust_name, RequestType.SCENARIO())
     stat.num_failures = 1
     stat.num_requests = 3
 
-    stat = grizzly.state.environment.stats.get(grizzly.scenarios[-2].locust_name, RequestType.SCENARIO())
+    stat = grizzly.state.locust.environment.stats.get(grizzly.scenarios[-2].locust_name, RequestType.SCENARIO())
     stat.num_failures = 0
     stat.num_requests = 1
 
@@ -519,7 +520,7 @@ ident   iter  status   description
     capsys.readouterr()
 
     grizzly.scenarios.create(behave_fixture.create_scenario('#3'))
-    stat = grizzly.state.environment.stats.get(grizzly.scenario.locust_name, RequestType.SCENARIO())
+    stat = grizzly.state.locust.environment.stats.get(grizzly.scenario.locust_name, RequestType.SCENARIO())
     stat.num_failures = 0
     stat.num_requests = 998
 


### PR DESCRIPTION
fixes #100.

access locust internals via `grizzly` context.

possibility to add message type callbacks both via code in `environment.py` or via a background step implementation.