### PR TITLE
move out `docs` extras from pyproject.toml

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -85,7 +85,7 @@
 	],
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-	"postCreateCommand": "ssh-add -l; python -m pip install -e .[dev,ci,docs,mq]",
+	"postCreateCommand": "ssh-add -l; python -m pip install -e .[dev,ci,mq] && python -m pip install -r requirements-docs.txt",
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",
 	"features": {

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -193,7 +193,7 @@ jobs:
 
     - name: install python dependencies
       id: pip
-      run: python -m pip install -e .[docs]
+      run: python -m pip install -r requirements-docs.txt
 
     - name: exists
       run: test -e ${{ matrix.script }}
@@ -227,7 +227,7 @@ jobs:
 
     - name: install python dependencies
       id: pip
-      run: python -m pip install -e .[docs]
+      run: python -m pip install -r requirements-docs.txt
 
     - name: build
       working-directory: ./docs/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,7 +75,9 @@ jobs:
 
     - name: install python dependencies
       id: install-python-deps
-      run: python -m pip install -e .[ci,docs]
+      run: |
+        python -m pip install -e .[ci]
+        python -m pip install -r requirements-docs.txt
 
     - name: build package
       id: build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,8 +67,6 @@ mq = [
 ]
 dev = [
     "astunparse >=1.6.3",
-    "mkdocs >=1.2.0",
-    "mkdocs-material >=8.2.1",
     "mypy >=0.931",
     "flake8-pyproject >=1.1.0",
     "pylint >=2.12.2",
@@ -89,17 +87,6 @@ ci = [
     "build >=0.7.0",
     "twine >=3.8.0,<4.0.0",
     "pip-tools >=6.5.0"
-]
-docs = [
-    "grizzly-loadtester-cli",
-    "novella @ git+https://github.com/mgor/novella.git@grizzly#egg=novella",
-    "pydoc-markdown[novella] >=4.6.1",
-    "pytablewriter>=0.64.1",
-    "pip-licenses>=3.5.3",
-    "requests>=2.27.1",
-    "mkdocs >=1.3.0",
-    "mkdocs-material >=8.3.2",
-    "tomli >= 2.0.1"
 ]
 
 [tool.setuptools_scm]

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,8 @@
+grizzly-loadtester-cli
+git+https://github.com/mgor/novella.git@grizzly#egg=novella
+pydoc-markdown[novella] >=4.6.1
+pytablewriter>=0.64.1
+pip-licenses>=3.5.3
+requests>=2.27.1
+mkdocs >=1.3.0
+mkdocs-material >=8.3.2


### PR DESCRIPTION
until NiklasRosenstein/novella#6 and NiklasRosenstein/novella#5 is fixed, we can't have the docs section in pyproject.toml,
since pypi doesn't allow publishing a package with direct reference, so a forked version including these fixes is needed.