### PR TITLE
allow an arbritary number of matches

### DIFF
--- a/grizzly/steps/_helpers.py
+++ b/grizzly/steps/_helpers.py
@@ -184,14 +184,16 @@ def _add_response_handler(
     if '|' in expression:
         expression, expression_arguments = split_value(expression)
         arguments = parse_arguments(expression_arguments)
-        unsupported_arguments = get_unsupported_arguments(['expected_matches'], arguments)
+        unsupported_arguments = get_unsupported_arguments(['expected_matches', 'as_json'], arguments)
 
         if len(unsupported_arguments) > 0:
             raise ValueError(f'unsupported arguments {", ".join(unsupported_arguments)}')
 
         expected_matches = int(arguments.get('expected_matches', '1'))
+        as_json = True if arguments.get('as_json', 'False') == 'True' else False
     else:
         expected_matches = 1
+        as_json = False
 
     # latest request
     request = grizzly.scenario.tasks()[-1]
@@ -219,6 +221,7 @@ def _add_response_handler(
             expression=expression,
             match_with=match_with,
             expected_matches=expected_matches,
+            as_json=as_json,
         )
     elif action == ResponseAction.VALIDATE:
         if condition is None:
@@ -229,6 +232,7 @@ def _add_response_handler(
             expression=expression,
             match_with=match_with,
             expected_matches=expected_matches,
+            as_json=as_json,
         )
 
     if target == ResponseTarget.METADATA:

--- a/grizzly/steps/scenario/tasks.py
+++ b/grizzly/steps/scenario/tasks.py
@@ -542,7 +542,7 @@ def step_task_async_group_close(context: Context) -> None:
     async_group = grizzly.scenario.tasks.tmp.async_group
 
     assert async_group is not None, 'no async request group is open'
-    assert len(async_group.requests) > 0, f'there are no requests in async group "{async_group.name}"'
+    assert len(async_group.tasks) > 0, f'there are no requests in async group "{async_group.name}"'
 
     grizzly.scenario.tasks.tmp.async_group = None
     grizzly.scenario.tasks.add(async_group)

--- a/grizzly/tasks/__init__.py
+++ b/grizzly/tasks/__init__.py
@@ -15,8 +15,8 @@ a step implementation is also needed.
 
 There are examples of this in the {@link framework.example}.
 '''
-from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Callable, List, Type, Set, Optional
+from abc import ABC, ABCMeta, abstractmethod
+from typing import TYPE_CHECKING, Any, Callable, List, Type, Set, Optional, Union, Dict
 from os import environ
 from pathlib import Path
 
@@ -84,7 +84,10 @@ class GrizzlyTask(ABC):
         return list(templates)
 
 
-class GrizzlyTaskWrapper(ABC):
+class GrizzlyTaskWrapper(GrizzlyTask, metaclass=ABCMeta):
+    name: str
+    list: Union[List[GrizzlyTask], Dict[str, GrizzlyTask]]
+
     @abstractmethod
     def add(self, task: GrizzlyTask) -> None:
         raise NotImplementedError(f'{self.__class__.__name__} has not implemented add')

--- a/grizzly/tasks/conditional.py
+++ b/grizzly/tasks/conditional.py
@@ -40,7 +40,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from ..context import GrizzlyContextScenario
 
 from . import GrizzlyTask, GrizzlyTaskWrapper, template
-from ..exceptions import RestartScenario, StopScenario, StopUser
 
 
 @template('condition')
@@ -119,9 +118,6 @@ class ConditionalTask(GrizzlyTask, GrizzlyTaskWrapper):
             except Exception as e:
                 exception = e
             finally:
-                if isinstance(exception, (RestartScenario, StopUser, StopScenario,)):
-                    raise exception
-
                 response_time = int((perf_counter() - start) * 1000)
 
                 parent.user.environment.events.request.fire(

--- a/grizzly/tasks/conditional.py
+++ b/grizzly/tasks/conditional.py
@@ -43,7 +43,7 @@ from . import GrizzlyTask, GrizzlyTaskWrapper, template
 
 
 @template('condition')
-class ConditionalTask(GrizzlyTask, GrizzlyTaskWrapper):
+class ConditionalTask(GrizzlyTaskWrapper):
     tasks: Dict[bool, List[GrizzlyTask]]
 
     name: str

--- a/grizzly/tasks/loop.py
+++ b/grizzly/tasks/loop.py
@@ -38,7 +38,7 @@ from . import GrizzlyTask, GrizzlyTaskWrapper, template
 
 
 @template('values')
-class LoopTask(GrizzlyTask, GrizzlyTaskWrapper):
+class LoopTask(GrizzlyTaskWrapper):
     tasks: List[GrizzlyTask]
 
     name: str

--- a/grizzly/tasks/loop.py
+++ b/grizzly/tasks/loop.py
@@ -35,7 +35,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from ..context import GrizzlyContextScenario, GrizzlyContext
 
 from . import GrizzlyTask, GrizzlyTaskWrapper, template
-from ..exceptions import RestartScenario, StopScenario, StopUser
 
 
 @template('values')
@@ -101,9 +100,6 @@ class LoopTask(GrizzlyTask, GrizzlyTaskWrapper):
                         del parent.user._context['variables'][self.variable]
                     except:
                         pass
-
-                if isinstance(exception, (RestartScenario, StopUser, StopScenario,)):
-                    raise exception
 
                 response_time = int((perf_counter() - start) * 1000)
 

--- a/tests/e2e/steps/scenario/test_tasks.py
+++ b/tests/e2e/steps/scenario/test_tasks.py
@@ -683,9 +683,9 @@ def test_e2e_step_async_group(behave_context_fixture: BehaveContextFixture) -> N
             'async-group-{{ index }}:test-get-1',
         ]), str(task.get_templates())
         assert task.name == 'async-group-{{ index }}'
-        assert len(task.requests) == 2
+        assert len(task.tasks) == 2
 
-        request = task.requests[0]
+        request = task.tasks[0]
         assert isinstance(request, RequestTask)
         assert request.method == RequestMethod.POST
         assert request.name == 'async-group-{{ index }}:test-post-1'
@@ -695,7 +695,7 @@ def test_e2e_step_async_group(behave_context_fixture: BehaveContextFixture) -> N
         assert jsonloads(request.source) == {'value': 'i have good news!'}
         assert request.get_templates() == ['async-group-{{ index }}:test-post-1']
 
-        request = task.requests[1]
+        request = task.tasks[1]
         assert isinstance(request, RequestTask)
         assert request.method == RequestMethod.GET
         assert request.name == 'async-group-{{ index }}:test-get-1'

--- a/tests/test_grizzly/steps/test__helpers.py
+++ b/tests/test_grizzly/steps/test__helpers.py
@@ -357,6 +357,17 @@ def test_add_save_handler(behave_fixture: BehaveFixture, locust_fixture: LocustF
 
         assert handler.expression == '$.test.value'
         assert handler.expected_matches == 100
+        assert not handler.as_json
+
+        add_save_handler(grizzly, ResponseTarget.PAYLOAD, '$.test.value | expected_matches=-1, as_json=True', '.*', 'test')
+        assert len(task.response.handlers.metadata) == 1
+        assert len(task.response.handlers.payload) == 3
+
+        handler = task.response.handlers.payload[-1]
+
+        assert handler.expression == '$.test.value'
+        assert handler.expected_matches == -1
+        assert handler.as_json
 
         with pytest.raises(ValueError) as ve:
             add_save_handler(grizzly, ResponseTarget.PAYLOAD, '$.test.value | expected_matches=100, foobar=False, hello=world', '.*', 'test')

--- a/tests/test_grizzly/tasks/test_async_group.py
+++ b/tests/test_grizzly/tasks/test_async_group.py
@@ -24,13 +24,13 @@ class TestAsyncRequestGroup:
     def test__init__(self) -> None:
         task_factory = AsyncRequestGroupTask(name='test')
 
-        assert isinstance(task_factory.requests, list)
-        assert len(task_factory.requests) == 0
+        assert isinstance(task_factory.tasks, list)
+        assert len(task_factory.tasks) == 0
         assert task_factory.name == 'test'
 
     def test_add(self) -> None:
         task_factory = AsyncRequestGroupTask(name='test')
-        requests = cast(List[RequestTask], task_factory.requests)
+        requests = cast(List[RequestTask], task_factory.tasks)
         assert len(requests) == 0
 
         task_factory.add(RequestTask(RequestMethod.GET, name='test', endpoint='/api/test'))
@@ -45,7 +45,7 @@ class TestAsyncRequestGroup:
     @pytest.mark.parametrize('affix', [True, False])
     def test_get_templates(self, affix: bool) -> None:
         task_factory = AsyncRequestGroupTask(name='async-{{ name }}')
-        assert len(task_factory.requests) == 0
+        assert len(task_factory.tasks) == 0
 
         name_template = 'test-'
         if affix:
@@ -55,7 +55,7 @@ class TestAsyncRequestGroup:
         task_factory.add(RequestTask(RequestMethod.GET, name=f'{name_template}-2', endpoint='/api/test'))
         task_factory.add(RequestTask(RequestMethod.GET, name=f'{name_template}-3', endpoint='/api/test'))
 
-        assert len(task_factory.requests) == 3
+        assert len(task_factory.tasks) == 3
         assert sorted(task_factory.get_templates()) == sorted([
             'async-{{ name }}',
             f'async-{{{{ name }}}}:{name_template}-1',
@@ -72,7 +72,7 @@ class TestAsyncRequestGroup:
         scenario_context.name = scenario_context.description = 'test scenario'
 
         task_factory = AsyncRequestGroupTask(name='test-async-group', scenario=scenario_context)
-        requests = cast(List[RequestTask], task_factory.requests)
+        requests = cast(List[RequestTask], task_factory.tasks)
         task = task_factory()
 
         with pytest.raises(NotImplementedError) as nie:
@@ -117,16 +117,16 @@ class TestAsyncRequestGroup:
 
         task(scenario)
 
-        assert spawn_mock.call_count == len(task_factory.requests)
+        assert spawn_mock.call_count == len(task_factory.tasks)
         args, _ = spawn_mock.call_args_list[0]
-        assert args[1] is task_factory.requests[0]
+        assert args[1] is task_factory.tasks[0]
         args, _ = spawn_mock.call_args_list[1]
-        assert args[1] is task_factory.requests[1]
+        assert args[1] is task_factory.tasks[1]
         assert settrace_mock.call_count == 0
 
         assert joinall_mock.call_count == 2
         args, _ = joinall_mock.call_args_list[-1]
-        assert len(args[0]) == len(task_factory.requests)
+        assert len(args[0]) == len(task_factory.tasks)
 
         assert requests_event_mock.call_count == 2
         _, kwargs = requests_event_mock.call_args_list[-1]
@@ -195,7 +195,7 @@ class TestAsyncRequestGroup:
         task_factory.add(RequestTask(RequestMethod.GET, name='sleep-1', endpoint='/api/sleep/1', scenario=context_scenario))
         # task_factory.add(RequestTask(RequestMethod.POST, name='post-echo', endpoint='/api/echo', source='{"foo": "bar"}', scenario=context_scenario))
 
-        assert len(task_factory.requests) == 3
+        assert len(task_factory.tasks) == 3
 
         task = task_factory()
         caplog.handler.formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')

--- a/tests/test_grizzly/users/base/test_response_handler.py
+++ b/tests/test_grizzly/users/base/test_response_handler.py
@@ -596,6 +596,61 @@ class TestSaveHandlerAction:
             300,
         ]
 
+        handler = SaveHandlerAction(
+            'test_list',
+            expression='$.test[?hello="world"].value',
+            match_with='.*',
+            expected_matches=-1,
+            as_json=True,
+        )
+
+        handler(
+            (
+                TransformerContentType.JSON,
+                {
+                    'test': [
+                        {
+                            'hello': 'world',
+                            'value': 'prop41',
+                        }
+                    ],
+                }
+            ),
+            user,
+            response_context_manager,
+        )
+
+        test_list = user.context_variables.get('test_list', None)
+        assert jsonloads(test_list) == [
+            'prop41',
+        ]
+
+        handler(
+            (
+                TransformerContentType.JSON,
+                {
+                    'test': [
+                        {
+                            'hello': 'world',
+                            'value': 'prop41',
+                        },
+                        {
+                            'hello': 'world',
+                            'value': 'prop42',
+                        },
+                    ],
+                }
+            ),
+            user,
+            response_context_manager,
+        )
+
+        test_list = user.context_variables.get('test_list', None)
+        assert jsonloads(test_list) == [
+            'prop41',
+            'prop42',
+        ]
+
 
 class TestResponseHandler:
     def test___init__(self, locust_fixture: LocustFixture) -> None:


### PR DESCRIPTION
and save as a list, even though there's only one match (ResponseHandlerAction).

Keep track of tmp tasks in a stack, so we can have nested `GrizzlyTasksWrappers` and close them one-by-one and add tasks in the correct one.