### PR TITLE
get messages from MQ with SYNCPOINT and configuration of max message size

### DIFF
--- a/grizzly/environment.py
+++ b/grizzly/environment.py
@@ -13,7 +13,7 @@ from behave.model_core import Status
 
 from .context import GrizzlyContext
 from .testdata.variables import destroy_variables
-from .locust import run as locustrun
+from .locust import run as locustrun, on_worker
 from .utils import catch, check_mq_client_logs, fail_direct, in_correct_section
 from .types import RequestType
 
@@ -86,7 +86,7 @@ def after_feature(context: Context, feature: Feature, *args: Tuple[Any, ...], **
                     behave_step = cast(Step, behave_scenario.steps[rindex])
                     behave_step.status = Status.failed
 
-        if pymqi.__name__ != 'grizzly_extras.dummy_pymqi':
+        if pymqi.__name__ != 'grizzly_extras.dummy_pymqi' and not on_worker(context):
             check_mq_client_logs(context)
     else:
         return_code = 1

--- a/grizzly_extras/async_message/daemon.py
+++ b/grizzly_extras/async_message/daemon.py
@@ -22,7 +22,7 @@ from grizzly_extras.transformer import JsonBytesEncoder
 
 def router() -> None:
     logger = ThreadLogger('router')
-    proc.setproctitle('async-messaged')
+    proc.setproctitle('grizzly-async-messaged')  # set appl name on ibm mq
     logger.debug('starting')
 
     context = zmq.Context(1)

--- a/tests/test_grizzly_extras/async_message/mq/test___init__.py
+++ b/tests/test_grizzly_extras/async_message/mq/test___init__.py
@@ -1,7 +1,7 @@
 import subprocess
 import sys
 
-from typing import Any, List, Optional, Tuple, Dict, cast
+from typing import Any, List, Tuple, Dict, cast
 from os import environ
 
 import pytest
@@ -258,25 +258,11 @@ class TestAsyncMessageQueueHandler:
         assert isinstance(gmo, pymqi.GMO)
 
     def test__request(self, mocker: MockerFixture) -> None:
-        def mocked_pymqi_close(p: pymqi.Queue, options: Optional[Any] = None) -> None:
-            pass
-
         def mocked_pymqi_put(p: pymqi.Queue, payload: Any, md: pymqi.MD) -> None:
             assert payload == 'test payload'
 
         def mocked_pymqi_put_rfh2(p: pymqi.Queue, payload: Any, md: pymqi.MD) -> None:
             assert len(payload) == 284
-
-        def mocked_pymqi_get(p: pymqi.Queue, *args: Tuple[Any, ...]) -> bytes:
-            return b'test payload'
-
-        def mocked_pymqi_get_rfh2(p: pymqi.Queue, *args: Tuple[Any, ...]) -> bytes:
-            return b'RFH \x02\x00\x00\x00\xfc\x00\x00\x00"\x02\x00\x00\xb8\x04\x00\x00        \x00\x00\x00\x00\xb8\x04\x00\x00 \x00\x00\x00<mcd><Msd>jms_bytes</Msd></mcd> ' \
-                   b'P\x00\x00\x00<jms><Dst>queue:///TEST.QUEUE</Dst><Tms>1655406556138</Tms><Dlv>2</Dlv></jms>   \\\x00\x00\x00<usr><ContentEncoding>gzip</ContentEncoding>' \
-                   b'<ContentLength dt=\'i8\'>32</ContentLength></usr> \x1f\x8b\x08\x00\xdc\x7f\xabb\x02\xff+I-.Q(H\xac\xcc\xc9OL\x01\x00\xe1=\x1d\xeb\x0c\x00\x00\x00'
-
-        def mocked_pymqi_get_that_raises(p: pymqi.Queue, *args: Tuple[Any, ...]) -> bytes:
-            raise pymqi.MQMIError(pymqi.CMQC.MQCC_FAILED, pymqi.CMQC.MQRC_UNEXPECTED_ERROR)
 
         mocker.patch.object(
             pymqi.Queue,
@@ -284,19 +270,21 @@ class TestAsyncMessageQueueHandler:
             mocked_pymqi_put,
         )
 
-        mocker.patch.object(
+        mocked_pymqi_get = mocker.patch.object(
             pymqi.Queue,
             'get',
-            mocked_pymqi_get,
+            return_value=b'test payload',
         )
 
         mocker.patch.object(
             pymqi.Queue,
             'close',
-            mocked_pymqi_close,
+            return_value=None,
         )
 
         handler = AsyncMessageQueueHandler(worker='asdf-asdf-asdf')
+
+        handler_queue_context = mocker.spy(handler, 'queue_context')
 
         request: AsyncMessageRequest = {}
 
@@ -324,6 +312,10 @@ class TestAsyncMessageQueueHandler:
         assert response.get('metadata', None) == pymqi.MD().get()
         assert response.get('response_length', 0) == len('test payload')
 
+        assert handler_queue_context.call_count == 1
+        _, kwargs = handler_queue_context.call_args_list[-1]
+        assert kwargs.get('endpoint', None) == 'TEST.QUEUE'
+
         mocker.patch.object(
             pymqi.Queue,
             'put',
@@ -335,10 +327,18 @@ class TestAsyncMessageQueueHandler:
         assert response.get('metadata', None) == Rfh2Encoder.create_md().get()
         assert response.get('response_length', 0) == 284
 
+        assert handler_queue_context.call_count == 2
+        _, kwargs = handler_queue_context.call_args_list[-1]
+        assert kwargs.get('endpoint', None) == 'TEST.QUEUE'
+
         handler.header_type = 'somethingWeird'
         with pytest.raises(AsyncMessageError) as mqe:
             handler._request(request)
         assert 'Invalid header_type: somethingWeird' in str(mqe)
+
+        assert handler_queue_context.call_count == 3
+        _, kwargs = handler_queue_context.call_args_list[-1]
+        assert kwargs.get('endpoint', None) == 'TEST.QUEUE'
 
         handler.message_wait = 0
 
@@ -358,21 +358,47 @@ class TestAsyncMessageQueueHandler:
         assert response.get('metadata', None) == pymqi.MD().get()
         assert response.get('response_length', None) == len('test payload')
 
+        assert handler_queue_context.call_count == 4
+        _, kwargs = handler_queue_context.call_args_list[-1]
+        assert kwargs.get('endpoint', None) == 'TEST.QUEUE'
+
+        assert mocked_pymqi_get.call_count == 1
+        args, _ = mocked_pymqi_get.call_args_list[-1]
+        assert args[0] is None  # max_message_size
+        assert isinstance(args[1], pymqi.MD)
+        assert isinstance(args[2], pymqi.GMO)
+
         assert create_gmo_spy.call_count == 1
         args, _ = create_gmo_spy.call_args_list[0]
         assert args[0] == 10
 
-        mocker.patch.object(
+        mocked_pymqi_get = mocker.patch.object(
             pymqi.Queue,
             'get',
-            mocked_pymqi_get_rfh2,
+            return_value=(
+                b'RFH \x02\x00\x00\x00\xfc\x00\x00\x00"\x02\x00\x00\xb8\x04\x00\x00        \x00\x00\x00\x00\xb8\x04\x00\x00 \x00\x00\x00<mcd><Msd>jms_bytes</Msd></mcd> '
+                b'P\x00\x00\x00<jms><Dst>queue:///TEST.QUEUE</Dst><Tms>1655406556138</Tms><Dlv>2</Dlv></jms>   \\\x00\x00\x00<usr><ContentEncoding>gzip</ContentEncoding>'
+                b'<ContentLength dt=\'i8\'>32</ContentLength></usr> \x1f\x8b\x08\x00\xdc\x7f\xabb\x02\xff+I-.Q(H\xac\xcc\xc9OL\x01\x00\xe1=\x1d\xeb\x0c\x00\x00\x00'
+            )
         )
+
+        request['context'].update({'endpoint': 'queue:TEST.QUEUE, max_message_size:13337'})
 
         handler.header_type = 'rfh2'
         response = handler._request(request)
         assert response.get('payload', None) == 'test payload'
         assert response.get('metadata', None) == Rfh2Encoder.create_md().get()
         assert response.get('response_length', None) == len('test payload')
+
+        assert handler_queue_context.call_count == 5
+        _, kwargs = handler_queue_context.call_args_list[-1]
+        assert kwargs.get('endpoint', None) == 'TEST.QUEUE'
+
+        assert mocked_pymqi_get.call_count == 1
+        args, _ = mocked_pymqi_get.call_args_list[-1]
+        assert args[0] == 13337  # max_message_size
+        assert isinstance(args[1], pymqi.MD)
+        assert isinstance(args[2], pymqi.GMO)
 
         assert create_gmo_spy.call_count == 2
         args, _ = create_gmo_spy.call_args_list[0]
@@ -383,6 +409,10 @@ class TestAsyncMessageQueueHandler:
         handler.message_wait = 13
 
         response = handler._request(request)
+        assert handler_queue_context.call_count == 6
+        _, kwargs = handler_queue_context.call_args_list[-1]
+        assert kwargs.get('endpoint', None) == 'TEST.QUEUE'
+
         assert create_gmo_spy.call_count == 3
         args, _ = create_gmo_spy.call_args_list[2]
         assert args[0] == 13
@@ -390,7 +420,7 @@ class TestAsyncMessageQueueHandler:
         mocker.patch.object(
             pymqi.Queue,
             'get',
-            mocked_pymqi_get_that_raises,
+            side_effect=[pymqi.MQMIError(pymqi.CMQC.MQCC_FAILED, pymqi.CMQC.MQRC_UNEXPECTED_ERROR)],
         )
         with pytest.raises(AsyncMessageError) as mqe:
             response = handler._request(request)


### PR DESCRIPTION
we've seen problems where the `async-messaged` client fails a scenario due to `MQRC_NO_MSG_AVAILABLE`. but when looking at the MQ queue put and get statistics, it all looks good (i.e. the same amount of expected puts and gets).

some messages was too big for the client message buffer size, resulting in `MQRC_TRUNCATED_MSG_FAILED`, in those cases it did seem like the message was put back on the queue, because number of missing messages did not correlated to number of `MQRC_TRUNCATED_MSG_FAILED` "errors" seen in the logs.

as a way to ensure that `async-messaged` doesn't loose messages, GET actions are now done with `MQGMO_SYNCPOINT`, and if there's an exception during the get operation, the queue manager will backout of what ever it has done (ensure that the message is put back on the queue).

also, to minimize the number of `MQRC_TRUNCATED_MSG_FAILED`, the parameter "max message size" was implemented in `grizzly_extras.async_messaged.mq` and supported added for `grizzly.tasks.clients.messagequeue` and `grizzly.users.messagequeue`. 