### PR TITLE
`__on_consumer__` testdata variables needs information about current scenario

### DIFF
--- a/grizzly/scenarios/__init__.py
+++ b/grizzly/scenarios/__init__.py
@@ -45,7 +45,7 @@ class GrizzlyScenario(SequentialTaskSet):
         producer_address = environ.get('TESTDATA_PRODUCER_ADDRESS', None)
         if producer_address is not None:
             self.consumer = TestdataConsumer(
-                grizzly=self.grizzly,
+                scenario=self,
                 address=producer_address,
                 identifier=self.__class__.__name__,
             )

--- a/grizzly/testdata/communication.py
+++ b/grizzly/testdata/communication.py
@@ -23,19 +23,20 @@ from . import GrizzlyVariables
 
 if TYPE_CHECKING:
     from ..context import GrizzlyContext
+    from ..scenarios import GrizzlyScenario
 
 
 class TestdataConsumer:
     # need so pytest doesn't raise PytestCollectionWarning
     __test__: bool = False
 
-    grizzly: 'GrizzlyContext'
+    scenario: 'GrizzlyScenario'
     logger: logging.Logger
     identifier: str
     stopped: bool
 
-    def __init__(self, grizzly: 'GrizzlyContext', identifier: str, address: str = 'tcp://127.0.0.1:5555') -> None:
-        self.grizzly = grizzly
+    def __init__(self, scenario: 'GrizzlyScenario', identifier: str, address: str = 'tcp://127.0.0.1:5555') -> None:
+        self.scenario = scenario
         self.identifier = identifier
         self.logger = logging.getLogger(f'{__name__}/{self.identifier}')
 
@@ -92,10 +93,10 @@ class TestdataConsumer:
 
         variables: Optional[Dict[str, Any]] = None
         if 'variables' in data:
-            variables = transform(self.grizzly, data['variables'], objectify=True)
+            variables = transform(self.scenario.grizzly, data['variables'], objectify=True, scenario=self.scenario.user._scenario)
             del data['variables']
 
-        data = transform(self.grizzly, data, objectify=False)
+        data = transform(self.scenario.grizzly, data, objectify=False, scenario=self.scenario.user._scenario)
 
         if variables is not None:
             data['variables'] = variables

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,7 +249,7 @@ module = "geventhttpclient.*"
 ignore_missing_imports = true
 
 [tool.coverage.run]
-omit = ["tests/*", "setup.py"]
+omit = ["tests/*", "setup.py", ".pytest_tmp"]
 
 [tool.pytest.ini_options]
 addopts = [

--- a/tests/test_grizzly/scenarios/test_iterator.py
+++ b/tests/test_grizzly/scenarios/test_iterator.py
@@ -24,7 +24,6 @@ from ...helpers import RequestCalled, TestTask
 
 
 if TYPE_CHECKING:
-    from grizzly.context import GrizzlyContext
     from grizzly.scenarios import GrizzlyScenario
 
 
@@ -94,7 +93,7 @@ class TestIterationScenario:
         try:
             _, _, scenario = grizzly_fixture(scenario_type=IteratorScenario)
 
-            def TestdataConsumer__init__(self: 'TestdataConsumer', grizzly: 'GrizzlyContext', address: str, identifier: str) -> None:
+            def TestdataConsumer__init__(self: 'TestdataConsumer', scenario: 'GrizzlyScenario', address: str, identifier: str) -> None:
                 pass
 
             mocker.patch(
@@ -134,7 +133,7 @@ class TestIterationScenario:
 
         assert isinstance(scenario, IteratorScenario)
 
-        scenario.consumer = TestdataConsumer(grizzly, identifier='test')
+        scenario.consumer = TestdataConsumer(scenario, identifier='test')
 
         def mock_request(data: Optional[Dict[str, Any]]) -> None:
             def request(self: 'TestdataConsumer', scenario: str) -> Optional[Dict[str, Any]]:

--- a/tests/test_grizzly/testdata/test_communication.py
+++ b/tests/test_grizzly/testdata/test_communication.py
@@ -417,9 +417,11 @@ class TestTestdataConsumer:
                 ]
             )
 
+        _, _, scenario = grizzly_fixture()
+        assert scenario is not None
         grizzly = grizzly_fixture.grizzly
 
-        consumer = TestdataConsumer(grizzly, identifier='test')
+        consumer = TestdataConsumer(scenario, identifier='test')
 
         try:
             # this will no longer throw StopUser, but rather go into an infinite loop
@@ -505,8 +507,12 @@ class TestTestdataConsumer:
             side_effect=[RuntimeError('zmq.Context.destroy failed')],
         )
 
+        _, _, scenario = grizzly_fixture()
+
+        assert scenario is not None
+
         with caplog.at_level(logging.DEBUG):
-            TestdataConsumer(grizzly_fixture.grizzly, identifier='test').stop()
+            TestdataConsumer(scenario, identifier='test').stop()
         assert caplog.messages[-1] == 'failed to stop'
 
     def test_request_exception(self, mocker: MockerFixture, noop_zmq: NoopZmqFixture, grizzly_fixture: GrizzlyFixture) -> None:
@@ -522,8 +528,12 @@ class TestTestdataConsumer:
             side_effect=[ZMQAgain]
         )
 
+        _, _, scenario = grizzly_fixture()
+
+        assert scenario is not None
+
         with pytest.raises(ZMQAgain):
-            TestdataConsumer(grizzly_fixture.grizzly, identifier='test').request('test')
+            TestdataConsumer(scenario, identifier='test').request('test')
 
         assert gsleep_mock.call_count == 1
         args, _ = gsleep_mock.call_args_list[-1]


### PR DESCRIPTION
so that `grizzly_print_stats` work, since it assumes that all statistics is prefixed with scenario identifier.