### PR TITLE
env conf inline resolving and "generic" `UntilRequestTask`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -89,8 +89,14 @@
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",
 	"features": {
-		"docker-from-docker": "latest",
-		"git": "os-provided",
-		"github-cli": "latest"
+        "ghcr.io/devcontainers/features/docker-from-docker:1": {
+            "version": "latest"
+        },
+        "ghcr.io/devcontainers/features/git:1": {
+            "version": "os-provided"
+        },
+        "ghcr.io/devcontainers/features/github-cli:1": {
+            "version": "latest"
+        }
 	}
 }

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -110,6 +110,8 @@ jobs:
     - name: checkout
       id: checkout
       uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - name: setup python
       id: setup-python

--- a/docs/content/framework/usage/variables/environment-configuration.md
+++ b/docs/content/framework/usage/variables/environment-configuration.md
@@ -1,6 +1,7 @@
 ---
 title: Environment configuration
 ---
+@anchor framework.usage.variables.environment_configuration Environment configuration
 
 It is possible to make the feature file environment agnostic by providing a `yaml` file containing a dictionary with a root node named `configuration`.
 The environment configuration file can also be used to store credentials and other sensitive information that should not be under version control.
@@ -27,7 +28,7 @@ The only rule for any nodes under `configuration` is that it **must** be a dicti
 
 ## Usage
 
-In a feature file the dictionary can then be used by prefixing the path of a node under `configuration` with `$conf::`.
+In a feature file the dictionary can then be used by prefixing the path of a node under `configuration` with `$conf::<tree path to variable>$`.
 
 Example:
 
@@ -39,13 +40,13 @@ Feature: application test
     And stop on first failure
 
   Scenario: frontend
-    Given a user of type "RestApi" load testing "$conf::frontend.host"
+    Given a user of type "RestApi" load testing "$conf::frontend.host$"
     ...
 
   Scenario: backend
-    Given a user of type "RestApi" load testing "$conf::backend.host"
-    And set context variable "auth.user.username" to "$conf::backend.auth.user.username"
-    And set context variable "auth.user.password" to "$conf::backend.auth.user.password"
+    Given a user of type "RestApi" load testing "$conf::backend.host$"
+    And set context variable "auth.user.username" to "$conf::backend.auth.user.username$"
+    And set context variable "auth.user.password" to "$conf::backend.auth.user.password$"
 ```
 
 This feature can now be run against a different environment just by creating a new environment configuration file with different values.

--- a/docs/content/framework/usage/variables/templating.md
+++ b/docs/content/framework/usage/variables/templating.md
@@ -1,10 +1,12 @@
 ---
 title: Templating
 ---
-@anchor framework.usage.variables.templating
+@anchor framework.usage.variables.templating Templating
 # Templating
 
-`grizzly` has support for templating in both step expression variables (most) and request payload, with the templating backend [Jinja2](https://jinja.palletsprojects.com/en/3.0.x/).
+`grizzly` has support for templating in both step expression variables (most) and request payload, with the templating backend [Jinja2](https://jinja.palletsprojects.com/en/3.0.x/),
+and also `grizzly` specific templating variables from environment variables or environment configuration files. The later is resolved **before** a test is started, while the former
+is resolved during run time. See {@link framework.usage.variables.environment_configuration} on how to use `$conf::`-variables.
 
 ## Request payload
 
@@ -127,10 +129,10 @@ The third post request:
 Most step expressions also support templating for their variables, for example:
 
 ```gherkin
-And set context variable "auth.user.username" to "$conf::backend.auth.user.username"
+And set context variable "auth.user.username" to "$conf::backend.auth.user.username$"
 And set context variable "auth.refresh_time" to "{{ AtomicIntegerIncrementer.refresh_time }}"
 And repeat for "{{ iterations * 0.25 }}"
-And save statistics to "influxdb://$conf::statistics.username:$conf::statistics.password@{{ influxdb_host }}/$conf::statistics.database"
+And save statistics to "influxdb://$conf::statistics.username$:$conf::statistics.password$@{{ influxdb_host }}/$conf::statistics.database$"
 And ask for value of variable "initial_id"
 And value for variable "AtomicIntegerIncrementer.id1" is "{{ initial_id }}"
 And value for variable "AtomicIntegerIncrementer.id2" is "{{ initial_id }}"

--- a/example/features/example.feature
+++ b/example/features/example.feature
@@ -5,7 +5,7 @@ Feature: grizzly example
     And add callback "steps.custom.callback_client_server" for message type "client_server" from client to server
 
   Scenario: dog facts api
-    Given a user of type "RestApi" load testing "$conf::facts.dog.host"
+    Given a user of type "RestApi" load testing "$conf::facts.dog.host$"
     And repeat for "2" iterations
     And value for variable "AtomicRandomInteger.dog_facts_count" is "1..5"
     # custom step
@@ -14,14 +14,14 @@ Feature: grizzly example
     And send message "{'server': 'client'}"
 
   Scenario: cat facts api
-    Given a user of type "steps.custom.User" load testing "$conf::facts.cat.host"
+    Given a user of type "steps.custom.User" load testing "$conf::facts.cat.host$"
     And repeat for "1" iteration
     And value for variable "AtomicRandomInteger.cat_facts_count" is "1..5"
     Then get request with name "get-cat-facts" from endpoint "/facts?limit={{ AtomicRandomInteger.cat_facts_count }}"
     And send message "{'client': 'server'}"
 
   Scenario: book api
-    Given a user of type "RestApi" load testing "$conf::facts.book.host"
+    Given a user of type "RestApi" load testing "$conf::facts.book.host$"
     And repeat for "1" iteration
     And value for variable "AtomicCsvRow.books" is "books/books.csv | random=True"
     And value for variable "steps.custom.AtomicCustomVariable.foobar" is "foobar"

--- a/grizzly/steps/_helpers.py
+++ b/grizzly/steps/_helpers.py
@@ -25,17 +25,29 @@ logger = logging.getLogger(__name__)
 
 
 def create_request_task(
-    context: Context, method: RequestMethod, source: Optional[str], endpoint: str, name: Optional[str] = None, substitutes: Optional[Dict[str, str]] = None,
+    context: Context,
+    method: RequestMethod,
+    source: Optional[str],
+    endpoint: str,
+    name: Optional[str] = None,
+    substitutes: Optional[Dict[str, str]] = None,
+    content_type: Optional[TransformerContentType] = None,
 ) -> RequestTask:
     grizzly = cast(GrizzlyContext, context.grizzly)
