### PR TITLE
request wait task

### DIFF
--- a/docs/usage/variables/environment-configuration.md
+++ b/docs/usage/variables/environment-configuration.md
@@ -3,7 +3,7 @@
 It is possible to make the feature file environment agnostic by providing a `yaml` file containing a dictionary with a root node named `configuration`.
 The environment configuration file can also be used to store credentials and other sensitive information that should not be under version control.
 
-Internally `grizzly` will check if the environment variable `GRIZZLY_CONFIGURATION_FILE` is set and contains a valid environment configuration file. When using `grizzly-cli` you specify the file with `-c/--configuration` which then will be set as a value for `GRIZZLY_CONFIGURATION_FILE`.
+Internally `grizzly` will check if the environment variable `GRIZZLY_CONFIGURATION_FILE` is set and contains a valid environment configuration file. When using `grizzly-cli` you specify the file with `-e/--environment-file` which then will be set as a value for `GRIZZLY_CONFIGURATION_FILE`.
 
 ## Format
 

--- a/grizzly/context.py
+++ b/grizzly/context.py
@@ -116,12 +116,6 @@ class GrizzlyContextState:
 
 
 @dataclass
-class GrizzlyContextScenarioWait:
-    minimum: float = field(default=1.0)
-    maximum: float = field(default=1.0)
-
-
-@dataclass
 class GrizzlyContextScenarioResponseTimePercentile:
     response_time: int
     percentile: float
@@ -171,7 +165,6 @@ class GrizzlyContextScenario:
 
     behave: Scenario = field(init=False, repr=False, hash=False, compare=False)
     context: Dict[str, Any] = field(init=False, repr=False, hash=False, compare=False, default_factory=dict)
-    wait: GrizzlyContextScenarioWait = field(init=False, repr=False, hash=False, compare=False, default_factory=GrizzlyContextScenarioWait)
     _tasks: GrizzlyContextTasks = field(init=False, repr=False, hash=False, compare=False)
     validation: GrizzlyContextScenarioValidation = field(init=False, hash=False, compare=False, default_factory=GrizzlyContextScenarioValidation)
     failure_exception: Optional[Type[Exception]] = field(init=False, default=None)

--- a/grizzly/steps/scenario/setup.py
+++ b/grizzly/steps/scenario/setup.py
@@ -98,26 +98,6 @@ def step_setup_iterations(context: Context, value: str, iteration_number: str) -
     grizzly.scenario.iterations = iterations
 
 
