### PR TITLE
create zmq socket for each request

### DIFF
--- a/grizzly/tasks/clients/__init__.py
+++ b/grizzly/tasks/clients/__init__.py
@@ -15,6 +15,8 @@ If `endpoint` is a template variable which includes the scheme, the scheme for t
 correct `grizzly.tasks.client` implementation is used. The additional scheme will be removed when the request is
 performed.
 '''
+import logging
+
 from abc import abstractmethod
 from typing import Dict, Generator, Type, List, Any, Optional, Callable
 from contextlib import contextmanager
@@ -159,6 +161,8 @@ class client:
         return impl
 
 
+logger = logging.getLogger(__name__)
+
 from .http import HttpClientTask
 from .blobstorage import BlobStorageClientTask
 from .messagequeue import MessageQueueClientTask
@@ -168,4 +172,5 @@ __all__ = [
     'HttpClientTask',
     'BlobStorageClientTask',
     'MessageQueueClientTask',
+    'logger',
 ]

--- a/grizzly/testdata/communication.py
+++ b/grizzly/testdata/communication.py
@@ -126,7 +126,7 @@ class TestdataProducer:
 
         self._stopping = False
 
-        self.logger.debug(f'servering:\n{self.testdata}')
+        self.logger.debug(f'serving:\n{self.testdata}')
 
     def reset(self) -> None:
         self.logger.debug('reseting')


### PR DESCRIPTION
since tasks runs in greenlets, they should not share the zmq.Socket.