### PR TITLE
more MQ information

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -249,6 +249,7 @@ jobs:
     if: always()
     needs:
     - linting
+    - test-and-coverage
     - test-e2e
     - documentation-build
 

--- a/grizzly/environment.py
+++ b/grizzly/environment.py
@@ -86,6 +86,13 @@ def after_feature(context: Context, feature: Feature, *args: Tuple[Any, ...], **
         if pymqi.__name__ != 'grizzly_extras.dummy_pymqi':
             check_mq_client_logs(context)
 
+    # show start and stop date time
+    stopped = datetime.now().astimezone()
+
+    print('')
+    print(f'Started: {context.started}')
+    print(f'Stopped: {stopped}')
+
     # the features duration is the sum of all scenarios duration, which is the sum of all steps duration
     try:
         duration = int(time() - context.start)

--- a/grizzly/environment.py
+++ b/grizzly/environment.py
@@ -14,8 +14,13 @@ from behave.model_core import Status
 from .context import GrizzlyContext
 from .testdata.variables import destroy_variables
 from .locust import run as locustrun
-from .utils import catch, fail_direct, in_correct_section
+from .utils import catch, check_mq_client_logs, fail_direct, in_correct_section
 from .types import RequestType
+
+try:
+    import pymqi  # pylint: disable=unused-import
+except ModuleNotFoundError:
+    from grizzly_extras import dummy_pymqi as pymqi
 
 
 def before_feature(context: Context, feature: Feature, *args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> None:
@@ -42,7 +47,7 @@ def before_feature(context: Context, feature: Feature, *args: Tuple[Any, ...], *
 
     context.grizzly = grizzly
     context.start = time()
-    context.started = datetime.now()
+    context.started = datetime.now().astimezone()
 
 
 @catch(KeyboardInterrupt)
@@ -77,6 +82,9 @@ def after_feature(context: Context, feature: Feature, *args: Tuple[Any, ...], **
                     rindex -= 1
                     behave_step = cast(Step, behave_scenario.steps[rindex])
                     behave_step.status = Status.failed
+
+        if pymqi.__name__ != 'grizzly_extras.dummy_pymqi':
+            check_mq_client_logs(context)
 
     # the features duration is the sum of all scenarios duration, which is the sum of all steps duration
     try:

--- a/grizzly/locust.py
+++ b/grizzly/locust.py
@@ -6,7 +6,6 @@ from typing import NoReturn, Optional, Callable, List, Tuple, Set, Dict, Type, c
 from os import environ
 from signal import SIGTERM
 from socket import error as SocketError
-from datetime import datetime
 from math import ceil
 from operator import itemgetter
 
@@ -491,13 +490,6 @@ def run(context: Context) -> int:
                 grizzly_print_percentile_stats(runner.stats)
                 print_error_report(runner.stats)
                 print_scenario_summary(grizzly)
-
-                # show start and stop date time
-                stopped = datetime.now()
-
-                print('')
-                print(f'Started: {context.started}')
-                print(f'Stopped: {stopped}')
 
             def spawning_complete() -> bool:
                 if isinstance(runner, MasterRunner):

--- a/grizzly/locust.py
+++ b/grizzly/locust.py
@@ -43,7 +43,9 @@ from .users.base import GrizzlyUser
 
 from .utils import create_scenario_class_type, create_user_class_type
 
-__all__: List[str] = []
+__all__: List[str] = [
+    'stats_logger',
+]
 
 
 unhandled_greenlet_exception = False

--- a/grizzly/tasks/clients/__init__.py
+++ b/grizzly/tasks/clients/__init__.py
@@ -178,38 +178,27 @@ class ClientTask(GrizzlyMetaRequestTask):
                     exception=exception,
                 )
 
-            log_all_requests = parent.user._scenario.context.get('log_all_requests', False)
-            response_status = meta.get('response', {}).get('status', 200)
-            print(f'{exception=}, {log_all_requests=}, {response_status=}')
             if exception is not None or parent.user._scenario.context.get('log_all_requests', False) or meta.get('response', {}).get('status', 200) != 200:
-                try:
-                    log_name = RequestLogger.normalize(name)
-                    print(f'{name=}, {log_name=}')
-                    log_date = datetime.now()
-                    print(f'{log_date=}')
-                    log_file = self.log_dir / f'{log_name}.{log_date.strftime("%Y%m%dT%H%M%S%f")}.log'
-                    print(f'{log_file=}')
+                log_name = RequestLogger.normalize(name)
+                log_date = datetime.now()
+                log_file = self.log_dir / f'{log_name}.{log_date.strftime("%Y%m%dT%H%M%S%f")}.log'
 
-                    meta.get('request', {}).update({'time': response_time})
+                meta.get('request', {}).update({'time': response_time})
 
-                    request_log: Dict[str, Any] = {
-                        'stacktrace': None,
-                        'response': meta.get('response', None),
-                        'request': meta.get('request', None),
-                    }
+                request_log: Dict[str, Any] = {
+                    'stacktrace': None,
+                    'response': meta.get('response', None),
+                    'request': meta.get('request', None),
+                }
 
-                    if exception is not None:
-                        request_log.update({'stacktrace': traceback.format_exception(
-                            type(exception),
-                            value=exception,
-                            tb=exception.__traceback__,
-                        )})
+                if exception is not None:
+                    request_log.update({'stacktrace': traceback.format_exception(
+                        type(exception),
+                        value=exception,
+                        tb=exception.__traceback__,
+                    )})
 
-                    log_file.write_text(jsondumps(request_log, indent=2))
-                    print(f'wrote {str(log_file)}')
-                except:
-                    traceback.print_exc()
-                    raise
+                log_file.write_text(jsondumps(request_log, indent=2))
 
         if exception is not None and parent.user._scenario.failure_exception is not None:
             raise parent.user._scenario.failure_exception()

--- a/grizzly/tasks/clients/__init__.py
+++ b/grizzly/tasks/clients/__init__.py
@@ -178,27 +178,38 @@ class ClientTask(GrizzlyMetaRequestTask):
                     exception=exception,
                 )
 
+            log_all_requests = parent.user._scenario.context.get('log_all_requests', False)
+            response_status = meta.get('response', {}).get('status', 200)
+            print(f'{exception=}, {log_all_requests=}, {response_status=}')
             if exception is not None or parent.user._scenario.context.get('log_all_requests', False) or meta.get('response', {}).get('status', 200) != 200:
-                log_name = RequestLogger.normalize(name)
-                log_date = datetime.now()
-                log_file = self.log_dir / f'{log_name}.{log_date.strftime("%Y%m%dT%H%M%S%f")}.log'
+                try:
+                    log_name = RequestLogger.normalize(name)
+                    print(f'{name=}, {log_name=}')
+                    log_date = datetime.now()
+                    print(f'{log_date=}')
+                    log_file = self.log_dir / f'{log_name}.{log_date.strftime("%Y%m%dT%H%M%S%f")}.log'
+                    print(f'{log_file=}')
 
-                meta.get('request', {}).update({'time': response_time})
+                    meta.get('request', {}).update({'time': response_time})
 
-                request_log: Dict[str, Any] = {
-                    'stacktrace': None,
-                    'response': meta.get('response', None),
-                    'request': meta.get('request', None),
-                }
+                    request_log: Dict[str, Any] = {
+                        'stacktrace': None,
+                        'response': meta.get('response', None),
+                        'request': meta.get('request', None),
+                    }
 
-                if exception is not None:
-                    request_log.update({'stacktrace': traceback.format_exception(
-                        type(exception),
-                        value=exception,
-                        tb=exception.__traceback__,
-                    )})
+                    if exception is not None:
+                        request_log.update({'stacktrace': traceback.format_exception(
+                            type(exception),
+                            value=exception,
+                            tb=exception.__traceback__,
+                        )})
 
-                log_file.write_text(jsondumps(request_log, indent=2))
+                    log_file.write_text(jsondumps(request_log, indent=2))
+                    print(f'wrote {str(log_file)}')
+                except:
+                    traceback.print_exc()
+                    raise
 
         if exception is not None and parent.user._scenario.failure_exception is not None:
             raise parent.user._scenario.failure_exception()

--- a/grizzly/tasks/clients/blobstorage.py
+++ b/grizzly/tasks/clients/blobstorage.py
@@ -141,8 +141,16 @@ class BlobStorageClientTask(ClientTask):
 
             source = parent.render(source_file.read_text())
 
+            meta.update({'request': {
+                'url': f'{destination}@{self.container}',
+                'payload': source,
+                'metadata': None,
+            }})
+
             with self.service_client.get_blob_client(container=self.container, blob=destination) as blob_client:
                 blob_client.upload_blob(source, content_settings=content_settings)
                 meta['response_length'] = len(source)
+
+            meta.update({'response': {}})
 
         return None, None

--- a/grizzly/tasks/clients/messagequeue.py
+++ b/grizzly/tasks/clients/messagequeue.py
@@ -292,6 +292,8 @@ class MessageQueueClientTask(ClientTask):
                 meta['action'] = self.endpoint_path
                 request['worker'] = self._worker
 
+                meta.update({'request': request.copy()})
+
                 client.send_json(request)
 
                 response = None
@@ -305,7 +307,10 @@ class MessageQueueClientTask(ClientTask):
 
                 response_length_source = (response or {}).get('payload', None) or ''
 
-                meta.update({'response_length': len(response_length_source)})
+                meta.update({
+                    'response_length': len(response_length_source),
+                    'response': response,
+                })
 
                 if response is None:
                     raise RuntimeError('no response')

--- a/grizzly_extras/async_message/mq/__init__.py
+++ b/grizzly_extras/async_message/mq/__init__.py
@@ -1,5 +1,5 @@
 from typing import Optional, Generator, Dict, cast
-from time import monotonic as time, sleep
+from time import perf_counter as time, sleep
 from contextlib import contextmanager
 
 from ...transformer import transformer, TransformerError, TransformerContentType
@@ -55,8 +55,10 @@ class AsyncMessageQueueHandler(AsyncMessageHandler):
             queue = pymqi.Queue(self.qmgr, endpoint)
 
         try:
+            self.logger.info(f'created queue context {endpoint}')  # tmp
             yield queue
         finally:
+            self.logger.info(f'closing {endpoint}')  # tmp
             queue.close()
 
     @register(handlers, 'CONN')
@@ -109,6 +111,8 @@ class AsyncMessageQueueHandler(AsyncMessageHandler):
 
         self.message_wait = context.get('message_wait', None) or 0
         self.header_type = context.get('header_type', None)
+
+        self.logger.info(f'connected to {connection}')  # tmp
 
         return {
             'message': 'connected',
@@ -230,6 +234,8 @@ class AsyncMessageQueueHandler(AsyncMessageHandler):
 
         action = request['action']
 
+        self.logger.info(f'executing {action} on {queue_name}')  # tmp
+
         if action != 'GET' and expression is not None:
             raise AsyncMessageError(f'argument expression is not allowed for action {action}')
 
@@ -257,6 +263,8 @@ class AsyncMessageQueueHandler(AsyncMessageHandler):
             with self.queue_context(endpoint=queue_name) as queue:
                 do_retry: bool = False
 
+                self.logger.info(f'executing {action} on {queue_name}')  # tmp
+                start = time()
                 if action == 'PUT':
                     payload = request.get('payload', None)
                     if self.header_type:
@@ -270,7 +278,6 @@ class AsyncMessageQueueHandler(AsyncMessageHandler):
                     queue.put(payload, md)
 
                 elif action == 'GET':
-
                     if msg_id_to_fetch is not None:
                         gmo = self._create_gmo()
                         gmo.MatchOptions = pymqi.CMQC.MQMO_MATCH_MSG_ID
@@ -294,12 +301,15 @@ class AsyncMessageQueueHandler(AsyncMessageHandler):
                             do_retry = True
                         else:
                             # Some other error condition.
+                            self.logger.error(str(e), exc_info=True)
                             raise AsyncMessageError(str(e))
 
                 if do_retry:
                     retries += 1
                     sleep(retries * retries * 0.5)
                 else:
+                    delta = (time() - start) * 1000
+                    self.logger.info(f'{action} on {queue_name} took {delta} ms, {response_length=}, {retries=}')  # tmp
                     return {
                         'payload': payload,
                         'metadata': md.get(),

--- a/grizzly_extras/async_message/mq/__init__.py
+++ b/grizzly_extras/async_message/mq/__init__.py
@@ -234,8 +234,6 @@ class AsyncMessageQueueHandler(AsyncMessageHandler):
 
         action = request['action']
 
-        self.logger.info(f'executing {action} on {queue_name}')  # tmp
-
         if action != 'GET' and expression is not None:
             raise AsyncMessageError(f'argument expression is not allowed for action {action}')
 

--- a/grizzly_extras/async_message/mq/__init__.py
+++ b/grizzly_extras/async_message/mq/__init__.py
@@ -55,10 +55,8 @@ class AsyncMessageQueueHandler(AsyncMessageHandler):
             queue = pymqi.Queue(self.qmgr, endpoint)
 
         try:
-            self.logger.info(f'created queue context {endpoint}')  # tmp
             yield queue
         finally:
-            self.logger.info(f'closing {endpoint}')  # tmp
             queue.close()
 
     @register(handlers, 'CONN')
@@ -112,7 +110,7 @@ class AsyncMessageQueueHandler(AsyncMessageHandler):
         self.message_wait = context.get('message_wait', None) or 0
         self.header_type = context.get('header_type', None)
 
-        self.logger.info(f'connected to {connection}')  # tmp
+        self.logger.info(f'connected to {connection}')
 
         return {
             'message': 'connected',
@@ -261,7 +259,7 @@ class AsyncMessageQueueHandler(AsyncMessageHandler):
             with self.queue_context(endpoint=queue_name) as queue:
                 do_retry: bool = False
 
-                self.logger.info(f'executing {action} on {queue_name}')  # tmp
+                self.logger.info(f'executing {action} on {queue_name}')
                 start = time()
                 if action == 'PUT':
                     payload = request.get('payload', None)
@@ -307,7 +305,7 @@ class AsyncMessageQueueHandler(AsyncMessageHandler):
                     sleep(retries * retries * 0.5)
                 else:
                     delta = (time() - start) * 1000
-                    self.logger.info(f'{action} on {queue_name} took {delta} ms, {response_length=}, {retries=}')  # tmp
+                    self.logger.info(f'{action} on {queue_name} took {delta} ms, {response_length=}, {retries=}')
                     return {
                         'payload': payload,
                         'metadata': md.get(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,7 @@ generated-members = ["REQ", "LINGER", "REP", "ROUTER", "NOBLOCK", "IDENTITY"]
 [tool.flake8]
 max-line-length = 180
 ignore = ["E722", "W503", "E402", "F405", "F403"]
-exclude = [".git", "__pycache__", "docs", "build", "dist"]
+exclude = [".git", "__pycache__", "docs", "build", "dist", ".pytest_tmp"]
 
 [tool.mypy]
 # https://github.com/python/mypy/issues/5870
@@ -258,8 +258,6 @@ addopts = [
     "--no-cov-on-fail"
 ]
 timeout = 10
-#filterwarnings = [
-#    "ignore:Trying to detect encoding from a tiny portion of.*:UserWarning",
-#    "ignore:currentThread\(\) is deprecated.*:DeprecationWarning",
-#    "ignore:setDaemon\(\) is deprecated.*:DeprecationWarning"
-#]
+filterwarnings = [
+    "ignore:setDaemon\\(\\) is deprecated.*:DeprecationWarning"
+]

--- a/tests/test_grizzly/listeners/test___init__.py
+++ b/tests/test_grizzly/listeners/test___init__.py
@@ -1,6 +1,6 @@
 import logging
 
-from typing import Any, Dict, Tuple, Optional, cast
+from typing import Any, Dict, Tuple, Optional, Callable, cast
 from os import environ
 from random import randint
 
@@ -9,7 +9,7 @@ import pytest
 from _pytest.logging import LogCaptureFixture
 from pytest_mock import MockerFixture
 from locust.env import Environment
-from locust.runners import LocalRunner, MasterRunner, WorkerRunner, CustomMessageListener
+from locust.runners import LocalRunner, MasterRunner, WorkerRunner
 from locust.stats import RequestStats, StatsError
 from behave.model import Scenario, Status
 
@@ -122,7 +122,7 @@ def test_init_master(listener_test_mocker: None, caplog: LogCaptureFixture, griz
 
         init_function(runner)
 
-        assert grizzly.state.locust.custom_messages == cast(Dict[str, CustomMessageListener], {
+        assert grizzly.state.locust.custom_messages == cast(Dict[str, Callable], {
             'test_message': callback,
         })
     finally:
@@ -147,7 +147,7 @@ def test_init_worker(listener_test_mocker: None, grizzly_fixture: GrizzlyFixture
         init_function(runner)
 
         assert environ.get('TESTDATA_PRODUCER_ADDRESS', None) == 'tcp://localhost:5555'
-        assert runner.custom_messages == cast(Dict[str, CustomMessageListener], {
+        assert runner.custom_messages == cast(Dict[str, Callable], {
             'grizzly_worker_quit': grizzly_worker_quit,
         })
 
@@ -162,7 +162,7 @@ def test_init_worker(listener_test_mocker: None, grizzly_fixture: GrizzlyFixture
 
         init_function(runner)
 
-        assert grizzly.state.locust.custom_messages == cast(Dict[str, CustomMessageListener], {
+        assert grizzly.state.locust.custom_messages == cast(Dict[str, Callable], {
             'grizzly_worker_quit': grizzly_worker_quit,
             'test_message_ack': callback_ack,
         })
@@ -209,7 +209,7 @@ def test_init_local(listener_test_mocker: None, grizzly_fixture: GrizzlyFixture)
 
         init_function(runner)
 
-        assert grizzly.state.locust.custom_messages == cast(Dict[str, CustomMessageListener], {
+        assert grizzly.state.locust.custom_messages == cast(Dict[str, Callable], {
             'test_message': callback,
             'test_message_ack': callback_ack,
         })

--- a/tests/test_grizzly/tasks/clients/test_blobstorage.py
+++ b/tests/test_grizzly/tasks/clients/test_blobstorage.py
@@ -17,7 +17,7 @@ from ....fixtures import BehaveFixture, GrizzlyFixture
 
 
 class TestBlobStorageClientTask:
-    def test___init__(self) -> None:
+    def test___init__(self, grizzly_fixture: GrizzlyFixture) -> None:
         with pytest.raises(AttributeError) as ae:
             BlobStorageClientTask(
                 RequestDirection.TO,
@@ -93,7 +93,7 @@ class TestBlobStorageClientTask:
         assert task.container == 'my-container'
         assert task.connection_string == 'DefaultEndpointsProtocol=https;AccountName=my-storage;AccountKey=aaaabbb=;EndpointSuffix=core.windows.net'
 
-    def test_get(self, behave_fixture: BehaveFixture, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
+    def test_get(self, behave_fixture: BehaveFixture, grizzly_fixture: GrizzlyFixture) -> None:
         behave = behave_fixture.context
         grizzly = cast(GrizzlyContext, behave.grizzly)
         grizzly.state.variables['test'] = 'none'

--- a/tests/test_grizzly/tasks/clients/test_http.py
+++ b/tests/test_grizzly/tasks/clients/test_http.py
@@ -60,7 +60,7 @@ class TestHttpClientTask:
 
         assert scenario.user._context['variables'].get('test', None) is None
 
-        print('1. check')
+        task_factory.name = 'test-1'
         response.status_code = 400
 
         task(scenario)
@@ -75,7 +75,7 @@ class TestHttpClientTask:
         assert request_fire_spy.call_count == 1
         _, kwargs = request_fire_spy.call_args_list[-1]
         assert kwargs.get('request_type', None) == 'CLTSK'
-        assert kwargs.get('name', None) == f'{scenario.user._scenario.identifier} Http<-test'
+        assert kwargs.get('name', None) == f'{scenario.user._scenario.identifier} test-1'
         assert kwargs.get('response_time', None) >= 0.0
         assert kwargs.get('response_length') == len(jsondumps({'hello': 'world'}))
         assert kwargs.get('context', None) is scenario.user._context
@@ -95,8 +95,7 @@ class TestHttpClientTask:
 
         scenario.user._context['variables']['test'] = None
         response.status_code = 200
-
-        print('\n2. check')
+        task_factory.name = 'test-2'
 
         task(scenario)
 
@@ -110,7 +109,7 @@ class TestHttpClientTask:
         assert request_fire_spy.call_count == 2
         _, kwargs = request_fire_spy.call_args_list[-1]
         assert kwargs.get('request_type', None) == 'CLTSK'
-        assert kwargs.get('name', None) == f'{scenario.user._scenario.identifier} Http<-test'
+        assert kwargs.get('name', None) == f'{scenario.user._scenario.identifier} test-2'
         assert kwargs.get('response_time', None) >= 0.0
         assert kwargs.get('response_length') == 0
         assert kwargs.get('context', None) is scenario.user._context
@@ -118,14 +117,14 @@ class TestHttpClientTask:
         assert len(list(task_factory.log_dir.rglob('**/*'))) == 2
 
         scenario.user._scenario.failure_exception = StopUser
+        task_factory.name = 'test-3'
 
-        print('\n3. check')
         with pytest.raises(StopUser):
             task(scenario)
 
         scenario.user._scenario.failure_exception = RestartScenario
+        task_factory.name = 'test-4'
 
-        print('\n4. check')
         with pytest.raises(RestartScenario):
             task(scenario)
 
@@ -139,7 +138,7 @@ class TestHttpClientTask:
         assert request_fire_spy.call_count == 4
         _, kwargs = request_fire_spy.call_args_list[-1]
         assert kwargs.get('request_type', None) == 'CLTSK'
-        assert kwargs.get('name', None) == f'{scenario.user._scenario.identifier} Http<-test'
+        assert kwargs.get('name', None) == f'{scenario.user._scenario.identifier} test-4'
         assert kwargs.get('response_time', None) >= 0.0
         assert kwargs.get('response_length') == 0
         assert kwargs.get('context', None) is scenario.user._context
@@ -153,7 +152,6 @@ class TestHttpClientTask:
         assert task_factory.arguments == {}
         assert task_factory.content_type == TransformerContentType.UNDEFINED
 
-        print('\n5. check')
         task(scenario)
 
         assert scenario.user._context['variables'].get('test', '') is None  # not set
@@ -180,7 +178,6 @@ class TestHttpClientTask:
         assert task_factory.content_type == TransformerContentType.UNDEFINED
         task = task_factory()
 
-        print('\n6. check')
         task(scenario)
 
         assert requests_get_spy.call_count == 6
@@ -191,13 +188,12 @@ class TestHttpClientTask:
         assert kwargs.get('headers', {}).get('x-grizzly-user', None).startswith('HttpClientTask::')
         assert len(list(task_factory.log_dir.rglob('**/*'))) == 5
 
-        task_factory = HttpClientTask(RequestDirection.FROM, 'https://$conf::test.host$/api/test | verify=False, content_type=json', 'http-env-get', variable='test')
+        task_factory = HttpClientTask(RequestDirection.FROM, 'https://$conf::test.host$/api/test | verify=False, content_type=json', 'http-env-get-1', variable='test')
         task = task_factory()
         assert task_factory.arguments == {'verify': False}
         assert task_factory.content_type == TransformerContentType.JSON
         assert len(list(task_factory.log_dir.rglob('**/*'))) == 5
 
-        print('\n7. check')
         task(scenario)
 
         assert requests_get_spy.call_count == 7
@@ -209,14 +205,13 @@ class TestHttpClientTask:
         assert request_fire_spy.call_count == 7
         assert len(list(task_factory.log_dir.rglob('**/*'))) == 5
 
-        task_factory = HttpClientTask(RequestDirection.FROM, 'https://$conf::test.host$/api/test | verify=True, content_type=json', 'http-env-get', variable='test')
+        task_factory = HttpClientTask(RequestDirection.FROM, 'https://$conf::test.host$/api/test | verify=True, content_type=json', 'http-env-get-2', variable='test')
         task = task_factory()
         assert task_factory.arguments == {'verify': True}
         assert task_factory.content_type == TransformerContentType.JSON
 
         scenario.user._scenario.context['log_all_requests'] = True
 
-        print('\n8. check')
         task(scenario)
 
         assert requests_get_spy.call_count == 8

--- a/tests/test_grizzly/tasks/clients/test_http.py
+++ b/tests/test_grizzly/tasks/clients/test_http.py
@@ -60,6 +60,7 @@ class TestHttpClientTask:
 
         assert scenario.user._context['variables'].get('test', None) is None
 
+        print('1. check')
         response.status_code = 400
 
         task(scenario)
@@ -95,6 +96,8 @@ class TestHttpClientTask:
         scenario.user._context['variables']['test'] = None
         response.status_code = 200
 
+        print('\n2. check')
+
         task(scenario)
 
         assert scenario.user._context['variables'].get('test', '') is None  # not set
@@ -116,11 +119,13 @@ class TestHttpClientTask:
 
         scenario.user._scenario.failure_exception = StopUser
 
+        print('\n3. check')
         with pytest.raises(StopUser):
             task(scenario)
 
         scenario.user._scenario.failure_exception = RestartScenario
 
+        print('\n4. check')
         with pytest.raises(RestartScenario):
             task(scenario)
 
@@ -148,6 +153,7 @@ class TestHttpClientTask:
         assert task_factory.arguments == {}
         assert task_factory.content_type == TransformerContentType.UNDEFINED
 
+        print('\n5. check')
         task(scenario)
 
         assert scenario.user._context['variables'].get('test', '') is None  # not set
@@ -174,6 +180,7 @@ class TestHttpClientTask:
         assert task_factory.content_type == TransformerContentType.UNDEFINED
         task = task_factory()
 
+        print('\n6. check')
         task(scenario)
 
         assert requests_get_spy.call_count == 6
@@ -190,6 +197,7 @@ class TestHttpClientTask:
         assert task_factory.content_type == TransformerContentType.JSON
         assert len(list(task_factory.log_dir.rglob('**/*'))) == 5
 
+        print('\n7. check')
         task(scenario)
 
         assert requests_get_spy.call_count == 7
@@ -208,6 +216,7 @@ class TestHttpClientTask:
 
         scenario.user._scenario.context['log_all_requests'] = True
 
+        print('\n8. check')
         task(scenario)
 
         assert requests_get_spy.call_count == 8

--- a/tests/test_grizzly/tasks/clients/test_messagequeue.py
+++ b/tests/test_grizzly/tasks/clients/test_messagequeue.py
@@ -58,7 +58,7 @@ class TestMessageQueueClientTaskNoPymqi:
 
 @pytest.mark.skipif(pymqi.__name__ == 'grizzly_extras.dummy_pymqi', reason='needs native IBM MQ libraries')
 class TestMessageQueueClientTask:
-    def test___init__(self, mocker: MockerFixture, noop_zmq: NoopZmqFixture) -> None:
+    def test___init__(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture, noop_zmq: NoopZmqFixture) -> None:
         noop_zmq('grizzly.tasks.clients.messagequeue')
 
         create_client_mocked = mocker.patch('grizzly.tasks.clients.messagequeue.MessageQueueClientTask.create_client', return_value=None)
@@ -106,7 +106,7 @@ class TestMessageQueueClientTask:
             if zmq_context is not None:
                 zmq_context.destroy()
 
-    def test_create_context(self, mocker: MockerFixture, noop_zmq: NoopZmqFixture) -> None:
+    def test_create_context(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture, noop_zmq: NoopZmqFixture) -> None:
         noop_zmq('grizzly.tasks.clients.messagequeue')
         create_client_mocked = mocker.patch('grizzly.tasks.clients.messagequeue.MessageQueueClientTask.create_client', return_value=None)
 
@@ -263,7 +263,7 @@ class TestMessageQueueClientTask:
             if zmq_context is not None:
                 zmq_context.destroy()
 
-    def test_create_client(self, noop_zmq: NoopZmqFixture) -> None:
+    def test_create_client(self, grizzly_fixture: GrizzlyFixture, noop_zmq: NoopZmqFixture) -> None:
         noop_zmq('grizzly.tasks.clients.messagequeue')
         connect_mock = noop_zmq.get_mock('zmq.Socket.connect')
         setsockopt_mock = noop_zmq._mocker.patch('grizzly.tasks.clients.messagequeue.zmq.Socket.setsockopt', autospec=True)
@@ -295,7 +295,7 @@ class TestMessageQueueClientTask:
             if zmq_context is not None:
                 zmq_context.destroy()
 
-    def test_connect(self, noop_zmq: NoopZmqFixture) -> None:
+    def test_connect(self, grizzly_fixture: GrizzlyFixture, noop_zmq: NoopZmqFixture) -> None:
         noop_zmq('grizzly.tasks.clients.messagequeue')
 
         recv_json_mock = noop_zmq.get_mock('recv_json')
@@ -443,6 +443,7 @@ class TestMessageQueueClientTask:
             assert task_factory._worker == 'dddd-eeee-ffff-9999'
             assert send_json_mock.call_count == 2
             args, _ = send_json_mock.call_args_list[-1]
+            print(args)
             assert args[1] == {
                 'action': 'GET',
                 'worker': 'dddd-eeee-ffff-9999',

--- a/tests/test_grizzly/tasks/test_until.py
+++ b/tests/test_grizzly/tasks/test_until.py
@@ -1,4 +1,4 @@
-from typing import Tuple, List
+from typing import Tuple, List, Any, Dict, Type
 from json import dumps as jsondumps
 
 import pytest
@@ -52,13 +52,22 @@ class TestUntilRequestTask:
             UntilRequestTask(grizzly, request, '$.`this`[?status="ready"] | wait=0.1, retries=0')
         assert 'retries argument cannot be less than 1' in str(ve)
 
-    @pytest.mark.parametrize('meta_request_task', [
-        RequestTask(RequestMethod.GET, name='test-request', endpoint='/api/test | content_type=json'),
-        HttpClientTask(RequestDirection.FROM, 'https://example.io/test | content_type=json', 'test-request'),
+    @pytest.mark.parametrize('meta_request_task_type, meta_args, meta_kwargs', [
+        (RequestTask, (RequestMethod.GET,), {'name': 'test-request', 'endpoint': '/api/test | content_type=json'}),
+        (HttpClientTask, (RequestDirection.FROM, 'https://example.io/test | content_type=json', 'test-request',), {}),
     ])
-    def test___call__(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture, meta_request_task: GrizzlyMetaRequestTask) -> None:
+    def test___call__(
+        self,
+        grizzly_fixture: GrizzlyFixture,
+        mocker: MockerFixture,
+        meta_request_task_type: Type[GrizzlyMetaRequestTask],
+        meta_args: Tuple[Any, ...],
+        meta_kwargs: Dict[str, Any],
+    ) -> None:
         _, _, scenario = grizzly_fixture()
         assert scenario is not None
+
+        meta_request_task = meta_request_task_type(*meta_args, **meta_kwargs)
 
         meta_request_task.scenario = grizzly_fixture.request_task.request.scenario
 

--- a/tests/test_grizzly/test_environment.py
+++ b/tests/test_grizzly/test_environment.py
@@ -3,6 +3,7 @@ from typing import Any, Tuple, Dict, Optional, cast
 from time import monotonic as time_monotonic
 from json import dumps as jsondumps
 from shutil import rmtree
+from datetime import datetime
 
 import pytest
 
@@ -85,6 +86,7 @@ def test_after_feature(behave_fixture: BehaveFixture, mocker: MockerFixture) -> 
     behave = behave_fixture.context
     feature = Feature(None, None, '', '', scenarios=[behave.scenario])
     behave.scenario.steps = [Step(None, None, '', '', '')]
+    behave.started = datetime.now().astimezone()
 
     class LocustRunning(Exception):
         pass

--- a/tests/test_grizzly/test_utils.py
+++ b/tests/test_grizzly/test_utils.py
@@ -1,7 +1,15 @@
+import logging
+
 from typing import Optional, Type, cast
 from types import FunctionType
+from datetime import datetime, timedelta, timezone
+from os import utime
 
 import pytest
+
+from _pytest.tmpdir import TempPathFactory
+from _pytest.logging import LogCaptureFixture
+from pytest_mock import MockerFixture
 
 from locust import TaskSet
 from behave.runner import Context
@@ -16,6 +24,7 @@ from grizzly.utils import (
     fail_direct,
     in_correct_section,
     parse_timespan,
+    check_mq_client_logs,
 )
 from grizzly.types import RequestMethod
 from grizzly.context import GrizzlyContext, GrizzlyContextScenario
@@ -464,3 +473,184 @@ def test_parse_timespan() -> None:
         'minutes': 5,
         'seconds': -6,
     }
+
+
+def test_check_mq_client_logs(behave_fixture: BehaveFixture, tmp_path_factory: TempPathFactory, mocker: MockerFixture, caplog: LogCaptureFixture) -> None:
+    context = behave_fixture.context
+    test_context = tmp_path_factory.mktemp('test_context')
+
+    amq_error_dir = test_context / 'IBM' / 'MQ' / 'data' / 'errors'
+    amq_error_dir.mkdir(parents=True, exist_ok=True)
+
+    test_logger = logging.getLogger('test_grizzly_print_stats')
+
+    mocker.patch('grizzly.utils.Path.expanduser', return_value=amq_error_dir)
+    mocker.patch('grizzly.locust.stats_logger', test_logger)
+
+    # context.started not set
+    with caplog.at_level(logging.INFO):
+        check_mq_client_logs(context)
+
+    assert len(caplog.messages) == 0
+
+    # no error files
+    context.started = datetime.now().astimezone()
+    with caplog.at_level(logging.INFO):
+        check_mq_client_logs(context)
+
+    assert len(caplog.messages) == 0
+
+    # one AMQERR*.LOG file, previous run
+    amqerr_log_file_1 = amq_error_dir / 'AMQERR01.LOG'
+    amqerr_log_file_1.write_text('''10/13/22 06:13:07 - Process(6437.52) User(mqm) Program(amqrmppa)
+                    Host(mq.example.io) Installation(Installation1)
+                    VRMF(9.2.1.0) QMgr(QM1)
+                    Time(2022-10-13T06:13:07.215Z)
+                    CommentInsert1(CLIENT.CONN)
+                    CommentInsert2(1111)
+                    CommentInsert3(1.2.3.4)
+
+AMQ9999E: Channel 'CLIENT.CONN' to host '1.2.3.4' ended abnormally.
+
+EXPLANATION:
+----- amqccisa.c : 10957 ------------------------------------------------------
+''')
+
+    with caplog.at_level(logging.INFO):
+        check_mq_client_logs(context)
+
+    assert len(caplog.messages) == 0
+
+    entry_date_1 = (datetime.now() + timedelta(hours=1)).astimezone(tz=timezone.utc)
+
+    # one AMQERR*.LOG file, one entry
+    with amqerr_log_file_1.open('a') as fd:
+        fd.write(f'''{entry_date_1.strftime('%m/%d/%y %H:%M:%S')} - Process(6437.52) User(mqm) Program(amqrmppa)
+                    Host(mq.example.io) Installation(Installation1)
+                    VRMF(9.2.1.0) QMgr(QM1)
+                    Time({entry_date_1.strftime('%Y-%m-%dT%H:%M:%S.000Z')})
+                    CommentInsert1(CLIENT.CONN)
+                    CommentInsert2(1111)
+                    CommentInsert3(1.2.3.4)
+
+AMQ9999E: Channel 'CLIENT.CONN' to host '1.2.3.4' ended abnormally.
+
+EXPLANATION:
+----- amqccisa.c : 10957 ------------------------------------------------------
+''')
+
+    with caplog.at_level(logging.INFO):
+        check_mq_client_logs(context)
+
+    assert len(caplog.messages) == 6
+
+    assert caplog.messages[0] == 'AMQ error log entries:'
+    assert caplog.messages[1].strip() == 'Timestamp (UTC)      Message'
+    assert caplog.messages[3].strip() == f"{entry_date_1.strftime('%Y-%m-%d %H:%M:%S')}  AMQ9999E: Channel 'CLIENT.CONN' to host '1.2.3.4' ended abnormally."
+    assert (
+        caplog.messages[2]
+        == caplog.messages[4]
+        == (
+            '--------------------|-----------------------------------------------------------------'
+            '----------------------------------------------------------------------------'
+        )
+    )
+    assert caplog.messages[5] == ''
+
+    caplog.clear()
+
+    # two AMQERR files, one with no data, one FDC file, old
+    old_date = entry_date_1 - timedelta(hours=2)
+
+    amqerr_log_file_2 = amq_error_dir / 'AMQERR99.LOG'
+    amqerr_log_file_2.touch()
+
+    amqerr_fdc_file_1 = amq_error_dir / 'AMQ6150.0.FDC'
+    amqerr_fdc_file_1.touch()
+    utime(amqerr_fdc_file_1, (old_date.timestamp(), old_date.timestamp()))
+
+    with caplog.at_level(logging.INFO):
+        check_mq_client_logs(context)
+
+    assert len(caplog.messages) == 6
+
+    assert caplog.messages[0] == 'AMQ error log entries:'
+    assert caplog.messages[1].strip() == 'Timestamp (UTC)      Message'
+    assert caplog.messages[3].strip() == f"{entry_date_1.strftime('%Y-%m-%d %H:%M:%S')}  AMQ9999E: Channel 'CLIENT.CONN' to host '1.2.3.4' ended abnormally."
+    assert (
+        caplog.messages[2]
+        == caplog.messages[4]
+        == (
+            '--------------------|-----------------------------------------------------------------'
+            '----------------------------------------------------------------------------'
+        )
+    )
+    assert caplog.messages[5] == ''
+
+    caplog.clear()
+
+    # two AMQERR files, both with valid data. three FDC files, one old
+    entry_date_2 = entry_date_1 + timedelta(minutes=23)
+    amqerr_log_file_2.write_text(f'''{entry_date_2.strftime('%m/%d/%y %H:%M:%S')} - Process(6437.52) User(mqm) Program(amqrmppa)
+                    Host(mq.example.io) Installation(Installation1)
+                    VRMF(9.2.1.0) QMgr(QM1)
+                    Time({entry_date_2.strftime('%Y-%m-%dT%H:%M:%S.000Z')})
+                    CommentInsert1(CLIENT.CONN)
+                    CommentInsert2(1111)
+                    CommentInsert3(1.2.3.4)
+
+AMQ1234E: dude, what did you do?!
+
+EXPLANATION:
+----- amqccisa.c : 10957 ------------------------------------------------------
+''')
+    amqerr_fdc_file_2 = amq_error_dir / 'AMQ1234.1.FDC'
+    amqerr_fdc_file_2.touch()
+    utime(amqerr_fdc_file_2, (entry_date_2.timestamp(), entry_date_2.timestamp(),))
+
+    amqerr_fdc_file_3 = amq_error_dir / 'AMQ4321.9.FDC'
+    amqerr_fdc_file_3.touch()
+    entry_date_3 = entry_date_2 + timedelta(minutes=73)
+    utime(amqerr_fdc_file_3, (entry_date_3.timestamp(), entry_date_3.timestamp(),))
+
+    with caplog.at_level(logging.INFO):
+        check_mq_client_logs(context)
+
+    print('\n'.join(caplog.messages))
+
+    assert len(caplog.messages) == 14
+
+    assert caplog.messages.index('AMQ error log entries:') == 0
+    assert caplog.messages.index('AMQ FDC files:') == 7
+
+    amqerr_log_entries = caplog.messages[0:6]
+    print(amqerr_log_entries)
+    assert len(amqerr_log_entries) == 6
+
+    assert amqerr_log_entries[1].strip() == 'Timestamp (UTC)      Message'
+    assert (
+        amqerr_log_entries[2]
+        == amqerr_log_entries[5]
+        == (
+            '--------------------|-----------------------------------------------------------------'
+            '----------------------------------------------------------------------------'
+        )
+    )
+    assert amqerr_log_entries[3].strip() == f"{entry_date_1.strftime('%Y-%m-%d %H:%M:%S')}  AMQ9999E: Channel 'CLIENT.CONN' to host '1.2.3.4' ended abnormally."
+    assert amqerr_log_entries[4].strip() == f'{entry_date_2.strftime("%Y-%m-%d %H:%M:%S")}  AMQ1234E: dude, what did you do?!'
+
+    amqerr_fdc_files = caplog.messages[7:-1]
+    assert len(amqerr_fdc_files) == 6
+
+    assert amqerr_fdc_files[1].strip() == 'Timestamp (UTC)      File'
+    assert (
+        amqerr_fdc_files[2]
+        == amqerr_fdc_files[5]
+        == (
+            '--------------------|-----------------------------------------------------------------'
+            '----------------------------------------------------------------------------'
+        )
+    )
+
+    assert amqerr_fdc_files[3].strip() == f'{entry_date_2.strftime("%Y-%m-%d %H:%M:%S")}  {amqerr_fdc_file_2}'
+    assert amqerr_fdc_files[4].strip() == f'{entry_date_3.strftime("%Y-%m-%d %H:%M:%S")}  {amqerr_fdc_file_3}'

--- a/tests/test_grizzly/users/base/test_request_logger.py
+++ b/tests/test_grizzly/users/base/test_request_logger.py
@@ -72,10 +72,10 @@ class TestRequestLogger:
         assert user.client is None
 
     @pytest.mark.usefixtures('request_logger')
-    def test__normalize(self, request_logger: RequestLogger) -> None:
-        assert request_logger._normalize('test') == 'test'
-        assert request_logger._normalize('Hello World!') == 'Hello-World'
-        assert request_logger._normalize('[does]this-look* <strange>!') == 'doesthis-look-strange'
+    def test_normalize(self, request_logger: RequestLogger) -> None:
+        assert request_logger.normalize('test') == 'test'
+        assert request_logger.normalize('Hello World!') == 'Hello-World'
+        assert request_logger.normalize('[does]this-look* <strange>!') == 'doesthis-look-strange'
 
     @pytest.mark.usefixtures('request_logger')
     def test__remove_secrets_attribute(self, request_logger: RequestLogger) -> None:


### PR DESCRIPTION
there has been a problem with missing messages from MQ. where as the get/put statistics (most of the time) has been correct, load flows has still failed due to no messages on the queue in question.

in an effort to get to the bottom with this problem some additional MQ information is fetched after each feature run (if `pymqi` is installed, e.g. `grizzly-loadtester[mq]`.

in addition to that, a very simple request logger has been implemented for `grizzly.tasks.clients.HttpClientTask`.