-    request = _create_request_task(context.config.base_dir, method, source, endpoint, name, substitutes=substitutes)
+    request = _create_request_task(context.config.base_dir, method, source, endpoint, name, substitutes=substitutes, content_type=content_type)
     request.scenario = grizzly.scenario
 
     return request
 
 
 def _create_request_task(
-    base_dir: str, method: RequestMethod, source: Optional[str], endpoint: str, name: Optional[str] = None, substitutes: Optional[Dict[str, str]] = None,
+    base_dir: str,
+    method: RequestMethod,
+    source: Optional[str],
+    endpoint: str,
+    name: Optional[str] = None,
+    substitutes: Optional[Dict[str, str]] = None,
+    content_type: Optional[TransformerContentType] = None,
 ) -> RequestTask:
     path = os.path.join(base_dir, 'requests')
     j2env = j2.Environment(

--- a/grizzly/steps/_helpers.py
+++ b/grizzly/steps/_helpers.py
@@ -104,8 +104,8 @@ def add_request_task(
     table: List[Optional[Row]]
     content_type: Optional[TransformerContentType] = None
 
-    if endpoint is not None and endpoint[:4] in ['$env', '$con']:
-        endpoint = cast(str, resolve_variable(grizzly, endpoint, guess_datatype=False))
+    if endpoint is not None and ('$env::' in endpoint or '$conf::' in endpoint):
+        endpoint = cast(str, resolve_variable(grizzly, endpoint, guess_datatype=False, only_grizzly=True))
 
     if context.table is not None:
         table = context.table

--- a/grizzly/steps/scenario/tasks.py
+++ b/grizzly/steps/scenario/tasks.py
@@ -377,6 +377,30 @@ def step_task_client_get_endpoint(context: Context, endpoint: str, name: str, va
     ))
 
 
+@then(u'get "{endpoint}" with name "{name}" until "{expression}"')
+def step_task_client_get_endpoint_until(context: Context, endpoint: str, name: str, expression: str) -> None:
+    """
+    Creates an instance of a {@pylink grizzly.tasks.clients} task, actual implementation of the task is determined
+    based on the URL scheme specified in `endpoint`. Gets information, repeated from another host or endpoint than the scenario
+    is load testing until the response matches `expression`.
+
+    See {@pylink grizzly.tasks.clients} task documentation for more information about client tasks.
+
+    Example:
+
+    ``` gherkin
+    Then get "https://www.example.org/example.json" with name "example-1" until "$.response[status='Success']
+    Then get "http://{{ endpoint }}" with name "example-2" until "//*[@status='Success']"
+    ```
+
+    Args:
+        endpoint (str): information about where to get information, see the specific getter task implementations for more information
+        name (str): name of the request, used in request statistics
+        expression (str): JSON or XPath expression for specific value in response payload
+    """
+    pass
+
+
 @then(u'put "{source}" to "{endpoint}" with name "{name}" as "{destination}"')
 def step_task_client_put_endpoint_file_destination(context: Context, source: str, endpoint: str, name: str, destination: str) -> None:
     """

--- a/grizzly/tasks/__init__.py
+++ b/grizzly/tasks/__init__.py
@@ -20,13 +20,16 @@ from typing import TYPE_CHECKING, Any, Callable, List, Type, Set, Optional
 from os import environ
 from pathlib import Path
 
+from grizzly_extras.transformer import TransformerContentType
+
 if TYPE_CHECKING:  # pragma: no cover
     from ..scenarios import GrizzlyScenario
     from ..context import GrizzlyContextScenario
+    from ..types import GrizzlyResponse
 
 
 class GrizzlyTask(ABC):
-    __template_attributes__: List[str]
+    __template_attributes__: List[str] = []
 
     _context_root: str
 
@@ -76,10 +79,6 @@ class GrizzlyTask(ABC):
 
             return templates
 
-        # tasks with no @template decorator
-        if not hasattr(self, '__template_attributes__'):
-            return []
-
         templates: Set[str] = set()
         for attribute in self.__template_attributes__:
             value = getattr(self, attribute, None)
@@ -89,6 +88,15 @@ class GrizzlyTask(ABC):
             templates.update(_get_value_templates(value))
 
         return list(templates)
+
+
+class GrizzlyMetaRequestTask(GrizzlyTask, metaclass=ABCMeta):
+    content_type: TransformerContentType
+    name: Optional[str]
+    endpoint: str
+
+    def execute(self, parent: 'GrizzlyScenario') -> 'GrizzlyResponse':
+        raise NotImplementedError(f'{self.__class__.name} has not implemented "execute"')
 
 
 class GrizzlyTaskWrapper(GrizzlyTask, metaclass=ABCMeta):

--- a/grizzly/tasks/clients/__init__.py
+++ b/grizzly/tasks/clients/__init__.py
@@ -37,7 +37,7 @@ from .. import GrizzlyMetaRequestTask, template
 @template('endpoint', 'destination', 'source', 'name')
 class ClientTask(GrizzlyMetaRequestTask):
     _schemes: List[str]
-    _schema: str
+    _scheme: str
     _short_name: str
     _direction_arrow: Dict[RequestDirection, str] = {
         RequestDirection.FROM: '<-',
@@ -79,7 +79,7 @@ class ClientTask(GrizzlyMetaRequestTask):
         if parsed.scheme not in self._schemes:
             raise AttributeError(f'{self.__class__.__name__}: "{parsed.scheme}" is not supported, must be one of {", ".join(self._schemes)}')
 
-        self._schema = parsed.scheme
+        self._scheme = parsed.scheme
 
         content_type: TransformerContentType = TransformerContentType.UNDEFINED
 

--- a/grizzly/tasks/clients/__init__.py
+++ b/grizzly/tasks/clients/__init__.py
@@ -37,6 +37,7 @@ from .. import GrizzlyMetaRequestTask, template
 @template('endpoint', 'destination', 'source', 'name')
 class ClientTask(GrizzlyMetaRequestTask):
     _schemes: List[str]
+    _schema: str
     _short_name: str
     _direction_arrow: Dict[RequestDirection, str] = {
         RequestDirection.FROM: '<-',
@@ -77,6 +78,8 @@ class ClientTask(GrizzlyMetaRequestTask):
 
         if parsed.scheme not in self._schemes:
             raise AttributeError(f'{self.__class__.__name__}: "{parsed.scheme}" is not supported, must be one of {", ".join(self._schemes)}')
+
+        self._schema = parsed.scheme
 
         content_type: TransformerContentType = TransformerContentType.UNDEFINED
 

--- a/grizzly/tasks/clients/blobstorage.py
+++ b/grizzly/tasks/clients/blobstorage.py
@@ -42,7 +42,7 @@ The MIME type of an uploaded file will automagically be guessed based on the [re
 '''
 import logging
 
-from typing import Any, Optional, cast
+from typing import Optional, cast
 from urllib.parse import urlparse, parse_qs
 from pathlib import Path
 from mimetypes import guess_type as mimetype_guess
@@ -53,7 +53,7 @@ from azure.storage.blob import BlobServiceClient, ContentSettings
 from . import client, ClientTask
 from ...scenarios import GrizzlyScenario
 from ...context import GrizzlyContextScenario
-from ...types import RequestDirection
+from ...types import RequestDirection, GrizzlyResponse
 from ...testdata.utils import resolve_variable
 
 # disable verbose INFO logging
@@ -108,10 +108,10 @@ class BlobStorageClientTask(ClientTask):
     def connection_string(self) -> str:
         return f'DefaultEndpointsProtocol={self._endpoints_protocol};AccountName={self.account_name};AccountKey={self.account_key};EndpointSuffix=core.windows.net'
 
-    def get(self, parent: GrizzlyScenario) -> Any:
+    def get(self, parent: GrizzlyScenario) -> GrizzlyResponse:
         return super().get(parent)
 
-    def put(self, parent: GrizzlyScenario) -> Any:
+    def put(self, parent: GrizzlyScenario) -> GrizzlyResponse:
         source = parent.render(cast(str, self.source))
 
         if self.destination is not None:
@@ -137,3 +137,5 @@ class BlobStorageClientTask(ClientTask):
             with self.service_client.get_blob_client(container=self.container, blob=destination) as blob_client:
                 blob_client.upload_blob(source, content_settings=content_settings)
                 meta['response_length'] = len(source)
+
+        return None, None

--- a/grizzly/tasks/clients/http.py
+++ b/grizzly/tasks/clients/http.py
@@ -16,20 +16,58 @@ Only supports `RequestDirection.FROM`.
 
 * `name` _str_ - name used in `locust` statistics
 '''
+from typing import Optional, Dict, Any
+
+from grizzly_extras.arguments import split_value, parse_arguments
+
 from . import client, ClientTask
 from ...scenarios import GrizzlyScenario
-from ...types import GrizzlyResponse
+from ...types import GrizzlyResponse, RequestDirection, bool_type
+from ...context import GrizzlyContextScenario
 
 import requests
 
 
 @client('http', 'https')
 class HttpClientTask(ClientTask):
+    arguments: Dict[str, Any]
+
+    def __init__(
+        self,
+        direction: RequestDirection,
+        endpoint: str,
+        name: Optional[str] = None,
+        /,
+        variable: Optional[str] = None,
+        source: Optional[str] = None,
+        destination: Optional[str] = None,
+        scenario: Optional[GrizzlyContextScenario] = None,
+    ) -> None:
+        verify = True
+
+        if '|' in endpoint:
+            endpoint, endpoint_arguments = split_value(endpoint)
+            arguments = parse_arguments(endpoint_arguments, unquote=False)
+
+            if 'verify' in arguments:
+                verify = bool_type(arguments['verify'])
+                del arguments['verify']
+
+            if len(arguments) > 0:
+                endpoint = f'{endpoint} | {", ".join([f"{key}={value}" for key, value in arguments.items()])}'
+
+        super().__init__(direction, endpoint, name, variable=variable, source=source, destination=destination, scenario=scenario)
+
+        self.arguments = {}
+
+        if self._schema == 'https':
+            self.arguments = {'verify': verify}
+
     def get(self, parent: GrizzlyScenario) -> GrizzlyResponse:
         with self.action(parent) as meta:
             url = parent.render(self.endpoint)
 
-            response = requests.get(url)
+            response = requests.get(url, **self.arguments)
             value = response.text
             if self.variable is not None:
                 parent.user._context['variables'][self.variable] = value

--- a/grizzly/tasks/clients/http.py
+++ b/grizzly/tasks/clients/http.py
@@ -31,6 +31,7 @@ import requests
 @client('http', 'https')
 class HttpClientTask(ClientTask):
     arguments: Dict[str, Any]
+    headers: Dict[str, str]
 
     def __init__(
         self,
@@ -59,15 +60,18 @@ class HttpClientTask(ClientTask):
         super().__init__(direction, endpoint, name, variable=variable, source=source, destination=destination, scenario=scenario)
 
         self.arguments = {}
+        self.headers = {
+            'x-grizzly-user': f'{self.__class__.__name__}::{id(self)}'
+        }
 
-        if self._schema == 'https':
+        if self._scheme == 'https':
             self.arguments = {'verify': verify}
 
     def get(self, parent: GrizzlyScenario) -> GrizzlyResponse:
         with self.action(parent) as meta:
             url = parent.render(self.endpoint)
 
-            response = requests.get(url, **self.arguments)
+            response = requests.get(url, headers=self.headers, **self.arguments)
             value = response.text
             if self.variable is not None:
                 parent.user._context['variables'][self.variable] = value

--- a/grizzly/tasks/clients/http.py
+++ b/grizzly/tasks/clients/http.py
@@ -16,24 +16,26 @@ Only supports `RequestDirection.FROM`.
 
 * `name` _str_ - name used in `locust` statistics
 '''
-from typing import Any
-
 from . import client, ClientTask
 from ...scenarios import GrizzlyScenario
+from ...types import GrizzlyResponse
 
 import requests
 
 
 @client('http', 'https')
 class HttpClientTask(ClientTask):
-    def get(self, parent: GrizzlyScenario) -> Any:
+    def get(self, parent: GrizzlyScenario) -> GrizzlyResponse:
         with self.action(parent) as meta:
             url = parent.render(self.endpoint)
 
             response = requests.get(url)
             value = response.text
-            parent.user._context['variables'][self.variable] = value
+            if self.variable is not None:
+                parent.user._context['variables'][self.variable] = value
             meta['response_length'] = len(value)
 
-    def put(self, parent: GrizzlyScenario) -> Any:
+            return dict(response.headers), value
+
+    def put(self, parent: GrizzlyScenario) -> GrizzlyResponse:
         return super().put(parent)

--- a/grizzly/tasks/request.py
+++ b/grizzly/tasks/request.py
@@ -89,7 +89,7 @@ class RequestTaskHandlers:
 
 class RequestTaskResponse:
     status_codes: List[int]
-    content_type: TransformerContentType
+    content_type: TransformerContentType  # @TODO remove this one!
     handlers: RequestTaskHandlers
 
     def __init__(self) -> None:

--- a/grizzly/tasks/request.py
+++ b/grizzly/tasks/request.py
@@ -63,9 +63,8 @@ from jinja2.environment import Template
 from grizzly_extras.transformer import TransformerContentType
 from grizzly_extras.arguments import parse_arguments, split_value, unquote
 
-from ..types import RequestMethod
-# need to rename to avoid unused-import collision due to RequestTask.template ?!
-from . import GrizzlyTask, template  # pylint: disable=unused-import
+from ..types import GrizzlyResponse, RequestMethod
+from . import GrizzlyMetaRequestTask, template  # pylint: disable=unused-import
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..context import GrizzlyContextScenario
@@ -109,7 +108,7 @@ class RequestTaskResponse:
 
 
 @template('name', 'endpoint', 'source', 'arguments', 'metadata')
-class RequestTask(GrizzlyTask):
+class RequestTask(GrizzlyMetaRequestTask):
     method: RequestMethod
     name: str
     endpoint: str
@@ -151,6 +150,7 @@ class RequestTask(GrizzlyTask):
             self.endpoint = value
 
         self.response.content_type = content_type
+        self.content_type = content_type
 
     @property
     def source(self) -> Optional[str]:
@@ -182,3 +182,6 @@ class RequestTask(GrizzlyTask):
             return parent.user.request(self)
 
         return task
+
+    def execute(self, parent: 'GrizzlyScenario') -> GrizzlyResponse:
+        return parent.user.request(self)

--- a/grizzly/tasks/until.py
+++ b/grizzly/tasks/until.py
@@ -19,7 +19,7 @@ ordinary {@pylink grizzly.tasks.request} or {@pylink grizzly.tasks.clients} task
 
 ## Arguments
 
-* `request` _{@pylink grizzly.tasks.requests} / {@pylink grizzly.tasks.clients}_ - request that is going to be repeated
+* `request` _{@pylink grizzly.tasks.request} / {@pylink grizzly.tasks.clients}_ - request that is going to be repeated
 
 * `condition` _str_ - condition expression that specifies how `request` should be repeated
 

--- a/grizzly/tasks/until.py
+++ b/grizzly/tasks/until.py
@@ -7,17 +7,19 @@ payload returned for the request.
 
 * {@pylink grizzly.steps.scenario.tasks.step_task_request_with_name_endpoint_until}
 
+* {@pylink grizzly.steps.scenario.tasks.step_task_client_get_endpoint_until}
+
 ## Statistics
 
 Executions of this task will be visible in `locust` request statistics with request type `UNTL` indicating how
 long time it took to finish the task. `name` will be suffixed with ` r=<retries>, w=<wait>, em=<expected_matches>`.
 
 The request task that is being repeated until `condition` is true will have it's own entry in the statistics as an
-ordinary {@pylink grizzly.tasks.request} task.
+ordinary {@pylink grizzly.tasks.request} or {@pylink grizzly.tasks.clients} task.
 
 ## Arguments
 
-* `request` _RequestTask_ - request that is going to be repeated
+* `request` _{@pylink grizzly.tasks.requests} / {@pylink grizzly.tasks.clients}_ - request that is going to be repeated
 
 * `condition` _str_ - condition expression that specifies how `request` should be repeated
 
@@ -47,8 +49,7 @@ from grizzly_extras.transformer import Transformer, TransformerContentType, Tran
 from grizzly_extras.arguments import get_unsupported_arguments, parse_arguments, split_value
 
 from ..types import RequestType
-from .request import RequestTask
-from . import GrizzlyTask, template
+from . import GrizzlyTask, GrizzlyMetaRequestTask, template
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..context import GrizzlyContextScenario, GrizzlyContext
@@ -57,7 +58,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 @template('condition', 'request')
 class UntilRequestTask(GrizzlyTask):
-    request: RequestTask
+    request: GrizzlyMetaRequestTask
     condition: str
 
     transform: Optional[Type[Transformer]]
@@ -67,7 +68,7 @@ class UntilRequestTask(GrizzlyTask):
     wait: float
     expected_matches: int
 
-    def __init__(self, grizzly: 'GrizzlyContext', request: RequestTask, condition: str, scenario: Optional['GrizzlyContextScenario'] = None) -> None:
+    def __init__(self, grizzly: 'GrizzlyContext', request: GrizzlyMetaRequestTask, condition: str, scenario: Optional['GrizzlyContextScenario'] = None) -> None:
         super().__init__(scenario)
 
         self.request = request
@@ -76,10 +77,10 @@ class UntilRequestTask(GrizzlyTask):
         self.wait = 1.0
         self.expected_matches = 1
 
-        if self.request.response.content_type == TransformerContentType.UNDEFINED:
+        if self.request.content_type == TransformerContentType.UNDEFINED:
             raise ValueError('content type must be specified for request')
 
-        self.transform = transformer.available.get(self.request.response.content_type, None)
+        self.transform = transformer.available.get(self.request.content_type, None)
 
         if '|' in self.condition:
             self.condition, until_arguments = split_value(self.condition)
@@ -106,16 +107,16 @@ class UntilRequestTask(GrizzlyTask):
 
     def __call__(self) -> Callable[['GrizzlyScenario'], Any]:
         if self.transform is None:
-            raise TypeError(f'could not find a transformer for {self.request.response.content_type.name}')
+            raise TypeError(f'could not find a transformer for {self.request.content_type.name}')
 
         transform = cast(Transformer, self.transform)
 
         def task(parent: 'GrizzlyScenario') -> Any:
-            task_name = f'{self.request.scenario.identifier} {self.request.name}, w={self.wait}s, r={self.retries}, em={self.expected_matches}'
+            task_name = f'{self.scenario.identifier} {self.request.name}, w={self.wait}s, r={self.retries}, em={self.expected_matches}'
             condition_rendered = parent.render(self.condition)
 
             if not transform.validate(condition_rendered):
-                raise RuntimeError(f'{condition_rendered} is not a valid expression for {self.request.response.content_type.name}')
+                raise RuntimeError(f'{condition_rendered} is not a valid expression for {self.request.content_type.name}')
 
             parser = transform.parser(condition_rendered)
             number_of_matches = 0
@@ -132,7 +133,7 @@ class UntilRequestTask(GrizzlyTask):
                     try:
                         gsleep(self.wait)
 
-                        _, payload = parent.user.request(self.request)
+                        _, payload = self.request.execute(parent)
 
                         if payload is not None:
                             transformed = transform.transform(payload)
@@ -177,7 +178,7 @@ class UntilRequestTask(GrizzlyTask):
                     exception=exception,
                 )
 
-                if exception is not None and self.request.scenario.failure_exception is not None:
-                    raise self.request.scenario.failure_exception()
+                if exception is not None and self.scenario.failure_exception is not None:
+                    raise self.scenario.failure_exception()
 
         return task

--- a/grizzly/testdata/variables/servicebus.py
+++ b/grizzly/testdata/variables/servicebus.py
@@ -28,8 +28,8 @@ Examples:
 ``` plain
 queue:test-queue
 topic:test-topic, subscription:test-subscription
-queue:"$conf::sb.endpoint.queue"
-topic:"$conf::sb.endpoint.topic", subscription:"$conf::sb.endpoint.subscription"
+queue:"$conf::sb.endpoint.queue$"
+topic:"$conf::sb.endpoint.topic$", subscription:"$conf::sb.endpoint.subscription$"
 queue:"{{ queue_name }}", expression="$.document[?(@.name=='TPM report')]"
 ```
 
@@ -53,13 +53,13 @@ The complete `url` has {@link framework.usage.variables.templating} support, but
 $conf::sb.url
 
 # not valid
-Endpoint=sb://$conf::sb.hostname/;SharedAccessKeyName=$conf::sb.keyname;SharedAccessKey=$conf::sb.key
+Endpoint=sb://$conf::sb.hostname/;SharedAccessKeyName=$conf::sb.keyname;SharedAccessKey=$conf::sb.key$
 ```
 
 ## Example
 
 ``` gherkin
-And value for variable "AtomicServiceBus.document_id" is "queue:documents-in | wait=120, url=$conf::sb.endpoint, repeat=True"
+And value for variable "AtomicServiceBus.document_id" is "queue:documents-in | wait=120, url=$conf::sb.endpoint$, repeat=True"
 ...
 Given a user of type "RestApi" load testing "http://example.com"
 ...
@@ -78,7 +78,7 @@ If no matching messages was found when peeking, it is repeated again up until th
 be specified for the endpint, e.g. `application/xml`.
 
 ``` gherkin
-And value for variable "AtomicServiceBus.tpm_document" is "queue:documents-in | wait=120, url=$conf::sb.endpoint, repeat=True, content_type=json, expression='$.document[?(@.name=='TPM Report')'"
+And value for variable "AtomicServiceBus.tpm_document" is "queue:documents-in | wait=120, url=$conf::sb.endpoint$, repeat=True, content_type=json, expression='$.document[?(@.name=='TPM Report')'"
 ```
 '''  # noqa: E501
 import logging

--- a/grizzly/users/restapi.py
+++ b/grizzly/users/restapi.py
@@ -178,7 +178,7 @@ class RestApiUser(ResponseHandler, RequestLogger, GrizzlyUser, HttpRequests, Asy
         self.headers = {
             'Authorization': None,
             'Content-Type': 'application/json',
-            'x-grizzly-user': f'{self.__class__.__name__}',
+            'x-grizzly-user': self.__class__.__name__,
         }
 
         self.session_started = None

--- a/tests/e2e/steps/background/test_setup.py
+++ b/tests/e2e/steps/background/test_setup.py
@@ -13,7 +13,7 @@ from ....fixtures import End2EndFixture
 @pytest.mark.parametrize('url', [
     'influxdb://grizzly:password@localhost/grizzly-statistics',
     'insights://localhost/?Testplan=grizzly-statistics&InstrumentationKey=asdfasdf=',
-    'influxdb://$conf::statistics.username:$conf::statistics.password@localhost/$conf::statistics.database',
+    'influxdb://$conf::statistics.username$:$conf::statistics.password$@localhost/$conf::statistics.database$',
 ])
 def test_e2e_step_setup_save_statistics(e2e_fixture: End2EndFixture, url: str) -> None:
     env_conf: Dict[str, Any] = {
@@ -35,7 +35,7 @@ def test_e2e_step_setup_save_statistics(e2e_fixture: End2EndFixture, url: str) -
         test_url = data.pop('url')
 
         for key, value in data.items():
-            test_url = test_url.replace(f'$conf::{key}', value)
+            test_url = test_url.replace(f'$conf::{key}$', value)
 
         assert grizzly.setup.statistics_url == test_url, f'{grizzly.setup.statistics_url} != {test_url}'
 

--- a/tests/e2e/test_until.py
+++ b/tests/e2e/test_until.py
@@ -1,0 +1,79 @@
+from typing import Dict, cast
+from textwrap import dedent
+from tempfile import NamedTemporaryFile
+
+import yaml
+
+from behave.runner import Context
+from behave.model import Feature
+from grizzly.context import GrizzlyContext
+
+from ..fixtures import End2EndFixture
+
+
+def test_e2e_until(e2e_fixture: End2EndFixture) -> None:
+    def after_feature(context: Context, feature: Feature) -> None:
+        from grizzly.locust import on_master
+        if on_master(context):
+            return
+
+        grizzly = cast(GrizzlyContext, context.grizzly)
+
+        stats = grizzly.state.locust.environment.stats
+
+        expectations = [
+            ('001 RequestTask', 'SCEN', 0, 1,),
+            ('001 RequestTask', 'TSTD', 0, 1,),
+            ('001 request-task', 'GET', 0, 2,),
+            ('001 request-task, w=1.0s, r=2, em=1', 'UNTL', 0, 1,),
+            ('002 HttpClientTask', 'SCEN', 0, 1,),
+            ('002 HttpClientTask', 'TSTD', 0, 1,),
+            ('002 http-client-task, w=1.0s, r=3, em=1', 'UNTL', 0, 1,),
+            ('002 http-client-task', 'CLTSK', 0, 2,),
+        ]
+
+        for name, method, expected_num_failures, expected_num_requests in expectations:
+            stat = stats.get(name, method)
+            assert stat.num_failures == expected_num_failures, f'{stat.method}:{stat.name}.num_failures: {stat.num_failures} != {expected_num_failures}'
+            assert stat.num_requests == expected_num_requests, f'{stat.method}:{stat.name}.num_requests: {stat.num_requests} != {expected_num_requests}'
+
+    e2e_fixture.add_after_feature(after_feature)
+
+    if e2e_fixture._distributed:
+        start_webserver_step = f'Then start webserver on master port "{e2e_fixture.webserver.port}"\n\n'
+    else:
+        start_webserver_step = ''
+
+    env_conf: Dict[str, Dict[str, Dict[str, str]]] = {
+        'configuration': {
+            'test': {
+                'host': f'http://{e2e_fixture.host}'
+            }
+        }
+    }
+
+    feature_file = e2e_fixture.create_feature(dedent(f'''Feature: UntilRequestTask
+    Background: common configuration
+        Given "2" users
+        And spawn rate is "2" user per second
+        {start_webserver_step}
+    Scenario: RequestTask
+        Given a user of type "RestApi" load testing "http://{e2e_fixture.host}"
+        And repeat for "1" iteration
+        And stop user on failure
+        Then get request with name "request-task" from endpoint "/api/until/hello?nth=2&wrong=foobar&right=world&as_array=true | content_type=json" until "$.`this`[?hello="world"] | retries=2, expected_matches=1"
+
+    Scenario: HttpClientTask
+        Given a user of type "RestApi" load testing "http://{e2e_fixture.host}"
+        And repeat for "1" iteration
+        And restart scenario on failure
+        Then get "http://$conf::test.host$/api/until/hello?nth=2&wrong=foobar&right=world&as_array=true | content_type=json" with name "http-client-task" until "$.`this`[?hello="world"] | retries=3, expected_matches=1"
+    '''))  # noqa: E501
+
+    with NamedTemporaryFile(delete=True, suffix='.yaml', dir=e2e_fixture.test_tmp_dir) as env_conf_file:
+        env_conf_file.write(yaml.dump(env_conf, Dumper=yaml.Dumper).encode())
+        env_conf_file.flush()
+
+        rc, _ = e2e_fixture.execute(feature_file, env_conf_file=env_conf_file.name)
+
+        assert rc == 0

--- a/tests/e2e/test_until.py
+++ b/tests/e2e/test_until.py
@@ -61,13 +61,13 @@ def test_e2e_until(e2e_fixture: End2EndFixture) -> None:
         Given a user of type "RestApi" load testing "http://{e2e_fixture.host}"
         And repeat for "1" iteration
         And stop user on failure
-        Then get request with name "request-task" from endpoint "/api/until/hello?nth=2&wrong=foobar&right=world&as_array=true | content_type=json" until "$.`this`[?hello="world"] | retries=2, expected_matches=1"
+        Then get request with name "request-task" from endpoint "/api/until/bar?nth=2&wrong=foobar&right=world&as_array=true | content_type=json" until "$.`this`[?bar="world"] | retries=2, expected_matches=1"
 
     Scenario: HttpClientTask
         Given a user of type "RestApi" load testing "http://{e2e_fixture.host}"
         And repeat for "1" iteration
-        And restart scenario on failure
-        Then get "http://$conf::test.host$/api/until/hello?nth=2&wrong=foobar&right=world&as_array=true | content_type=json" with name "http-client-task" until "$.`this`[?hello="world"] | retries=3, expected_matches=1"
+        And stop user on failure
+        Then get "http://$conf::test.host$/api/until/foo?nth=2&wrong=foobar&right=world&as_array=true | content_type=json" with name "http-client-task" until "$.`this`[?foo="world"] | retries=3, expected_matches=1"
     '''))  # noqa: E501
 
     with NamedTemporaryFile(delete=True, suffix='.yaml', dir=e2e_fixture.test_tmp_dir) as env_conf_file:

--- a/tests/e2e/test_until.py
+++ b/tests/e2e/test_until.py
@@ -61,13 +61,14 @@ def test_e2e_until(e2e_fixture: End2EndFixture) -> None:
         Given a user of type "RestApi" load testing "http://{e2e_fixture.host}"
         And repeat for "1" iteration
         And stop user on failure
-        Then get request with name "request-task" from endpoint "/api/until/bar?nth=2&wrong=foobar&right=world&as_array=true | content_type=json" until "$.`this`[?bar="world"] | retries=2, expected_matches=1"
+        Then get request with name "request-task-reset" from endpoint "/api/until/reset"
+        Then get request with name "request-task" from endpoint "/api/until/barbar?nth=2&wrong=foobar&right=world&as_array=true | content_type=json" until "$.`this`[?barbar="world"] | retries=2, expected_matches=1"
 
     Scenario: HttpClientTask
         Given a user of type "RestApi" load testing "http://{e2e_fixture.host}"
         And repeat for "1" iteration
         And stop user on failure
-        Then get "http://$conf::test.host$/api/until/foo?nth=2&wrong=foobar&right=world&as_array=true | content_type=json" with name "http-client-task" until "$.`this`[?foo="world"] | retries=3, expected_matches=1"
+        Then get "http://$conf::test.host$/api/until/foofoo?nth=2&wrong=foobar&right=world&as_array=true | content_type=json" with name "http-client-task" until "$.`this`[?foofoo="world"] | retries=3, expected_matches=1"
     '''))  # noqa: E501
 
     with NamedTemporaryFile(delete=True, suffix='.yaml', dir=e2e_fixture.test_tmp_dir) as env_conf_file:

--- a/tests/test_grizzly/steps/background/test_setup.py
+++ b/tests/test_grizzly/steps/background/test_setup.py
@@ -48,10 +48,10 @@ def test_step_setup_save_statistics(behave_fixture: BehaveFixture) -> None:
 
     try:
         with pytest.raises(AssertionError):
-            step_impl(behave, 'influxdb://test:8000/$env::DATABASE')
+            step_impl(behave, 'influxdb://test:8000/$env::DATABASE$')
 
         environ['DATABASE'] = 'test_db'
-        step_impl(behave, 'influxdb://test:8000/$env::DATABASE')
+        step_impl(behave, 'influxdb://test:8000/$env::DATABASE$')
         assert grizzly.setup.statistics_url == 'influxdb://test:8000/test_db'
     finally:
         try:
@@ -64,13 +64,13 @@ def test_step_setup_save_statistics(behave_fixture: BehaveFixture) -> None:
 
     try:
         with pytest.raises(AssertionError):
-            step_impl(behave, 'insights://?IngestionEndpoint=$env::TEST_VARIABLE&Testplan=test&InstrumentationKey=aaaabbbb=')
+            step_impl(behave, 'insights://?IngestionEndpoint=$env::TEST_VARIABLE$&Testplan=test&InstrumentationKey=aaaabbbb=')
         environ['TEST_VARIABLE'] = 'HelloWorld'
 
-        step_impl(behave, 'insights://username:password@?IngestionEndpoint=$env::TEST_VARIABLE&Testplan=test&InstrumentationKey=aaaabbbb=')
+        step_impl(behave, 'insights://username:password@?IngestionEndpoint=$env::TEST_VARIABLE$&Testplan=test&InstrumentationKey=aaaabbbb=')
         assert grizzly.setup.statistics_url == 'insights://username:password@?IngestionEndpoint=HelloWorld&Testplan=test&InstrumentationKey=aaaabbbb='
 
-        step_impl(behave, 'insights://username:password@insights.example.com?IngestionEndpoint=$env::TEST_VARIABLE&Testplan=test&InstrumentationKey=aaaabbbb=')
+        step_impl(behave, 'insights://username:password@insights.example.com?IngestionEndpoint=$env::TEST_VARIABLE$&Testplan=test&InstrumentationKey=aaaabbbb=')
         assert grizzly.setup.statistics_url == 'insights://username:password@insights.example.com?IngestionEndpoint=HelloWorld&Testplan=test&InstrumentationKey=aaaabbbb='
     finally:
         try:
@@ -96,9 +96,9 @@ def test_step_setup_save_statistics(behave_fixture: BehaveFixture) -> None:
     step_impl(
         behave,
         (
-            'insights://$conf::statistics.username:$conf::statistics.password@?'
-            'IngestionEndpoint=$conf::statistics.url&Testplan=$conf::statistics.testplan&'
-            'InstrumentationKey=$conf::statistics.instrumentationkey'
+            'insights://$conf::statistics.username$:$conf::statistics.password$@?'
+            'IngestionEndpoint=$conf::statistics.url$&Testplan=$conf::statistics.testplan$&'
+            'InstrumentationKey=$conf::statistics.instrumentationkey$'
         ),
     )
     grizzly.setup.statistics_url == 'insights://username:password@?IngestionEndpoint=insights.example.com&Testplan=test&InstrumentationKey=aaaabbbb='

--- a/tests/test_grizzly/steps/scenario/test_setup.py
+++ b/tests/test_grizzly/steps/scenario/test_setup.py
@@ -212,7 +212,7 @@ def test_step_setup_iterations(behave_fixture: BehaveFixture) -> None:
     try:
         environ['ITERATIONS'] = '1337'
 
-        step_setup_iterations(behave, '$env::ITERATIONS', 'iteration')
+        step_setup_iterations(behave, '$env::ITERATIONS$', 'iteration')
         assert grizzly.scenario.iterations == 1337
     finally:
         try:
@@ -221,7 +221,7 @@ def test_step_setup_iterations(behave_fixture: BehaveFixture) -> None:
             pass
 
     grizzly.state.configuration['test.iterations'] = 13
-    step_setup_iterations(behave, '$conf::test.iterations', 'iterations')
+    step_setup_iterations(behave, '$conf::test.iterations$', 'iterations')
     assert grizzly.scenario.iterations == 13
 
 

--- a/tests/test_grizzly/steps/scenario/test_tasks.py
+++ b/tests/test_grizzly/steps/scenario/test_tasks.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import List, cast
 
 import pytest
 

--- a/tests/test_grizzly/steps/scenario/test_tasks.py
+++ b/tests/test_grizzly/steps/scenario/test_tasks.py
@@ -411,6 +411,49 @@ def test_step_task_client_get_endpoint(behave_fixture: BehaveFixture) -> None:
     assert task.endpoint == '{{ endpoint_url }}'
 
 
+def test_step_task_client_get_endpoint_until(behave_fixture: BehaveFixture) -> None:
+    behave = behave_fixture.context
+    grizzly = cast(GrizzlyContext, behave.grizzly)
+
+    with pytest.raises(AssertionError) as ae:
+        step_task_client_get_endpoint_until(behave, 'api.example.io/api/test', 'step-name', '$.`this`[?status=true]')
+    assert str(ae.value) == 'could not find scheme in "api.example.io/api/test"'
+
+    with pytest.raises(AssertionError) as ae:
+        step_task_client_get_endpoint_until(behave, 'foo://api.example.io/api/test', 'step-name', '$.`this`[?status=true]')
+    assert str(ae.value) == 'no client task registered for foo'
+
+    with pytest.raises(ValueError) as ve:
+        step_task_client_get_endpoint_until(behave, 'https://api.example.io/api/test', 'step-name', '$.`this`[?status=true]')
+    assert str(ve.value) == 'content type must be specified for request'
+
+    with pytest.raises(ValueError) as ve:
+        step_task_client_get_endpoint_until(behave, 'https://api.example.io/api/test | content_type=json', 'step-name', '$.`this`[?success=true] | foo=bar, bar=foo')
+    assert str(ve.value) == 'unsupported arguments foo, bar'
+
+    step_task_client_get_endpoint_until(behave, 'https://api.example.io/api/test | content_type=json', 'step-name', '$.`this`[?success=true]')
+
+    assert len(grizzly.scenario.tasks) == 1
+    task = grizzly.scenario.tasks[-1]
+    assert isinstance(task, UntilRequestTask)
+    assert task.scenario is task.request.scenario
+    assert isinstance(task.request, HttpClientTask)
+    assert task.request.content_type == TransformerContentType.JSON
+    assert task.request.endpoint == 'https://api.example.io/api/test'
+
+    grizzly.state.configuration['test.host'] = 'https://api.example.com'
+
+    step_task_client_get_endpoint_until(behave, 'https://$conf::test.host$/api/test | content_type=json', 'step-name', '$.`this`[success=false]')
+
+    assert len(grizzly.scenario.tasks) == 2
+    task = grizzly.scenario.tasks[-1]
+    assert isinstance(task, UntilRequestTask)
+    assert task.scenario is task.request.scenario
+    assert isinstance(task.request, HttpClientTask)
+    assert task.request.content_type == TransformerContentType.JSON
+    assert task.request.endpoint == 'https://api.example.com/api/test'
+
+
 def test_step_task_date(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)

--- a/tests/test_grizzly/steps/scenario/test_user.py
+++ b/tests/test_grizzly/steps/scenario/test_user.py
@@ -30,14 +30,14 @@ def test_step_user_type(behave_fixture: BehaveFixture) -> None:
     with pytest.raises(AssertionError):
         step_user_type(behave, 'RestApi', '{{ host }}')
 
-    grizzly.state.variables['host'] = 'http://test.ru:1337'
+    grizzly.state.variables['host'] = 'http://example.io:1337'
     step_user_type(behave, 'RestApi', '{{ host }}')
 
-    assert grizzly.scenario.context['host'] == 'http://test.ru:1337'
+    assert grizzly.scenario.context['host'] == 'http://example.io:1337'
 
     try:
         environ['TARGET_HOST'] = 'http://host.docker.internal'
-        step_user_type(behave, 'RestApi', '$env::TARGET_HOST')
+        step_user_type(behave, 'RestApi', '$env::TARGET_HOST$')
         assert grizzly.scenario.context['host'] == 'http://host.docker.internal'
     finally:
         try:
@@ -45,9 +45,9 @@ def test_step_user_type(behave_fixture: BehaveFixture) -> None:
         except KeyError:
             pass
 
-    grizzly.state.configuration['target.host'] = 'http://conf.host.nu'
-    step_user_type(behave, 'RestApi', '$conf::target.host')
-    assert grizzly.scenario.context['host'] == 'http://conf.host.nu'
+    grizzly.state.configuration['target.host'] = 'http://conf.example.io'
+    step_user_type(behave, 'RestApi', '$conf::target.host$')
+    assert grizzly.scenario.context['host'] == 'http://conf.example.io'
 
 
 def test_step_user_type_with_weight(behave_fixture: BehaveFixture) -> None:

--- a/tests/test_grizzly/steps/test__helpers.py
+++ b/tests/test_grizzly/steps/test__helpers.py
@@ -219,11 +219,11 @@ def test_add_request_task(grizzly_fixture: GrizzlyFixture, tmp_path_factory: Tem
     assert task.response.content_type == TransformerContentType.JSON
 
     with pytest.raises(AssertionError) as ae:
-        add_request_task(behave, method=RequestMethod.GET, source=None, endpoint='$conf::test.endpoint', name='foo-bar')
+        add_request_task(behave, method=RequestMethod.GET, source=None, endpoint='$conf::test.endpoint$', name='foo-bar')
     assert 'configuration variable "test.endpoint" is not set' in str(ae)
 
     grizzly.state.configuration['test.endpoint'] = '/foo/bar'
-    add_request_task(behave, method=RequestMethod.GET, source=None, endpoint='$conf::test.endpoint', name='foo-bar')
+    add_request_task(behave, method=RequestMethod.GET, source=None, endpoint='$conf::test.endpoint$', name='foo-bar')
 
     task = tasks[-1]
     assert task.endpoint == '/foo/bar'

--- a/tests/test_grizzly/tasks/clients/test_blobstorage.py
+++ b/tests/test_grizzly/tasks/clients/test_blobstorage.py
@@ -125,7 +125,7 @@ class TestBlobStorageClientTask:
             })
             grizzly.state.configuration.update({
                 'storage.account': 'my-storage',
-                'storage.account_key': 'aaaabbb=',
+                'storage.account_key': 'aaaa+bbb/64=',
                 'storage.container': 'my-container',
             })
 
@@ -145,8 +145,9 @@ class TestBlobStorageClientTask:
                 destination='destination.txt',
             )
             assert task_factory.account_name == 'my-storage'
-            assert task_factory.account_key == 'aaaabbb='
+            assert task_factory.account_key == 'aaaa+bbb/64='
             assert task_factory.container == 'my-container'
+            assert task_factory.connection_string == 'DefaultEndpointsProtocol=https;AccountName=my-storage;AccountKey=aaaa+bbb/64=;EndpointSuffix=core.windows.net'
 
             task = task_factory()
 

--- a/tests/test_grizzly/tasks/clients/test_blobstorage.py
+++ b/tests/test_grizzly/tasks/clients/test_blobstorage.py
@@ -132,7 +132,7 @@ class TestBlobStorageClientTask:
             with pytest.raises(ValueError) as ve:
                 BlobStorageClientTask(
                     RequestDirection.TO,
-                    'bss://$conf::storage.account?AccountKey=$conf::storage.account_key&Container=$conf::storage.container',
+                    'bss://$conf::storage.account$?AccountKey=$conf::storage.account_key$&Container=$conf::storage.container$',
                     source=None,
                     destination='destination.txt',
                 )
@@ -140,7 +140,7 @@ class TestBlobStorageClientTask:
 
             task_factory = BlobStorageClientTask(
                 RequestDirection.TO,
-                'bss://$conf::storage.account?AccountKey=$conf::storage.account_key&Container=$conf::storage.container',
+                'bss://$conf::storage.account$?AccountKey=$conf::storage.account_key$&Container=$conf::storage.container$',
                 source='source.json',
                 destination='destination.txt',
             )
@@ -181,7 +181,7 @@ class TestBlobStorageClientTask:
 
             task_factory = BlobStorageClientTask(
                 RequestDirection.TO,
-                'bss://$conf::storage.account?AccountKey=$conf::storage.account_key&Container=$conf::storage.container',
+                'bss://$conf::storage.account$?AccountKey=$conf::storage.account_key$&Container=$conf::storage.container$',
                 'test-bss-request',
                 source='{{ source }}',
                 destination='{{ destination }}',

--- a/tests/test_grizzly/tasks/clients/test_http.py
+++ b/tests/test_grizzly/tasks/clients/test_http.py
@@ -65,7 +65,8 @@ class TestHttpClientTask:
         assert requests_get_spy.call_count == 1
         args, kwargs = requests_get_spy.call_args_list[-1]
         assert args[0] == 'http://example.org'
-        assert len(kwargs) == 0
+        assert len(kwargs) == 1
+        assert kwargs.get('headers', {}).get('x-grizzly-user', None).startswith('HttpClientTask::')
 
         assert request_fire_spy.call_count == 1
         _, kwargs = request_fire_spy.call_args_list[-1]
@@ -84,7 +85,8 @@ class TestHttpClientTask:
         assert requests_get_spy.call_count == 2
         args, kwargs = requests_get_spy.call_args_list[-1]
         assert args[0] == 'http://example.org'
-        assert len(kwargs) == 0
+        assert len(kwargs) == 1
+        assert kwargs.get('headers', {}).get('x-grizzly-user', None).startswith('HttpClientTask::')
 
         assert request_fire_spy.call_count == 2
         _, kwargs = request_fire_spy.call_args_list[-1]
@@ -109,7 +111,8 @@ class TestHttpClientTask:
         assert requests_get_spy.call_count == 4
         args, kwargs = requests_get_spy.call_args_list[-1]
         assert args[0] == 'http://example.org'
-        assert len(kwargs) == 0
+        assert len(kwargs) == 1
+        assert kwargs.get('headers', {}).get('x-grizzly-user', None).startswith('HttpClientTask::')
 
         assert request_fire_spy.call_count == 4
         _, kwargs = request_fire_spy.call_args_list[-1]
@@ -133,7 +136,8 @@ class TestHttpClientTask:
         assert requests_get_spy.call_count == 5
         args, kwargs = requests_get_spy.call_args_list[-1]
         assert args[0] == 'http://example.org'
-        assert len(kwargs) == 0
+        assert len(kwargs) == 1
+        assert kwargs.get('headers', {}).get('x-grizzly-user', None).startswith('HttpClientTask::')
 
         assert request_fire_spy.call_count == 5
         _, kwargs = request_fire_spy.call_args_list[-1]
@@ -156,8 +160,9 @@ class TestHttpClientTask:
         assert requests_get_spy.call_count == 6
         args, kwargs = requests_get_spy.call_args_list[-1]
         assert args[0] == 'https://example.org/api/test'
-        assert len(kwargs) == 1
+        assert len(kwargs) == 2
         assert kwargs.get('verify', None)
+        assert kwargs.get('headers', {}).get('x-grizzly-user', None).startswith('HttpClientTask::')
 
         task_factory = HttpClientTask(RequestDirection.FROM, 'https://$conf::test.host$/api/test | verify=False, content_type=json', 'http-env-get', variable='test')
         task = task_factory()
@@ -169,8 +174,9 @@ class TestHttpClientTask:
         assert requests_get_spy.call_count == 7
         args, kwargs = requests_get_spy.call_args_list[-1]
         assert args[0] == 'https://example.org/api/test'
-        assert len(kwargs) == 1
+        assert len(kwargs) == 2
         assert not kwargs.get('verify', None)
+        assert kwargs.get('headers', {}).get('x-grizzly-user', None).startswith('HttpClientTask::')
 
         task_factory = HttpClientTask(RequestDirection.FROM, 'https://$conf::test.host$/api/test | verify=True, content_type=json', 'http-env-get', variable='test')
         task = task_factory()
@@ -182,8 +188,9 @@ class TestHttpClientTask:
         assert requests_get_spy.call_count == 8
         args, kwargs = requests_get_spy.call_args_list[-1]
         assert args[0] == 'https://example.org/api/test'
-        assert len(kwargs) == 1
+        assert len(kwargs) == 2
         assert kwargs.get('verify', None)
+        assert kwargs.get('headers', {}).get('x-grizzly-user', None).startswith('HttpClientTask::')
 
     def test_put(self, grizzly_fixture: GrizzlyFixture) -> None:
         task_factory = HttpClientTask(RequestDirection.TO, 'http://put.example.org', source='')

--- a/tests/test_grizzly/tasks/clients/test_http.py
+++ b/tests/test_grizzly/tasks/clients/test_http.py
@@ -136,6 +136,17 @@ class TestHttpClientTask:
         assert kwargs.get('context', None) is scenario.user._context
         assert isinstance(kwargs.get('exception', None), RuntimeError)
 
+        grizzly.state.configuration['test.host'] = 'https://example.org'
+
+        task_factory = HttpClientTask(RequestDirection.FROM, 'https://$conf::test.host$/api/test', 'http-env-get', variable='test')
+        task = task_factory()
+
+        task(scenario)
+
+        assert requests_get_spy.call_count == 6
+        args, _ = requests_get_spy.call_args_list[-1]
+        assert args[0] == 'https://example.org/api/test'
+
     def test_put(self, grizzly_fixture: GrizzlyFixture) -> None:
         task_factory = HttpClientTask(RequestDirection.TO, 'http://put.example.org', source='')
         task = task_factory()

--- a/tests/test_grizzly/tasks/clients/test_messagequeue.py
+++ b/tests/test_grizzly/tasks/clients/test_messagequeue.py
@@ -234,7 +234,7 @@ class TestMessageQueueClientTask:
                 'header_type': 'rfh2',
             }
 
-            task_factory.endpoint = 'mqs://$conf::mq.username:$conf::mq.password@$conf::mq.host/$conf::mq.endpoint?QueueManager=$conf::mq.qm&Channel=$conf::mq.channel'
+            task_factory.endpoint = 'mqs://$conf::mq.username$:$conf::mq.password$@$conf::mq.host$/$conf::mq.endpoint$?QueueManager=$conf::mq.qm$&Channel=$conf::mq.channel$'
             task_factory.grizzly.state.configuration = {
                 'mq.username': 'mq_conf_username',
                 'mq.password': 'mq_conf_password',

--- a/tests/test_grizzly/testdata/test_utils.py
+++ b/tests/test_grizzly/testdata/test_utils.py
@@ -74,9 +74,11 @@ def test_initialize_testdata_with_tasks(
             content='hello this is the {{ content }}!',
             content_type=TransformerContentType.JSON,
         ))
+        assert scenario.tasks.scenario is scenario
+        request.content_type = TransformerContentType.JSON
         scenario.tasks.add(UntilRequestTask(grizzly, request=request, condition='{{ condition }}'))
-        scenario.tasks.add(ConditionalTask(scenario=scenario, name='conditional-1', condition='{{ value | int > 5 }}'))
-        scenario.tasks.add(ConditionalTask(scenario=scenario, name='conditional-1', condition='{{ AtomicIntegerIncrementer.value | int > 5 }}'))
+        scenario.tasks.add(ConditionalTask(name='conditional-1', condition='{{ value | int > 5 }}'))
+        scenario.tasks.add(ConditionalTask(name='conditional-1', condition='{{ AtomicIntegerIncrementer.value | int > 5 }}'))
         scenario.tasks.add(LogMessageTask(message='transformer_task={{ transformer_task }}'))
         scenario.orphan_templates.append('hello {{ orphan }} template')
         testdata, external_dependencies = initialize_testdata(grizzly, scenario.tasks)

--- a/tests/test_grizzly/testdata/variables/test_servicebus.py
+++ b/tests/test_grizzly/testdata/variables/test_servicebus.py
@@ -71,7 +71,7 @@ def test_atomicservicebus_url() -> None:
         atomicservicebus_url(url)
     assert 'AtomicServiceBus: SharedAccessKeyName must be in the query string' in str(ve)
 
-    url = '$conf::sb.url'
+    url = '$conf::sb.url$'
     with pytest.raises(ValueError) as ve:
         atomicservicebus_url(url)
     assert 'AtomicServiceBus: configuration variable "sb.url" is not set' in str(ve)
@@ -132,12 +132,12 @@ def test_atomicservicebus_endpoint() -> None:
         atomicservicebus_endpoint(endpoint)
     assert 'AtomicServiceBus: value contained variable "queue_name" which has not been set' in str(ve)
 
-    endpoint = 'queue:"$conf::sb.endpoint.queue"'
+    endpoint = 'queue:"$conf::sb.endpoint.queue$"'
     with pytest.raises(ValueError) as ve:
         atomicservicebus_endpoint(endpoint)
     assert 'AtomicServiceBus: configuration variable "sb.endpoint.queue" is not set' in str(ve)
 
-    endpoint = 'topic:documents-in, subscription:"$conf::sb.endpoint.subscription"'
+    endpoint = 'topic:documents-in, subscription:"$conf::sb.endpoint.subscription$"'
     with pytest.raises(ValueError) as ve:
         atomicservicebus_endpoint(endpoint)
     assert 'AtomicServiceBus: configuration variable "sb.endpoint.subscription" is not set' in str(ve)
@@ -154,17 +154,17 @@ def test_atomicservicebus_endpoint() -> None:
         grizzly.state.variables['queue_name'] = 'test-queue'
         assert atomicservicebus_endpoint(endpoint) == 'queue:test-queue'
 
-        endpoint = 'queue:"$conf::sb.endpoint.queue"'
+        endpoint = 'queue:"$conf::sb.endpoint.queue$"'
         grizzly.state.configuration['sb.endpoint.queue'] = 'test-queue'
         assert atomicservicebus_endpoint(endpoint) == 'queue:test-queue'
 
         grizzly.state.configuration['sb.endpoint.subscription'] = 'test-subscription'
         grizzly.state.configuration['sb.endpoint.topic'] = 'test-topic'
 
-        endpoint = 'topic:"$conf::sb.endpoint.topic",subscription:"$conf::sb.endpoint.subscription"'
+        endpoint = 'topic:"$conf::sb.endpoint.topic$",subscription:"$conf::sb.endpoint.subscription$"'
         assert atomicservicebus_endpoint(endpoint) == 'topic:test-topic, subscription:test-subscription'
 
-        endpoint = 'topic:"$conf::sb.endpoint.topic",subscription:"$conf::sb.endpoint.subscription",expression:"{{ queue_name }}"'
+        endpoint = 'topic:"$conf::sb.endpoint.topic$",subscription:"$conf::sb.endpoint.subscription$",expression:"{{ queue_name }}"'
         assert atomicservicebus_endpoint(endpoint) == 'topic:test-topic, subscription:test-subscription, expression:test-queue'
 
     finally:
@@ -173,7 +173,7 @@ def test_atomicservicebus_endpoint() -> None:
         except:
             pass
 
-    endpoint = 'queue:"$env::QUEUE_NAME"'
+    endpoint = 'queue:"$env::QUEUE_NAME$"'
     with pytest.raises(ValueError) as ve:
         atomicservicebus_endpoint(endpoint)
     assert 'AtomicServiceBus: environment variable "QUEUE_NAME" is not set' in str(ve)

--- a/tests/webserver.py
+++ b/tests/webserver.py
@@ -153,6 +153,7 @@ def catch_all(_: Any) -> FlaskResponse:
 
 class Webserver:
     _web_server: WSGIServer
+    _greenlet: gevent.Greenlet
 
     def __init__(self, port: int = 0) -> None:
         self._web_server = WSGIServer(
@@ -167,7 +168,7 @@ class Webserver:
         return cast(int, self._web_server.server_port)
 
     def start(self) -> None:
-        gevent.spawn(lambda: self._web_server.serve_forever())
+        self._greenlet = gevent.spawn(lambda: self._web_server.serve_forever())
         gevent.sleep(0.01)
         logger.debug(f'started webserver on port {self.port}')
 
@@ -188,3 +189,8 @@ class Webserver:
         logger.debug(f'stopped webserver on port {self.port}')
 
         return True
+
+
+if __name__ == '__main__':
+    with Webserver(port=8080) as webserver:
+        gevent.joinall([webserver._greenlet])

--- a/tests/webserver.py
+++ b/tests/webserver.py
@@ -129,6 +129,7 @@ def app_until_attribute(attribute: str) -> FlaskResponse:
     nth = int(args['nth'])
     wrong = args.get('wrong')
     right = args.get('right')
+    as_array = args.get('as_array', None)
 
     if app_request_count[x_grizzly_user] < nth - 1:
         status = wrong
@@ -137,7 +138,12 @@ def app_until_attribute(attribute: str) -> FlaskResponse:
         status = right
         app_request_count[x_grizzly_user] = 0
 
-    return jsonify({attribute: status})
+    json_result: Any = {attribute: status}
+
+    if as_array is not None:
+        json_result = [json_result]
+
+    return jsonify(json_result)
 
 
 @app.errorhandler(404)

--- a/tests/webserver.py
+++ b/tests/webserver.py
@@ -1,5 +1,6 @@
 import csv
 import logging
+import json
 
 from typing import Dict, Any, Optional, Type, Literal, cast
 from types import TracebackType
@@ -142,6 +143,8 @@ def app_until_attribute(attribute: str) -> FlaskResponse:
 
     if as_array is not None:
         json_result = [json_result]
+
+    logger.debug(f'sending {json.dumps(json_result)} to {x_grizzly_user}')
 
     return jsonify(json_result)
 


### PR DESCRIPTION
changed pattern for environment variables and environment configuration variables from `$(env|conf)::[\w]` (could only render strings that *ONLY* contained one of those) to `$(env|conf)::[\w]$`, which makes it possible to easily render a chunk of text that contains one or more variables.

needs to be released as a new minor version, since the breaking change on how the variables are used.

also rewrote `UntilRequestTask` so it would support both `RequestTask` and `ClientTask` [implementations] for repeating a request until the expression/condition is met. Any task that implements `GrizzlyMetaRequestTask` could be used with `UntilRequestTask` now.