-@given(u'wait time inbetween requests is random between "{minimum:f}" and "{maximum:f}" seconds')
-def step_setup_wait_time(context: Context, minimum: float, maximum: float) -> None:
-    '''Set how long (seconds) locust should wait between tasks.
-
-    Default value is `1.0` seconds. Set `wait_min = wait_max` if the wait shouldn't be random in the
-    specified interval.
-
-    ```gherkin
-    And wait time inbetween requests is random between "0.3" and "0.5" seconds
-    ```
-
-    Args:
-        wait_min (float): minimum wait time
-        wait_max (float): maximum wait time
-    '''
-    grizzly = cast(GrizzlyContext, context.grizzly)
-    grizzly.scenario.wait.minimum = minimum
-    grizzly.scenario.wait.maximum = maximum
-
-
 @given(u'value for variable "{name}" is "{value}"')
 def step_setup_variable_value(context: Context, name: str, value: str) -> None:
     '''Initialize a variable.

--- a/grizzly/steps/scenario/tasks.py
+++ b/grizzly/steps/scenario/tasks.py
@@ -7,7 +7,7 @@ from behave import register_type, then, given  # pylint: disable=no-name-in-modu
 from ..helpers import add_request_task, get_task_client, is_template
 from ...types import RequestDirection, RequestMethod
 from ...context import GrizzlyContext
-from ...tasks import LogMessage, WaitTask, TransformerTask, UntilRequestTask, DateTask, AsyncRequestGroupTask, TimerTask
+from ...tasks import LogMessage, WaitTask, TransformerTask, UntilRequestTask, DateTask, AsyncRequestGroupTask, TimerTask, RequestWaitTask
 
 from grizzly_extras.transformer import TransformerContentType
 
@@ -576,3 +576,50 @@ def step_task_timer_stop(context: Context, name: str) -> None:
 
     grizzly.scenario.tasks.add(task)
     grizzly.scenario.timers.update({name: None})
+
+
+@given(u'wait "{min_time:g}..{max_time:g}" seconds between tasks')
+def step_task_request_wait_between(context: Context, min_time: float, max_time: float) -> None:
+    '''Set number of, randomly, seconds the user will wait between executing tasks.
+
+    ```gherkin
+    And wait randomly "1.4..1.7" seconds between tasks
+    # wait between 1.4 and 1.7 seconds
+    Then get request with name "test-get-1" from endpoint "..."
+    # wait between 1.4 and 1.7 seconds
+    Then get request with name "test-get-2" from endpoint "..."
+    # wait between 1.4 and 1.7 seconds
+    And wait "0.1" seconds between tasks
+    # wait 0.1 seconds
+    Then get request with name "test-get-3" from endpoint "..."
+    # wait 0.1 seconds
+    ...
+    ```
+    '''
+    grizzly = cast(GrizzlyContext, context.grizzly)
+    if min_time > max_time:
+        min_time, max_time = max_time, min_time
+
+    grizzly.scenario.tasks.add(RequestWaitTask(min_time=min_time, max_time=max_time))
+
+
+@given(u'wait "{time:g}" seconds between tasks')
+def step_task_request_wait_constant(context: Context, time: float) -> None:
+    '''Set number of, constant, seconds the user will wait between executing tasks.
+
+    ```gherkin
+    And wait "1.4" seconds between tasks
+    # wait 1.4 seconds
+    Then get request with name "test-get-1" from endpoint "..."
+    # wait 1.4 seconds
+    Then get request with name "test-get-2" from endpoint "..."
+    # wait 1.4 seconds
+    And wait "0.1" seconds between tasks
+    # wait 0.1 seconds
+    Then get request with name "test-get-3" from endpoint "..."
+    # wait 0.1 seconds
+    ...
+    ```
+    '''
+    grizzly = cast(GrizzlyContext, context.grizzly)
+    grizzly.scenario.tasks.add(RequestWaitTask(time))

--- a/grizzly/steps/scenario/tasks.py
+++ b/grizzly/steps/scenario/tasks.py
@@ -40,17 +40,17 @@ def step_task_request_with_name_to_endpoint_until(context: Context, method: Requ
 
     `condition` is a JSON- or Xpath expression, that also has support for "grizzly style" arguments:
 
+    __Endpoint Arguments__:
+
+    * `retries` (int): maximum number of times to repeat the request if `condition` is not met (default `3`)
+
+    * `wait` (float): number of seconds to wait between retries (default `1.0`)
+
     Args:
         method (RequestMethod): type of request
         name (str): name of the requests in logs, can contain variables
         direction (RequestDirection): one of `to` or `from` depending on the value of `method`
         endpoint (str): URI relative to `host` in the scenario, can contain variables and in certain cases `user_class_name` specific parameters
-
-    ## Arguments:
-
-    * `retries` (int): maximum number of times to repeat the request if `condition` is not met (default `3`)
-
-    * `wait` (float): number of seconds to wait between retries (default `1.0`)
     '''
 
     assert method.direction == RequestDirection.FROM, 'this step is only valid for request methods with direction FROM'
@@ -455,11 +455,7 @@ def step_task_date(context: Context, value: str, variable: str) -> None:
     Then parse date "{{ datetime.now() }} | offset=1Y" and save in variable "date3"
     ```
 
-    Args:
-        value (str): datetime string and arguments
-        variable (str): name of, initialized, variable where response will be saved in
-
-    ## Arguments
+    __Endpoint Arguments__:
 
     At least one of the following optional arguments **must** be specified:
 
@@ -468,6 +464,10 @@ def step_task_date(context: Context, value: str, variable: str) -> None:
     * `timezone` _str_ (optional) - a valid [timezone name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
 
     * `offset` _str_ (optional) - a time span string describing the offset, Y = years, M = months, D = days, h = hours, m = minutes, s = seconds, e.g. `1Y-2M10D`
+
+    Args:
+        value (str): datetime string and arguments
+        variable (str): name of, initialized, variable where response will be saved in
     '''
     grizzly = cast(GrizzlyContext, context.grizzly)
     assert variable in grizzly.state.variables, f'variable {variable} has not been initialized'
@@ -583,7 +583,7 @@ def step_task_request_wait_between(context: Context, min_time: float, max_time: 
     '''Set number of, randomly, seconds the user will wait between executing tasks.
 
     ```gherkin
