### PR TITLE
`grizzly.tasks.client` must have a name

### DIFF
--- a/grizzly/steps/scenario/tasks.py
+++ b/grizzly/steps/scenario/tasks.py
@@ -335,8 +335,8 @@ def step_task_transform(context: Context, content: str, content_type: Transforme
     ))
 
 
-@then(u'get "{endpoint}" and save response in "{variable}"')
-def step_task_client_get_endpoint(context: Context, endpoint: str, variable: str) -> None:
+@then(u'get "{endpoint}" with name "{name}" and save response in "{variable}"')
+def step_task_client_get_endpoint(context: Context, endpoint: str, name: str, variable: str) -> None:
     '''Get information from another host or endpoint than the scenario is load testing and save the response in a variable.
 
     Task implementations are found in `grizzly.task.clients` and each implementation is looked up through the scheme in the
@@ -345,12 +345,13 @@ def step_task_client_get_endpoint(context: Context, endpoint: str, variable: str
     used by the task.
 
     ```gherkin
-    Then get "https://www.example.org/example.json" and save response in "example_openapi"
-    Then get "http://{{ endpoint }}" and save response in "endpoint_result"
+    Then get "https://www.example.org/example.json" with name "example-1" and save response in "example_openapi"
+    Then get "http://{{ endpoint }}" with name "example-2" and save response in "endpoint_result"
     ```
 
     Args:
         endpoint (str): information about where to get information, see the specific getter task implementations for more information
+        name (str): name of the request, used in request statistics
         variable (str): name of, initialized, variable where response will be saved in
     '''
     grizzly = cast(GrizzlyContext, context.grizzly)
