### PR TITLE
sort request statistics per scenario

### DIFF
--- a/grizzly/types.py
+++ b/grizzly/types.py
@@ -112,12 +112,30 @@ class RequestType(Enum, AdvancedEnum, init='alias _weight'):
         return cast(int, weight) if weight is not None else 10
 
     @classmethod
+    def get_method_weight(cls, method: str) -> int:
+        try:
+            request_type = cls.from_alias(method)
+            weight = request_type.weight
+        except AttributeError:
+            weight = 10
+
+        return weight
+
+    @classmethod
     def from_method(cls, request_type: RequestMethod) -> str:
         method_name = cast(Optional[RequestType], getattr(cls, request_type.name, None))
         if method_name is not None:
             return cast(str, method_name.alias)
 
         return request_type.name
+
+    @classmethod
+    def from_alias(cls, alias: str) -> 'RequestType':
+        for request_type in cls:
+            if request_type.alias == alias:
+                return request_type
+
+        raise AttributeError(f'no request type with alias {alias}')
 
     @classmethod
     def from_string(cls, key: str) -> str:

--- a/grizzly/types.py
+++ b/grizzly/types.py
@@ -89,28 +89,33 @@ class RequestMethod(Enum, AdvancedEnum, settings=NoAlias):
         return self.value
 
 
-class RequestType(Enum, AdvancedEnum, settings=NoAlias):
-    SCENARIO = 'SCEN'
-    TESTDATA = 'TSTD'
-    UNTIL = 'UNTL'
-    VARIABLE = 'VAR'
-    ASYNC_GROUP = 'ASYNC'
-    CLIENT_TASK = 'CLTSK'
-    HELLO = 'HELO'
-    RECEIVE = 'RECV'
-    CONNECT = 'CONN'
+class RequestType(Enum, AdvancedEnum, init='alias _weight'):
+    SCENARIO = ('SCEN', 0,)
+    TESTDATA = ('TSTD', 1,)
+    UNTIL = ('UNTL', None,)
+    VARIABLE = ('VAR', None,)
+    ASYNC_GROUP = ('ASYNC', None,)
+    CLIENT_TASK = ('CLTSK', None,)
+    HELLO = ('HELO', None,)
+    RECEIVE = ('RECV', None,)
+    CONNECT = ('CONN', None,)
 
     def __call__(self) -> str:
         return str(self)
 
     def __str__(self) -> str:
-        return self.value
+        return cast(str, getattr(self, 'alias'))
+
+    @property
+    def weight(self) -> int:
+        weight = getattr(self, '_weight', None)
+        return cast(int, weight) if weight is not None else 10
 
     @classmethod
     def from_method(cls, request_type: RequestMethod) -> str:
         method_name = cast(Optional[RequestType], getattr(cls, request_type.name, None))
         if method_name is not None:
-            return method_name.value
+            return cast(str, method_name.alias)
 
         return request_type.name
 
@@ -118,9 +123,9 @@ class RequestType(Enum, AdvancedEnum, settings=NoAlias):
     def from_string(cls, key: str) -> str:
         attribute = cast(Optional[RequestType], getattr(cls, key, None))
         if attribute is not None:
-            return attribute.value
+            return cast(str, attribute.alias)
 
-        if key in [e.value for e in cls]:
+        if key in [e.alias for e in cls]:
             return key
 
         attribute = cast(Optional[RequestMethod], getattr(RequestMethod, key, None))

--- a/tests/test_grizzly/test_types.py
+++ b/tests/test_grizzly/test_types.py
@@ -24,7 +24,8 @@ class TestRequestDirection:
 class TestRequestType:
     def test___str__(self) -> None:
         for custom_type in RequestType:
-            assert str(custom_type) == custom_type.value
+            assert str(custom_type) == custom_type.value[0]
+            assert custom_type.weight >= 0
 
     @pytest.mark.parametrize('input,expected', [
         (RequestMethod.GET, 'GET',),
@@ -36,11 +37,11 @@ class TestRequestType:
         assert RequestType.from_method(input) == expected
 
     @pytest.mark.parametrize('input,expected', [
-        (e.name, e.value,) for e in RequestType
+        (e.name, e.value[0],) for e in RequestType
     ] + [
         (e.name, e.name,) for e in RequestMethod if getattr(RequestType, e.name, None) is None
     ] + [
-        (e.value, e.value,) for e in RequestType
+        (e.value[0], e.value[0],) for e in RequestType
     ])
     def test_from_string(self, input: str, expected: str) -> None:
         assert RequestType.from_string(input) == expected
@@ -51,7 +52,18 @@ class TestRequestType:
 
     @pytest.mark.parametrize('input', [e for e in RequestType])
     def test___call___and___str__(self, input: RequestType) -> None:
-        assert input() == input.value == str(input)
+        assert input() == input.value[0] == str(input)
+
+    def test_weight(self) -> None:
+        assert RequestType.SCENARIO.weight == 0
+        assert RequestType.TESTDATA.weight > RequestType.SCENARIO.weight
+        assert RequestType.UNTIL.weight > RequestType.TESTDATA.weight
+        assert RequestType.VARIABLE.weight == RequestType.UNTIL.weight
+        assert RequestType.ASYNC_GROUP.weight == RequestType.VARIABLE.weight
+        assert RequestType.CLIENT_TASK.weight == RequestType.ASYNC_GROUP.weight
+        assert RequestType.HELLO.weight == RequestType.CLIENT_TASK.weight
+        assert RequestType.RECEIVE.weight == RequestType.HELLO.weight
+        assert RequestType.CONNECT.weight == RequestType.RECEIVE.weight
 
 
 class TestRequestMethod:

--- a/tests/test_grizzly/test_types.py
+++ b/tests/test_grizzly/test_types.py
@@ -65,6 +65,30 @@ class TestRequestType:
         assert RequestType.RECEIVE.weight == RequestType.HELLO.weight
         assert RequestType.CONNECT.weight == RequestType.RECEIVE.weight
 
+    def test_get_method_weight(self) -> None:
+        assert RequestType.get_method_weight('ASDF') == RequestType.get_method_weight('GET')
+        assert RequestType.get_method_weight('GET') == RequestType.get_method_weight('POST')
+        assert RequestType.get_method_weight('SCEN') == 0
+        assert RequestType.get_method_weight('TSTD') == 1
+
+        for request_type in RequestType:
+            if request_type.weight < 10:
+                continue
+
+            assert RequestType.get_method_weight(request_type.alias) == 10
+
+        for request_method in RequestMethod:
+            assert RequestType.get_method_weight(request_method.name) == 10
+
+    @pytest.mark.parametrize('alias,request_type', [(request_type.alias, request_type,) for request_type in RequestType])
+    def test_from_alias(self, alias: str, request_type: RequestType) -> None:
+        assert RequestType.from_alias(alias) == request_type
+
+    def test_from_alias_non_existing(self) -> None:
+        with pytest.raises(AttributeError) as ae:
+            RequestType.from_alias('ASDF')
+        assert str(ae.value) == 'no request type with alias ASDF'
+
 
 class TestRequestMethod:
     def test_from_string(self) -> None:


### PR DESCRIPTION
based on [the grizzly] request type weight. e.g. `SCEN` (Scenario) "request" should always be the first with in a scenario (based on `ident`).