### PR TITLE
concurrency fixes in MQ and SB related code

### DIFF
--- a/grizzly/users/base/grizzly_user.py
+++ b/grizzly/users/base/grizzly_user.py
@@ -36,6 +36,7 @@ class GrizzlyUser(User):
     logger: Logger
 
     weight: int = 1
+    host: str
 
     def __init__(self, environment: Environment, *args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> None:
         super().__init__(environment, *args, **kwargs)
@@ -44,6 +45,8 @@ class GrizzlyUser(User):
         self._context = merge_dicts({}, GrizzlyUser._context)
         self.logger = logging.getLogger(f'{self.__class__.__name__}/{id(self)}')
         self._scenario_state = None
+
+        assert self.host is not None, f'{self.__class__.__name__} must have host set'
 
     @property
     def scenario_state(self) -> Optional[ScenarioState]:

--- a/grizzly/users/blobstorage.py
+++ b/grizzly/users/blobstorage.py
@@ -45,15 +45,14 @@ from ..utils import merge_dicts
 
 class BlobStorageUser(GrizzlyUser):
     client: BlobServiceClient
-    host: str
     _context: Dict[str, Any] = {}
 
     def __init__(self, environment: Environment, *args: Tuple[Any], **kwargs: Dict[str, Any]) -> None:
         super().__init__(environment, *args, **kwargs)
 
-        conn_str = self.host
+        conn_str: str = self.host
         if conn_str.startswith('DefaultEndpointsProtocol='):
-            conn_str = conn_str[25:]
+            conn_str = conn_str[25:]  # pylint: disable=unsubscriptable-object
 
         # Replace semicolon separators between parameters to ? and & and massage it to make it "urlparse-compliant"
         # for validation

--- a/grizzly/users/iothub.py
+++ b/grizzly/users/iothub.py
@@ -45,7 +45,6 @@ from ..utils import merge_dicts
 
 class IotHubUser(GrizzlyUser):
     client: IoTHubDeviceClient
-    host: str
     _context: Dict[str, Any] = {}
 
     def __init__(self, environment: Environment, *args: Tuple[Any], **kwargs: Dict[str, Any]) -> None:

--- a/grizzly/users/restapi.py
+++ b/grizzly/users/restapi.py
@@ -151,7 +151,7 @@ class refresh_token:
 class RestApiUser(ResponseHandler, RequestLogger, GrizzlyUser, HttpRequests, AsyncRequests):
     session_started: Optional[float]
     headers: Dict[str, Optional[str]]
-    host: str
+
     _context: Dict[str, Any] = {
         'verify_certificates': True,
         'auth': {

--- a/grizzly/users/servicebus.py
+++ b/grizzly/users/servicebus.py
@@ -107,8 +107,6 @@ class ServiceBusUser(ResponseHandler, RequestLogger, GrizzlyUser):
     zmq_url = 'tcp://127.0.0.1:5554'
     hellos: Set[str]
 
-    host: str
-
     def __init__(self, environment: Environment, *args: Tuple[Any], **kwargs: Dict[str, Any]) -> None:
         super().__init__(environment, *args, **kwargs)
 

--- a/grizzly_extras/async_message/mq/__init__.py
+++ b/grizzly_extras/async_message/mq/__init__.py
@@ -310,6 +310,9 @@ class AsyncMessageQueueHandler(AsyncMessageHandler):
                                 do_retry = True
                             else:
                                 raise AsyncMessageError(f'message with size {original_length} bytes does not fit in message buffer of {max_message_size} bytes')
+                        elif e.reason == pymqi.CMQC.MQRC_BACKED_OUT:
+                            self.logger.warning(f'got MQRC_BACKED_OUT while getting message, {retries=}')
+                            do_retry = True
                         else:
                             # Some other error condition.
                             self.logger.error(str(e), exc_info=True)

--- a/tests/test_grizzly/users/base/test_grizzly_user.py
+++ b/tests/test_grizzly/users/base/test_grizzly_user.py
@@ -23,6 +23,8 @@ logging.getLogger().setLevel(logging.CRITICAL)
 
 
 class DummyGrizzlyUser(GrizzlyUser):
+    host: str = 'http://example.com'
+
     def request(self, request: RequestTask) -> GrizzlyResponse:
         raise NotImplementedError(f'{self.__class__.__name__} has not implemented request')
 
@@ -77,7 +79,9 @@ class TestGrizzlyUser:
             user_type = type(
                 'ContextVariablesUserFileRequest',
                 (GrizzlyUser, FileRequests, ),
-                {},
+                {
+                    'host': 'http://example.io',
+                },
             )
             user = user_type(locust_fixture)
             assert issubclass(user.__class__, (FileRequests,))

--- a/tests/test_grizzly/users/base/test_response_event.py
+++ b/tests/test_grizzly/users/base/test_response_event.py
@@ -41,7 +41,7 @@ class TestResponseEvent:
         class Called(Exception):
             pass
 
-        ResponseEvent.host = 'http://example.com'
+        ResponseEvent.host = TestUser.host = 'http://example.com'
         user = ResponseEvent(locust_fixture.env)
 
         def handler(name: str, request: Optional[RequestTask], context: Union[ResponseContextManager, Tuple[Dict[str, Any], str]], user: User) -> None:

--- a/tests/test_grizzly/users/base/test_response_handler.py
+++ b/tests/test_grizzly/users/base/test_response_handler.py
@@ -40,6 +40,7 @@ class TestResponseHandlerAction:
 
     def test___(self, locust_fixture: LocustFixture) -> None:
         assert issubclass(ResponseHandlerAction, ABC)
+        TestUser.host = 'http://example.net'
         user = TestUser(locust_fixture.env)
         handler = TestResponseHandlerAction.Dummy('$.', '.*')
         assert handler.expression == '$.'
@@ -51,6 +52,7 @@ class TestResponseHandlerAction:
         assert str(nie.value) == 'Dummy has not implemented __call__'
 
     def test_get_matches(self, locust_fixture: LocustFixture) -> None:
+        TestUser.host = 'http://example.net'
         user = TestUser(locust_fixture.env)
         handler = TestResponseHandlerAction.Dummy('//hello/world', '.*')
 
@@ -94,6 +96,7 @@ class TestValidationHandlerAction:
     def test___call___true(self, locust_fixture: LocustFixture) -> None:
         scenario = GrizzlyContextScenario(index=1)
         scenario.name = 'test-scenario'
+        TestUser.host = 'http://example.net'
         user = TestUser(locust_fixture.env)
         user._scenario = scenario
 
@@ -256,6 +259,7 @@ class TestValidationHandlerAction:
     def test___call___false(self, locust_fixture: LocustFixture) -> None:
         scenario = GrizzlyContextScenario(index=1)
         scenario.name = 'test-scenario'
+        TestUser.host = 'http://example.io'
         user = TestUser(locust_fixture.env)
         user._scenario = scenario
         response = Response()
@@ -427,6 +431,7 @@ class TestSaveHandlerAction:
         assert handler.expected_matches == 1
 
     def test___call__(self, locust_fixture: LocustFixture) -> None:
+        TestUser.host = 'http://example.com'
         user = TestUser(locust_fixture.env)
         response = Response()
         response._content = '{}'.encode('utf-8')
@@ -677,7 +682,7 @@ class TestResponseHandler:
         assert len(user.response_event._handlers) == 1
 
     def test_response_handler_response_context(self, mocker: MockerFixture, locust_fixture: LocustFixture) -> None:
-        ResponseHandler.host = 'http://example.com'
+        ResponseHandler.host = TestUser.host = 'http://example.com'
         user = ResponseHandler(locust_fixture.env)
         test_user = TestUser(locust_fixture.env)
 
@@ -771,7 +776,7 @@ class TestResponseHandler:
         assert 'failed to transform' in str(response_context_manager._manual_result)
 
     def test_response_handler_custom_response(self, mocker: MockerFixture, locust_fixture: LocustFixture) -> None:
-        ResponseHandler.host = 'http://example.com'
+        ResponseHandler.host = TestUser.host = 'http://example.com'
         user = ResponseHandler(locust_fixture.env)
         test_user = TestUser(locust_fixture.env)
 


### PR DESCRIPTION
implementation of using MQ feature `SYNCHPOINT` to get messages in a transactional way, being able to backout/rollback if something goes wrong, ensuring that messages involved are put back on the queue for next client to read.

fixed concurrency problem in testdata variables, which was discovered via `AtomicServiceBus`, making interaction with the implementations more robust related to concurrency.