-    And wait randomly "1.4..1.7" seconds between tasks
+    And wait "1.4..1.7" seconds between tasks
     # wait between 1.4 and 1.7 seconds
     Then get request with name "test-get-1" from endpoint "..."
     # wait between 1.4 and 1.7 seconds

--- a/grizzly/tasks/__init__.py
+++ b/grizzly/tasks/__init__.py
@@ -88,6 +88,7 @@ from .until import UntilRequestTask
 from .date import DateTask
 from .async_group import AsyncRequestGroupTask
 from .timer import TimerTask
+from .request_wait import RequestWaitTask
 
 
 __all__ = [
@@ -101,4 +102,5 @@ __all__ = [
     'DateTask',
     'AsyncRequestGroupTask',
     'TimerTask',
+    'RequestWaitTask',
 ]

--- a/grizzly/tasks/clients/messagequeue.py
+++ b/grizzly/tasks/clients/messagequeue.py
@@ -1,5 +1,5 @@
 # pylint: disable=line-too-long
-'''This task performs IBM MQM GET opertions to a specified queue or topic.
+'''This task performs IBM MQM get and put opertions to a specified queue or topic.
 
 This is useful if the scenario is another user type than `MessageQueueUser`, but the scenario still requires an action towards an MQ server.
 Use [transformer task](/grizzly/framework/usage/tasks/transformer/) to extract specific parts of the message.
@@ -35,6 +35,8 @@ All variables in the URL have support for [templating](/grizzly/framework/usage/
 Instances of this task is created with the step expression, if endpoint is defined with scheme `mq` or `mqs`:
 
 * [`step_task_client_get_endpoint`](/grizzly/framework/usage/steps/scenario/tasks/#step_task_client_get_endpoint)
+
+* [`step_task_client_put_endpoint_file`](/grizzly/framework/usage/steps/scenario/tasks/#step_task_client_put_endpoint_file)
 '''  # noqa: E501
 from typing import Optional, Dict, Any, List, cast
 from urllib.parse import urlparse, parse_qs, unquote

--- a/grizzly/tasks/request_wait.py
+++ b/grizzly/tasks/request_wait.py
@@ -1,8 +1,6 @@
-'''This task changes the default wait time between tasks that has been set with step:
+'''This task sets the wait time between tasks in a scenario.
 
-```gherkin
-And wait time inbetween requests is random between "1.0" and "1.0" seconds
-```
+The default is to wait `0` seconds between each task.
 
 This is useful in a scenario with many requests that should have some wait time between them, but there are a group
 of tasks (e.g. Transform, Date or Log Messages) that should execute as fast as possible.

--- a/grizzly/tasks/request_wait.py
+++ b/grizzly/tasks/request_wait.py
@@ -1,0 +1,46 @@
+'''This task changes the default wait time between tasks that has been set with step:
+
+```gherkin
+And wait time inbetween requests is random between "1.0" and "1.0" seconds
+```
+
+This is useful in a scenario with many requests that should have some wait time between them, but there are a group
+of tasks (e.g. Transform, Date or Log Messages) that should execute as fast as possible.
+
+Instances of this task is created with the step expression:
+
+* [`step_task_request_wait`](/grizzly/framework/usage/steps/scenario/tasks/#step_task_request_wait)
+'''
+from typing import TYPE_CHECKING, Optional, Callable, Any
+
+from locust import between, constant
+
+from . import GrizzlyTask
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ..scenarios import GrizzlyScenario
+    from ..context import GrizzlyContextScenario
+
+
+class RequestWaitTask(GrizzlyTask):
+    min_time: float
+    max_time: Optional[float]
+
+    def __init__(self, min_time: float, max_time: Optional[float] = None, scenario: Optional['GrizzlyContextScenario'] = None) -> None:
+        super().__init__(scenario)
+
+        self.min_time = min_time
+        self.max_time = max_time
+
+    def __call__(self) -> Callable[['GrizzlyScenario'], Any]:
+        def task(parent: 'GrizzlyScenario') -> Any:
+            if self.max_time is None:
+                wait_time = constant(self.min_time)
+            else:
+                wait_time = between(self.min_time, self.max_time)
+
+            bound_wait_time = wait_time.__get__(parent.user, parent.user.__class__)
+
+            setattr(parent.user, 'wait_time', bound_wait_time)
+
+        return task

--- a/grizzly/tasks/request_wait.py
+++ b/grizzly/tasks/request_wait.py
@@ -9,7 +9,9 @@ of tasks (e.g. Transform, Date or Log Messages) that should execute as fast as p
 
 Instances of this task is created with the step expression:
 
-* [`step_task_request_wait`](/grizzly/framework/usage/steps/scenario/tasks/#step_task_request_wait)
+* [`step_task_request_wait_constant`](/grizzly/framework/usage/steps/scenario/tasks/#step_task_request_wait_constant)
+
+* [`step_task_request_wait_between`](/grizzly/framework/usage/steps/scenario/tasks/#step_task_request_wait_between)
 '''
 from typing import TYPE_CHECKING, Optional, Callable, Any
 

--- a/grizzly/utils.py
+++ b/grizzly/utils.py
@@ -11,7 +11,6 @@ from copy import deepcopy
 
 from behave.runner import Context
 from behave.model import Scenario, Status
-from locust import between
 
 from .types import WrappedFunc, T
 
@@ -130,7 +129,6 @@ def create_user_class_type(scenario: 'GrizzlyContextScenario', global_context: O
         '__dependencies__': base_user_class_type.__dependencies__,
         '_context': context,
         '_scenario': scenario,
-        'wait_time': between(scenario.wait.minimum, scenario.wait.maximum),
         **distribution,
     })
 

--- a/grizzly/utils.py
+++ b/grizzly/utils.py
@@ -130,6 +130,7 @@ def create_user_class_type(scenario: 'GrizzlyContextScenario', global_context: O
         '__dependencies__': base_user_class_type.__dependencies__,
         '_context': context,
         '_scenario': scenario,
+        'wait_time': between(scenario.wait.minimum, scenario.wait.maximum),
         **distribution,
     })
 
@@ -146,7 +147,6 @@ def create_scenario_class_type(base_type: str, scenario: 'GrizzlyContextScenario
     return type(task_class_name, (base_task_class_type, ), {
         '__module__': base_task_class_type.__module__,
         'tasks': [],
-        'wait_time': between(scenario.wait.minimum, scenario.wait.maximum)
     })
 
 

--- a/pydoc-markdown.yaml
+++ b/pydoc-markdown.yaml
@@ -53,6 +53,9 @@ renderer:
           - title: Timer
             contents:
             - grizzly.tasks.timer
+          - title: Request Wait
+            contents:
+            - grizzly.tasks.request_wait
           - title: Clients
             children:
               - title: HTTP

--- a/tests/e2e/steps/scenario/test_setup.py
+++ b/tests/e2e/steps/scenario/test_setup.py
@@ -102,28 +102,6 @@ def test_e2e_step_setup_iterations(behave_context_fixture: BehaveContextFixture,
     assert rc == 0
 
 
-def test_e2e_step_setup_wait_time(behave_context_fixture: BehaveContextFixture) -> None:
-    def validate_wait_time(context: Context) -> None:
-        grizzly = cast(GrizzlyContext, context.grizzly)
-
-        assert grizzly.scenario.wait.minimum == 0.3
-        assert grizzly.scenario.wait.maximum == 0.5
-
-        raise SystemExit(0)
-
-    behave_context_fixture.add_validator(validate_wait_time)
-
-    feature_file = behave_context_fixture.test_steps(
-        scenario=[
-            'And wait time inbetween requests is random between "0.3" and "0.5" seconds',
-        ],
-    )
-
-    rc, _ = behave_context_fixture.execute(feature_file)
-
-    assert rc == 0
-
-
 def test_e2e_step_variable_value(behave_context_fixture: BehaveContextFixture) -> None:
     def validate_variable_value(context: Context) -> None:
         grizzly = cast(GrizzlyContext, context.grizzly)

--- a/tests/e2e/steps/scenario/test_tasks.py
+++ b/tests/e2e/steps/scenario/test_tasks.py
@@ -790,8 +790,20 @@ def test_e2e_step_task_request_wait(behave_context_fixture: BehaveContextFixture
         task = grizzly.scenario.tasks.pop()
 
         assert isinstance(task, RequestWaitTask), f'{type(task)} is not expected RequestWaitTask'
+        assert task.min_time == 15
+        assert task.max_time is None
+
+        task = grizzly.scenario.tasks.pop()
+
+        assert isinstance(task, RequestWaitTask), f'{type(task)} is not expected RequestWaitTask'
         assert task.min_time == 1.4
         assert task.max_time == 1.7
+
+        task = grizzly.scenario.tasks.pop()
+
+        assert isinstance(task, RequestWaitTask), f'{type(task)} is not expected RequestWaitTask'
+        assert task.min_time == 15
+        assert task.max_time == 18
 
         raise SystemExit(0)
 
@@ -799,7 +811,9 @@ def test_e2e_step_task_request_wait(behave_context_fixture: BehaveContextFixture
 
     feature_file = behave_context_fixture.test_steps(
         scenario=[
+            'Given wait "15..18" seconds between tasks',
             'And wait "1.4..1.7" seconds between tasks',
+            'Given wait "15" seconds between tasks',
             'And wait "1.4" seconds between tasks',
         ]
     )

--- a/tests/e2e/steps/scenario/test_tasks.py
+++ b/tests/e2e/steps/scenario/test_tasks.py
@@ -754,7 +754,6 @@ def test_e2e_step_task_timer_start_and_stop(behave_context_fixture: BehaveContex
 
     feature_file = behave_context_fixture.test_steps(
         scenario=[
-            'And wait time inbetween requests is random between "0.0" and "0.0" seconds',
             'Then print message "before-timer-1"',
             'Then start timer with name "timer-1"',
             'Then wait for "1.0" seconds',

--- a/tests/test_grizzly/steps/scenario/test_setup.py
+++ b/tests/test_grizzly/steps/scenario/test_setup.py
@@ -235,19 +235,6 @@ def test_step_setup_iterations(behave_fixture: BehaveFixture) -> None:
     assert grizzly.scenario.iterations == 13
 
 
-def test_step_setup_wait_time(behave_fixture: BehaveFixture) -> None:
-    behave = behave_fixture.context
-    grizzly = cast(GrizzlyContext, behave.grizzly)
-
-    assert grizzly.scenario.wait.minimum == 1.0
-    assert grizzly.scenario.wait.maximum == 1.0
-
-    step_setup_wait_time(behave, 8.3, 10.4)
-
-    assert grizzly.scenario.wait.minimum == 8.3
-    assert grizzly.scenario.wait.maximum == 10.4
-
-
 def test_step_setup_variable_value(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)

--- a/tests/test_grizzly/steps/scenario/test_tasks.py
+++ b/tests/test_grizzly/steps/scenario/test_tasks.py
@@ -8,7 +8,7 @@ from json import dumps as jsondumps
 from behave.model import Table, Row
 from grizzly.context import GrizzlyContext
 from grizzly.types import RequestMethod, RequestDirection
-from grizzly.tasks import TransformerTask, LogMessage, WaitTask, TimerTask
+from grizzly.tasks import TransformerTask, LogMessage, WaitTask, TimerTask, RequestWaitTask
 from grizzly.tasks.clients import HttpClientTask
 from grizzly.steps import *  # pylint: disable=unused-wildcard-import  # noqa: F403
 
@@ -561,3 +561,41 @@ def test_step_task_timer_start_and_stop(behave_fixture: BehaveFixture) -> None:
     }
 
     assert grizzly.scenario.tasks[-2] is grizzly.scenario.tasks[-1]
+
+
+def test_step_task_request_wait_between(behave_fixture: BehaveFixture) -> None:
+    behave = behave_fixture.context
+    grizzly = behave_fixture.grizzly
+
+    assert len(grizzly.scenario.tasks) == 0
+
+    step_task_request_wait_between(behave, 1.4, 1.7)
+
+    assert len(grizzly.scenario.tasks) == 1
+
+    task = cast(RequestWaitTask, grizzly.scenario.tasks[-1])
+    assert task.min_time == 1.4
+    assert task.max_time == 1.7
+
+    step_task_request_wait_between(behave, 30, 20)
+
+    assert len(grizzly.scenario.tasks) == 2
+
+    task = cast(RequestWaitTask, grizzly.scenario.tasks[-1])
+    assert task.min_time == 20
+    assert task.max_time == 30
+
+
+def test_step_task_request_wait_constant(behave_fixture: BehaveFixture) -> None:
+    behave = behave_fixture.context
+    grizzly = behave_fixture.grizzly
+
+    assert len(grizzly.scenario.tasks) == 0
+
+    step_task_request_wait_constant(behave, 10)
+
+    assert len(grizzly.scenario.tasks) == 1
+
+    task = cast(RequestWaitTask, grizzly.scenario.tasks[-1])
+    assert task.min_time == 10
+    assert task.max_time is None

--- a/tests/test_grizzly/tasks/test_request_wait.py
+++ b/tests/test_grizzly/tasks/test_request_wait.py
@@ -1,0 +1,42 @@
+import pytest
+
+from locust.exception import MissingWaitTimeError
+from grizzly.tasks import RequestWaitTask
+
+from ...fixtures import GrizzlyFixture
+
+
+class TestRequestWaitTask:
+    def test___init__(self) -> None:
+        task_factory = RequestWaitTask(1.0)
+
+        assert task_factory.min_time == 1.0
+        assert task_factory.max_time is None
+
+        task_factory = RequestWaitTask(2.0, 13.0)
+        assert task_factory.min_time == 2.0
+        assert task_factory.max_time == 13.0
+
+    def test___call__(self, grizzly_fixture: GrizzlyFixture) -> None:
+        _, _, scenario = grizzly_fixture()
+
+        assert scenario is not None
+
+        # force the scenario user to not have a wait_time method
+        scenario.user.wait_time = None
+
+        with pytest.raises(MissingWaitTimeError):
+            scenario.wait_time()
+
+        task = RequestWaitTask(1.0, 12.0)()
+
+        task(scenario)
+
+        wait_time = scenario.wait_time()
+        assert wait_time >= 1.0 and wait_time <= 12.0
+
+        task = RequestWaitTask(13.0)()
+
+        task(scenario)
+
+        assert scenario.wait_time() == 13.0

--- a/tests/test_grizzly/test_context.py
+++ b/tests/test_grizzly/test_context.py
@@ -17,7 +17,6 @@ from grizzly.context import (
     GrizzlyContextSetup,
     GrizzlyContextScenario,
     GrizzlyContextScenarioValidation,
-    GrizzlyContextScenarioWait,
     GrizzlyContextSetupLocust,
     GrizzlyContextSetupLocustMessages,
     GrizzlyContextState,
@@ -314,7 +313,6 @@ class TestGrizzlyContextScenario:
         assert not hasattr(scenario, 'user_class_name')
         assert scenario.iterations == 1
         assert scenario.context == {}
-        assert isinstance(scenario.wait, GrizzlyContextScenarioWait)
         assert scenario.tasks == []
         assert isinstance(scenario.validation, GrizzlyContextScenarioValidation)
         assert not scenario.failure_exception


### PR DESCRIPTION
a new task that changes how long the user will wait between executing tasks. doing it as a task, makes it possible to control the pace in the scenario during run time.

removed old step and context variables that would set it before.

**default before this change was constant 1.0 seconds between tasks, if not changed. with this change it will be 0 seconds, which is the default from `locust`**