@@ -360,12 +361,13 @@ def step_task_client_get_endpoint(context: Context, endpoint: str, variable: str
     grizzly.scenario.tasks.add(task_client(
         RequestDirection.FROM,
         endpoint,
+        name,
         variable=variable,
     ))
 
 
-@then(u'put "{source}" to "{endpoint}" as "{destination}"')
-def step_task_client_put_endpoint_file_destination(context: Context, source: str, endpoint: str, destination: str) -> None:
+@then(u'put "{source}" to "{endpoint}" with name "{name}" as "{destination}"')
+def step_task_client_put_endpoint_file_destination(context: Context, source: str, endpoint: str, name: str, destination: str) -> None:
     '''Put information to another host or endpoint than the scenario is load testing, source being a file.
 
     Task implementations are found in `grizzly.task.clients` and each implementation is looked up through the scheme in the
@@ -374,12 +376,13 @@ def step_task_client_put_endpoint_file_destination(context: Context, source: str
     used by the task.
 
     ```gherkin
-    Then put "test-file.json" to "bs://my-storage?AccountKey=aaaabbb=&Container=my-container" as "uploaded-test-file.json"
+    Then put "test-file.json" to "bs://my-storage?AccountKey=aaaabbb=&Container=my-container" with name "upload-file" as "uploaded-test-file.json"
     ```
 
     Args:
         source (str): relative path to file in `feature/requests`, supports templating
         endpoint (str): information about where to get information, see the specific getter task implementations for more information
+        name (str): name of the request, used in request statistics
         destination (str): name of source on the destination
     '''
     assert context.text is None, 'step text is not allowed for this step expression'
@@ -393,13 +396,14 @@ def step_task_client_put_endpoint_file_destination(context: Context, source: str
     grizzly.scenario.tasks.add(task_client(
         RequestDirection.TO,
         endpoint,
+        name,
         source=source,
         destination=destination,
     ))
 
 
-@then(u'put "{source}" to "{endpoint}"')
-def step_task_client_put_endpoint_file(context: Context, source: str, endpoint: str) -> None:
+@then(u'put "{source}" to "{endpoint}" with name "{name}"')
+def step_task_client_put_endpoint_file(context: Context, source: str, endpoint: str, name: str) -> None:
     '''Put information to another host or endpoint than the scenario is load testing, source being a file.
 
     Task implementations are found in `grizzly.task.clients` and each implementation is looked up through the scheme in the
@@ -408,12 +412,13 @@ def step_task_client_put_endpoint_file(context: Context, source: str, endpoint: 
     used by the task.
 
     ```gherkin
-    Then put "test-file.json" to "bs://my-storage?AccountKey=aaaabbb=&Container=my-container"
+    Then put "test-file.json" to "bs://my-storage?AccountKey=aaaabbb=&Container=my-container" with name "upload-file"
     ```
 
     Args:
         source (str): relative path to file in `feature/requests`, supports templating
         endpoint (str): information about where to get information, see the specific getter task implementations for more information
+        name (str): name of the request, used in request statistics
     '''
     assert context.text is None, 'step text is not allowed for this step expression'
 
@@ -426,6 +431,7 @@ def step_task_client_put_endpoint_file(context: Context, source: str, endpoint: 
     grizzly.scenario.tasks.add(task_client(
         RequestDirection.TO,
         endpoint,
+        name,
         source=source,
         destination=None,
     ))

--- a/grizzly/tasks/clients/__init__.py
+++ b/grizzly/tasks/clients/__init__.py
@@ -10,7 +10,7 @@ from ...types import RequestType, RequestDirection
 from .. import GrizzlyTask, template
 
 
-@template('endpoint', 'destination', 'source')
+@template('endpoint', 'destination', 'source', 'name')
 class ClientTask(GrizzlyTask):
     _schemes: List[str]
     _short_name: str
@@ -103,7 +103,8 @@ class ClientTask(GrizzlyTask):
                 action = meta.get('action', self.variable)
                 name = f'{parent.user._scenario.identifier} {self._short_name}{meta.get("direction", self._direction_arrow[self.direction])}{action}'
             else:
-                name = f'{parent.user._scenario.identifier} {self.name}'
+                rendered_name = parent.render(self.name)
+                name = f'{parent.user._scenario.identifier} {rendered_name}'
             response_time = int((time() - start_time) * 1000)
             response_length = meta.get('response_length', None) or 0
 

--- a/grizzly/tasks/clients/blobstorage.py
+++ b/grizzly/tasks/clients/blobstorage.py
@@ -58,13 +58,15 @@ class BlobStorageClientTask(ClientTask):
     def __init__(
         self,
         direction: RequestDirection,
-        endpoint: str, /,
+        endpoint: str,
+        name: Optional[str] = None,
+        /,
         variable: Optional[str] = None,
         source: Optional[str] = None,
         destination: Optional[str] = None,
         scenario: Optional[GrizzlyContextScenario] = None,
     ) -> None:
-        super().__init__(direction, endpoint, variable=variable, destination=destination, source=source, scenario=scenario)
+        super().__init__(direction, endpoint, name, variable=variable, destination=destination, source=source, scenario=scenario)
 
         parsed = urlparse(self.endpoint)
 

--- a/grizzly/tasks/clients/http.py
+++ b/grizzly/tasks/clients/http.py
@@ -8,8 +8,6 @@ Instances of this task is created with the step expression, if endpoint is defin
 '''
 from typing import Any
 
-from jinja2 import Template
-
 from . import client, ClientTask
 from ...scenarios import GrizzlyScenario
 
@@ -20,7 +18,7 @@ import requests
 class HttpClientTask(ClientTask):
     def get(self, parent: GrizzlyScenario) -> Any:
         with self.action(parent) as meta:
-            url = Template(self.endpoint).render(**parent.user._context['variables'])
+            url = parent.render(self.endpoint)
 
             response = requests.get(url)
             value = response.text

--- a/grizzly/tasks/clients/messagequeue.py
+++ b/grizzly/tasks/clients/messagequeue.py
@@ -76,7 +76,9 @@ class MessageQueueClientTask(ClientTask):
     def __init__(
         self,
         direction: RequestDirection,
-        endpoint: str, /,
+        endpoint: str,
+        name: Optional[str] = None,
+        /,
         variable: Optional[str] = None,
         source: Optional[str] = None,
         destination: Optional[str] = None,
@@ -88,7 +90,7 @@ class MessageQueueClientTask(ClientTask):
         if destination is not None:
             raise ValueError(f'{self.__class__.__name__}: destination is not allowed')
 
-        super().__init__(direction, endpoint, variable=variable, destination=destination, source=source, scenario=scenario)
+        super().__init__(direction, endpoint, name, variable=variable, destination=destination, source=source, scenario=scenario)
 
         self.create_context()
 
@@ -238,7 +240,7 @@ class MessageQueueClientTask(ClientTask):
 
     def request(self, parent: GrizzlyScenario, request: AsyncMessageRequest) -> AsyncMessageResponse:
         if self._worker is None:
-            with self.action(parent) as meta:
+            with self.action(parent, supress=True) as meta:
                 self.connect(meta)
 
         with self.action(parent) as meta:

--- a/tests/e2e/steps/scenario/test_tasks.py
+++ b/tests/e2e/steps/scenario/test_tasks.py
@@ -435,6 +435,7 @@ def test_e2e_step_task_client_get_endpoint(behave_context_fixture: BehaveContext
         assert isinstance(task, HttpClientTask)
         assert task.direction == RequestDirection.FROM
         assert task.endpoint == 'https://www.example.org/example.json'
+        assert task.name == 'https-get'
         assert task.variable == 'example_openapi', f'{task.variable} != example_openapi'
         assert task.source is None
         assert task.destination is None
@@ -445,6 +446,7 @@ def test_e2e_step_task_client_get_endpoint(behave_context_fixture: BehaveContext
         assert isinstance(task, HttpClientTask)
         assert task.direction == RequestDirection.FROM
         assert task.endpoint == '{{ endpoint }}'
+        assert task.name == 'http-get'
         assert task.variable == 'endpoint_result'
         assert task.source is None
         assert task.destination is None
@@ -459,8 +461,8 @@ def test_e2e_step_task_client_get_endpoint(behave_context_fixture: BehaveContext
         scenario=[
             'And value for variable "example_openapi" is "None"',
             'And value for variable "endpoint_result" is "None"',
-            'Then get "https://www.example.org/example.json" and save response in "example_openapi"',
-            'Then get "http://{{ endpoint }}" and save response in "endpoint_result"',
+            'Then get "https://www.example.org/example.json" with name "https-get" and save response in "example_openapi"',
+            'Then get "http://{{ endpoint }}" with name "http-get" and save response in "endpoint_result"',
         ]
     )
 
@@ -485,6 +487,7 @@ def test_e2e_step_task_client_put_endpoint_file_destination(behave_context_fixtu
         assert isinstance(task, BlobStorageClientTask)
         assert task.direction == RequestDirection.TO
         assert task.endpoint == 'bs://my-unsecure-storage?AccountKey=aaaabbb=&Container=my-container'
+        assert task.name == 'bs-put'
         assert task.variable is None
         assert task.source == 'test-file.json'
         assert task.destination == 'uploaded-test-file.json'
@@ -500,6 +503,7 @@ def test_e2e_step_task_client_put_endpoint_file_destination(behave_context_fixtu
         assert isinstance(task, BlobStorageClientTask)
         assert task.direction == RequestDirection.TO
         assert task.endpoint == 'bss://my-storage?AccountKey=aaaabbb=&Container=my-container'
+        assert task.name == 'bss-put'
         assert task.variable is None
         assert task.source == 'test-files.json'
         assert task.destination == 'uploaded-test-files.json'
@@ -517,8 +521,8 @@ def test_e2e_step_task_client_put_endpoint_file_destination(behave_context_fixtu
 
     feature_file = behave_context_fixture.test_steps(
         scenario=[
-            'Then put "test-file.json" to "bs://my-unsecure-storage?AccountKey=aaaabbb=&Container=my-container" as "uploaded-test-file.json"',
-            'Then put "test-files.json" to "bss://my-storage?AccountKey=aaaabbb=&Container=my-container" as "uploaded-test-files.json"',
+            'Then put "test-file.json" to "bs://my-unsecure-storage?AccountKey=aaaabbb=&Container=my-container" with name "bs-put" as "uploaded-test-file.json"',
+            'Then put "test-files.json" to "bss://my-storage?AccountKey=aaaabbb=&Container=my-container" with name "bss-put" as "uploaded-test-files.json"',
         ]
     )
 
@@ -543,6 +547,7 @@ def test_e2e_step_task_client_put_endpoint_file(behave_context_fixture: BehaveCo
         assert isinstance(task, BlobStorageClientTask)
         assert task.direction == RequestDirection.TO
         assert task.endpoint == 'bs://my-unsecure-storage?AccountKey=aaaabbb=&Container=my-container'
+        assert task.name == 'bs-put'
         assert task.variable is None
         assert task.source == 'test-file.json'
         assert task.destination is None
@@ -558,6 +563,7 @@ def test_e2e_step_task_client_put_endpoint_file(behave_context_fixture: BehaveCo
         assert isinstance(task, BlobStorageClientTask)
         assert task.direction == RequestDirection.TO
         assert task.endpoint == 'bss://my-storage?AccountKey=aaaabbb=&Container=my-container'
+        assert task.name == 'bss-put'
         assert task.variable is None
         assert task.source == 'test-files.json'
         assert task.destination is None
@@ -575,8 +581,8 @@ def test_e2e_step_task_client_put_endpoint_file(behave_context_fixture: BehaveCo
 
     feature_file = behave_context_fixture.test_steps(
         scenario=[
-            'Then put "test-file.json" to "bs://my-unsecure-storage?AccountKey=aaaabbb=&Container=my-container"',
-            'Then put "test-files.json" to "bss://my-storage?AccountKey=aaaabbb=&Container=my-container"',
+            'Then put "test-file.json" to "bs://my-unsecure-storage?AccountKey=aaaabbb=&Container=my-container" with name "bs-put"',
+            'Then put "test-files.json" to "bss://my-storage?AccountKey=aaaabbb=&Container=my-container" with name "bss-put"',
         ]
     )
 

--- a/tests/test_grizzly/steps/scenario/test_tasks.py
+++ b/tests/test_grizzly/steps/scenario/test_tasks.py
@@ -363,31 +363,31 @@ def test_step_task_client_get_endpoint(behave_fixture: BehaveFixture) -> None:
     grizzly = cast(GrizzlyContext, behave.grizzly)
 
     with pytest.raises(AssertionError) as ae:
-        step_task_client_get_endpoint(behave, 'obscure.example.com', 'test')
+        step_task_client_get_endpoint(behave, 'obscure.example.com', 'step-name', 'test')
     assert 'could not find scheme in "obscure.example.com"' in str(ae)
 
     with pytest.raises(AssertionError) as ae:
-        step_task_client_get_endpoint(behave, 'obscure://obscure.example.com', 'test')
+        step_task_client_get_endpoint(behave, 'obscure://obscure.example.com', 'step-name', 'test')
     assert 'no client task registered for obscure' in str(ae)
 
     with pytest.raises(ValueError) as ve:
-        step_task_client_get_endpoint(behave, 'http://www.example.org', 'test')
+        step_task_client_get_endpoint(behave, 'http://www.example.org', 'step-name', 'test')
     assert 'HttpClientTask: variable test has not been initialized' in str(ve)
 
     if pymqi.__name__ != 'grizzly_extras.dummy_pymqi':
         with pytest.raises(ValueError) as ve:
-            step_task_client_get_endpoint(behave, 'mq://mq.example.org', 'test')
+            step_task_client_get_endpoint(behave, 'mq://mq.example.org', 'step-name', 'test')
         assert 'MessageQueueClientTask: variable test has not been initialized' in str(ve)
 
     grizzly.state.variables['test'] = 'none'
 
     assert len(grizzly.scenario.tasks) == 0
-    step_task_client_get_endpoint(behave, 'http://www.example.org', 'test')
+    step_task_client_get_endpoint(behave, 'http://www.example.org', 'step-name', 'test')
     assert len(grizzly.scenario.tasks) == 1
     assert isinstance(grizzly.scenario.tasks[-1], HttpClientTask)
 
     grizzly.state.variables['endpoint_url'] = 'https://example.org'
-    step_task_client_get_endpoint(behave, 'https://{{ endpoint_url }}', 'test')
+    step_task_client_get_endpoint(behave, 'https://{{ endpoint_url }}', 'step-name', 'test')
 
     task = grizzly.scenario.tasks[-1]
     assert task.endpoint == '{{ endpoint_url }}'
@@ -427,16 +427,16 @@ def test_step_task_client_put_endpoint_file_destination(behave_fixture: BehaveFi
     assert len(grizzly.scenario.tasks) == 0
 
     with pytest.raises(AssertionError) as ae:
-        step_task_client_put_endpoint_file_destination(behave, 'file.json', 'http://example.org/put', 'uploaded-file.json')
+        step_task_client_put_endpoint_file_destination(behave, 'file.json', 'http://example.org/put', 'step-name', 'uploaded-file.json')
     assert 'step text is not allowed for this step expression' in str(ae.value)
 
     behave.text = None
 
     with pytest.raises(AssertionError) as ae:
-        step_task_client_put_endpoint_file_destination(behave, 'file-{{ suffix }}.json', 'http://{{ url }}', 'uploaded-file-{{ suffix }}.json')
+        step_task_client_put_endpoint_file_destination(behave, 'file-{{ suffix }}.json', 'http://{{ url }}', 'step-name', 'uploaded-file-{{ suffix }}.json')
     assert 'source file cannot be a template' == str(ae.value)
 
-    step_task_client_put_endpoint_file_destination(behave, 'file-test.json', 'http://{{ url }}', 'uploaded-file-{{ suffix }}.json')
+    step_task_client_put_endpoint_file_destination(behave, 'file-test.json', 'http://{{ url }}', 'step-name', 'uploaded-file-{{ suffix }}.json')
 
     assert len(grizzly.scenario.tasks) == 1
     task = grizzly.scenario.tasks[-1]
@@ -464,16 +464,16 @@ def test_step_task_client_put_endpoint_file(behave_fixture: BehaveFixture) -> No
     assert len(grizzly.scenario.tasks) == 0
 
     with pytest.raises(AssertionError) as ae:
-        step_task_client_put_endpoint_file(behave, 'file.json', 'http://example.org/put')
+        step_task_client_put_endpoint_file(behave, 'file.json', 'http://example.org/put', 'step-name')
     assert 'step text is not allowed for this step expression' in str(ae.value)
 
     behave.text = None
 
     with pytest.raises(AssertionError) as ae:
-        step_task_client_put_endpoint_file(behave, 'file-{{ suffix }}.json', 'http://{{ url }}')
+        step_task_client_put_endpoint_file(behave, 'file-{{ suffix }}.json', 'http://{{ url }}', 'step-name')
     assert 'source file cannot be a template' == str(ae.value)
 
-    step_task_client_put_endpoint_file(behave, 'file-test.json', 'http://{{ url }}')
+    step_task_client_put_endpoint_file(behave, 'file-test.json', 'http://{{ url }}', 'step-name')
 
     assert len(grizzly.scenario.tasks) == 1
     task = grizzly.scenario.tasks[-1]

--- a/tests/test_grizzly/tasks/clients/test_blobstorage.py
+++ b/tests/test_grizzly/tasks/clients/test_blobstorage.py
@@ -64,6 +64,7 @@ class TestBlobStorageClientTask:
 
         assert isinstance(task.service_client, BlobServiceClient)
         assert task.endpoint == 'bs://my-storage?AccountKey=aaaabbb=&Container=my-container'
+        assert task.name is None
         assert task.source == ''
         assert task.variable is None
         assert task.destination is None
@@ -76,11 +77,13 @@ class TestBlobStorageClientTask:
         task = BlobStorageClientTask(
             RequestDirection.TO,
             'bss://my-storage?AccountKey=aaaabbb=&Container=my-container',
+            'upload-empty-file',
             source='',
         )
 
         assert isinstance(task.service_client, BlobServiceClient)
         assert task.endpoint == 'bss://my-storage?AccountKey=aaaabbb=&Container=my-container'
+        assert task.name == 'upload-empty-file'
         assert task.source == ''
         assert task.variable is None
         assert task.destination is None
@@ -187,6 +190,7 @@ class TestBlobStorageClientTask:
             task_factory = BlobStorageClientTask(
                 RequestDirection.TO,
                 'bss://$conf::storage.account?AccountKey=$conf::storage.account_key&Container=$conf::storage.container',
+                'test-bss-request',
                 source='{{ source }}',
                 destination='{{ destination }}',
             )
@@ -211,7 +215,7 @@ class TestBlobStorageClientTask:
             assert request_fire_spy.call_count == 2
             _, kwargs = request_fire_spy.call_args_list[-1]
             assert kwargs.get('request_type', None) == 'CLTSK'
-            assert kwargs.get('name', None) == f'{scenario.user._scenario.identifier} BlobStorage->my-container'
+            assert kwargs.get('name', None) == f'{scenario.user._scenario.identifier} test-bss-request'
             assert kwargs.get('response_time', None) >= 0.0
             assert kwargs.get('response_length') == len('this is my hello world test!')
             assert kwargs.get('context', None) is scenario.user._context
@@ -233,7 +237,7 @@ class TestBlobStorageClientTask:
             assert request_fire_spy.call_count == 3
             _, kwargs = request_fire_spy.call_args_list[-1]
             assert kwargs.get('request_type', None) == 'CLTSK'
-            assert kwargs.get('name', None) == f'{scenario.user._scenario.identifier} BlobStorage->my-container'
+            assert kwargs.get('name', None) == f'{scenario.user._scenario.identifier} test-bss-request'
             assert kwargs.get('response_time', None) >= 0.0
             assert kwargs.get('response_length') == len('this is my hello world test!')
             assert kwargs.get('context', None) is scenario.user._context


### PR DESCRIPTION
implementation of #106. force a name for a request in the step
expressions, results in easier to read locust statistics.

also, only log failed connect requests in `MessageQueueClientTask`.