### PR TITLE
csv logging

### DIFF
--- a/grizzly/context.py
+++ b/grizzly/context.py
@@ -9,7 +9,8 @@ import yaml
 from behave.model import Scenario
 from locust.runners import Runner
 
-from .types import MessageCallback, MessageDirection
+from grizzly.types import MessageCallback, MessageDirection
+
 from .testdata import GrizzlyVariables
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/grizzly/environment.py
+++ b/grizzly/environment.py
@@ -11,11 +11,12 @@ from behave.runner import Context
 from behave.model import Feature, Step, Scenario
 from behave.model_core import Status
 
+from grizzly.types import RequestType
+
 from .context import GrizzlyContext
 from .testdata.variables import destroy_variables
 from .locust import run as locustrun, on_worker
 from .utils import catch, check_mq_client_logs, fail_direct, in_correct_section
-from .types import RequestType
 
 try:
     import pymqi  # pylint: disable=unused-import

--- a/grizzly/listeners/__init__.py
+++ b/grizzly/listeners/__init__.py
@@ -19,8 +19,9 @@ from locust.stats import (
 )
 from behave.model import Status
 
+from grizzly.types import MessageDirection, RequestType, TestdataType
+
 from ..context import GrizzlyContext
-from ..types import MessageDirection, RequestType, TestdataType
 from ..testdata.communication import TestdataProducer
 
 producer: Optional[TestdataProducer] = None

--- a/grizzly/locust.py
+++ b/grizzly/locust.py
@@ -33,10 +33,11 @@ from locust.util.timespan import parse_timespan
 from locust import events
 from jinja2.exceptions import TemplateError
 
+from grizzly.types import RequestType, TestdataType
+
 from . import __version__, __locust_version__
 from .listeners import init, init_statistics_listener, quitting, validate_result, spawning_complete, locust_test_start, locust_test_stop
 from .testdata.utils import initialize_testdata
-from .types import RequestType, TestdataType
 from .context import GrizzlyContext
 from .tasks import GrizzlyTask
 from .users.base import GrizzlyUser

--- a/grizzly/scenarios/__init__.py
+++ b/grizzly/scenarios/__init__.py
@@ -7,10 +7,11 @@ from locust.exception import StopUser
 from locust.user.sequential_taskset import SequentialTaskSet
 from jinja2 import Template
 
+from grizzly.types import ScenarioState
+
 from ..context import GrizzlyContext
 from ..testdata.communication import TestdataConsumer
 from ..tasks import GrizzlyTask
-from ..types import ScenarioState
 
 if TYPE_CHECKING:
     from ..users.base import GrizzlyUser

--- a/grizzly/scenarios/iterator.py
+++ b/grizzly/scenarios/iterator.py
@@ -10,7 +10,8 @@ from locust.exception import StopUser, InterruptTaskSet, RescheduleTaskImmediate
 from locust.stats import StatsEntry
 from gevent.exceptions import GreenletExit
 
-from ..types import RequestType, ScenarioState
+from grizzly.types import RequestType, ScenarioState
+
 from ..exceptions import RestartScenario, StopScenario
 from . import GrizzlyScenario
 

--- a/grizzly/steps/_helpers.py
+++ b/grizzly/steps/_helpers.py
@@ -14,8 +14,9 @@ from behave.model import Row
 from grizzly_extras.transformer import TransformerContentType
 from grizzly_extras.arguments import split_value, parse_arguments, get_unsupported_arguments
 
+from grizzly.types import RequestMethod, ResponseTarget, ResponseAction
+
 from ..context import GrizzlyContext
-from ..types import RequestMethod, ResponseTarget, ResponseAction
 from ..tasks import RequestTask
 from ..tasks.clients import client, ClientTask
 from ..testdata.utils import resolve_variable

--- a/grizzly/steps/background/setup.py
+++ b/grizzly/steps/background/setup.py
@@ -13,7 +13,8 @@ from behave.runner import Context
 
 from grizzly_extras.text import permutation
 
-from ...types import MessageDirection, Environment, Message
+from grizzly.types import MessageDirection, Environment, Message
+
 from ...context import GrizzlyContext
 from ...utils import merge_dicts
 from ...testdata.utils import create_context_variable, resolve_variable

--- a/grizzly/steps/scenario/response.py
+++ b/grizzly/steps/scenario/response.py
@@ -23,9 +23,10 @@ from behave import register_type, when, then  # pylint: disable=no-name-in-modul
 from grizzly_extras.transformer import TransformerContentType
 from grizzly_extras.text import permutation
 
+from grizzly.types import ResponseTarget
+
 from ...context import GrizzlyContext
 from ...tasks import RequestTask
-from ...types import ResponseTarget
 from .._helpers import add_save_handler, add_validation_handler, add_request_task_response_status_codes
 
 

--- a/grizzly/steps/scenario/tasks.py
+++ b/grizzly/steps/scenario/tasks.py
@@ -7,10 +7,9 @@ from typing import cast
 from behave.runner import Context
 from behave import register_type, then, given, when  # pylint: disable=no-name-in-module
 
-from grizzly.tasks.conditional import ConditionalTask  # pylint: disable=no-name-in-module
+from grizzly.types import RequestDirection, RequestMethod
 
 from .._helpers import add_request_task, get_task_client, is_template
-from ...types import RequestDirection, RequestMethod
 from ...context import GrizzlyContext
 from ...tasks import (
     LogMessageTask,
@@ -22,6 +21,7 @@ from ...tasks import (
     TimerTask,
     TaskWaitTask,
     LoopTask,
+    ConditionalTask,
 )
 
 from grizzly_extras.transformer import TransformerContentType

--- a/grizzly/tasks/__init__.py
+++ b/grizzly/tasks/__init__.py
@@ -23,9 +23,9 @@ from pathlib import Path
 from grizzly_extras.transformer import TransformerContentType
 
 if TYPE_CHECKING:  # pragma: no cover
+    from grizzly.types import GrizzlyResponse
     from ..scenarios import GrizzlyScenario
     from ..context import GrizzlyContextScenario
-    from ..types import GrizzlyResponse
 
 
 class GrizzlyTask(ABC):

--- a/grizzly/tasks/async_group.py
+++ b/grizzly/tasks/async_group.py
@@ -34,9 +34,10 @@ import gevent
 from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple
 from time import perf_counter as time_perf_counter
 
+from grizzly.types import RequestType
+
 from . import GrizzlyTask, GrizzlyTaskWrapper, RequestTask, template
 from ..users.base import AsyncRequests
-from ..types import RequestType
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..context import GrizzlyContextScenario

--- a/grizzly/tasks/clients/__init__.py
+++ b/grizzly/tasks/clients/__init__.py
@@ -31,9 +31,10 @@ from datetime import datetime
 from grizzly_extras.transformer import TransformerContentType
 from grizzly_extras.arguments import split_value, parse_arguments
 
+from grizzly.types import RequestType, RequestDirection, GrizzlyResponse
+
 from ...context import GrizzlyContext, GrizzlyContextScenario
 from ...scenarios import GrizzlyScenario
-from ...types import RequestType, RequestDirection, GrizzlyResponse
 from ...testdata.utils import resolve_variable
 from ...users.base import RequestLogger
 from .. import GrizzlyMetaRequestTask, template

--- a/grizzly/tasks/clients/blobstorage.py
+++ b/grizzly/tasks/clients/blobstorage.py
@@ -49,11 +49,11 @@ from mimetypes import guess_type as mimetype_guess
 
 from azure.storage.blob import BlobServiceClient, ContentSettings
 
+from grizzly.types import RequestDirection, GrizzlyResponse
 
 from . import client, ClientTask
 from ...scenarios import GrizzlyScenario
 from ...context import GrizzlyContextScenario
-from ...types import RequestDirection, GrizzlyResponse
 
 # disable verbose INFO logging
 azure_logger = logging.getLogger('azure.core.pipeline.policies.http_logging_policy')

--- a/grizzly/tasks/clients/http.py
+++ b/grizzly/tasks/clients/http.py
@@ -20,9 +20,10 @@ from typing import Optional, Dict, Any
 
 from grizzly_extras.arguments import split_value, parse_arguments
 
+from grizzly.types import GrizzlyResponse, RequestDirection, bool_type
+
 from . import client, ClientTask
 from ...scenarios import GrizzlyScenario
-from ...types import GrizzlyResponse, RequestDirection, bool_type
 from ...context import GrizzlyContextScenario
 
 import requests

--- a/grizzly/tasks/clients/messagequeue.py
+++ b/grizzly/tasks/clients/messagequeue.py
@@ -82,10 +82,11 @@ from zmq.sugar.constants import NOBLOCK as ZMQ_NOBLOCK, REQ as ZMQ_REQ, LINGER a
 from gevent import sleep as gsleep
 from grizzly_extras.async_message import AsyncMessageContext, AsyncMessageResponse, AsyncMessageRequest
 
+from grizzly.types import GrizzlyResponse, RequestDirection, RequestType
+
 from . import client, ClientTask, logger
 from ...context import GrizzlyContextScenario
 from ...scenarios import GrizzlyScenario
-from ...types import GrizzlyResponse, RequestDirection, RequestType
 from ...testdata.utils import resolve_variable
 
 

--- a/grizzly/tasks/request.py
+++ b/grizzly/tasks/request.py
@@ -63,7 +63,8 @@ from jinja2.environment import Template
 from grizzly_extras.transformer import TransformerContentType
 from grizzly_extras.arguments import parse_arguments, split_value, unquote
 
-from ..types import GrizzlyResponse, RequestMethod
+from grizzly.types import GrizzlyResponse, RequestMethod
+
 from . import GrizzlyMetaRequestTask, template  # pylint: disable=unused-import
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/grizzly/tasks/until.py
+++ b/grizzly/tasks/until.py
@@ -48,7 +48,8 @@ from gevent import sleep as gsleep
 from grizzly_extras.transformer import Transformer, TransformerContentType, TransformerError, transformer
 from grizzly_extras.arguments import get_unsupported_arguments, parse_arguments, split_value
 
-from ..types import RequestType
+from grizzly.types import RequestType
+
 from . import GrizzlyTask, GrizzlyMetaRequestTask, template
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/grizzly/testdata/__init__.py
+++ b/grizzly/testdata/__init__.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Type, Any, Optional, Callable, List, Tuple, Set, cast
 from importlib import import_module
 
-from ..types import GrizzlyVariableType
+from grizzly.types import GrizzlyVariableType
 
 
 if TYPE_CHECKING:

--- a/grizzly/testdata/communication.py
+++ b/grizzly/testdata/communication.py
@@ -15,7 +15,8 @@ from gevent.lock import Semaphore
 from locust.exception import StopUser
 from locust.env import Environment
 
-from ..types import TestdataType
+from grizzly.types import TestdataType
+
 from .utils import transform
 from .variables import AtomicVariablePersist
 from . import GrizzlyVariables

--- a/grizzly/testdata/utils.py
+++ b/grizzly/testdata/utils.py
@@ -11,10 +11,11 @@ from jinja2 import Template, Environment
 from jinja2.meta import find_undeclared_variables
 from locust.exception import StopUser
 
+from grizzly.types import RequestType, TestdataType, GrizzlyVariableType
+from grizzly.testdata.ast import get_template_variables
+
 from ..tasks import GrizzlyTask
-from ..types import RequestType, TestdataType, GrizzlyVariableType
 from ..utils import merge_dicts
-from .ast import get_template_variables
 from . import GrizzlyVariables
 
 

--- a/grizzly/testdata/variables/__init__.py
+++ b/grizzly/testdata/variables/__init__.py
@@ -13,7 +13,8 @@ from typing import Generic, Optional, Callable, Set, Any, Tuple, Dict, TypeVar, 
 
 from gevent.lock import Semaphore, DummySemaphore
 
-from ...types import bool_type
+from grizzly.types import bool_type
+
 from ...context import GrizzlyContext
 
 

--- a/grizzly/testdata/variables/csv_row.py
+++ b/grizzly/testdata/variables/csv_row.py
@@ -63,7 +63,8 @@ from random import randint
 
 from grizzly_extras.arguments import split_value, parse_arguments
 
-from ...types import bool_type
+from grizzly.types import bool_type
+
 from . import AtomicVariable
 
 

--- a/grizzly/testdata/variables/directory_contents.py
+++ b/grizzly/testdata/variables/directory_contents.py
@@ -41,7 +41,8 @@ from random import randint
 
 from grizzly_extras.arguments import split_value, parse_arguments
 
-from ...types import bool_type
+from grizzly.types import bool_type
+
 from . import AtomicVariable
 
 

--- a/grizzly/testdata/variables/integer_incrementer.py
+++ b/grizzly/testdata/variables/integer_incrementer.py
@@ -78,7 +78,8 @@ from typing import Union, Dict, Any, Type, Optional, cast
 
 from grizzly_extras.arguments import split_value, parse_arguments
 
-from ...types import bool_type
+from grizzly.types import bool_type
+
 from . import AtomicVariable, AtomicVariablePersist
 
 

--- a/grizzly/testdata/variables/random_string.py
+++ b/grizzly/testdata/variables/random_string.py
@@ -42,7 +42,8 @@ from uuid import uuid4
 
 from grizzly_extras.arguments import split_value, parse_arguments
 
-from ...types import bool_type, int_rounded_float_type
+from grizzly.types import bool_type, int_rounded_float_type
+
 from . import AtomicVariable
 
 

--- a/grizzly/testdata/variables/servicebus.py
+++ b/grizzly/testdata/variables/servicebus.py
@@ -96,7 +96,8 @@ from grizzly_extras.async_message import AsyncMessageContext, AsyncMessageReques
 from grizzly_extras.arguments import split_value, parse_arguments, get_unsupported_arguments
 from grizzly_extras.transformer import TransformerContentType
 
-from ...types import RequestType, bool_type
+from grizzly.types import RequestType, bool_type
+
 from ...context import GrizzlyContext
 from ..utils import resolve_variable
 from . import AtomicVariable

--- a/grizzly/users/base/__init__.py
+++ b/grizzly/users/base/__init__.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 
 if TYPE_CHECKING:
-    from ...types import GrizzlyResponse
+    from grizzly.types import GrizzlyResponse
     from ...tasks import RequestTask
 
 

--- a/grizzly/users/base/grizzly_user.py
+++ b/grizzly/users/base/grizzly_user.py
@@ -12,7 +12,8 @@ from locust.user.users import User
 from locust.user.task import LOCUST_STATE_RUNNING
 from locust.env import Environment
 
-from ...types import GrizzlyResponse, RequestType, ScenarioState
+from grizzly.types import GrizzlyResponse, RequestType, ScenarioState
+
 from ...tasks import RequestTask
 from ...utils import merge_dicts
 from . import FileRequests

--- a/grizzly/users/base/request_logger.py
+++ b/grizzly/users/base/request_logger.py
@@ -12,8 +12,9 @@ from locust.env import Environment
 from jinja2 import Template
 from requests import Response as RequestResponse
 
+from grizzly.types import GrizzlyResponse, HandlerContextType, RequestDirection, GrizzlyResponseContextManager
+
 from ...tasks import RequestTask
-from ...types import GrizzlyResponse, HandlerContextType, RequestDirection, GrizzlyResponseContextManager
 from ...utils import merge_dicts
 from .response_event import ResponseEvent
 from .grizzly_user import GrizzlyUser

--- a/grizzly/users/base/response_handler.py
+++ b/grizzly/users/base/response_handler.py
@@ -5,8 +5,9 @@ from json import dumps as jsondumps
 import jinja2 as j2
 from locust.env import Environment
 
+from grizzly.types import HandlerContextType, GrizzlyResponseContextManager, GrizzlyResponse
+
 from ...tasks import RequestTask
-from ...types import HandlerContextType, GrizzlyResponseContextManager, GrizzlyResponse
 from ...exceptions import ResponseHandlerError, TransformerLocustError
 from .grizzly_user import GrizzlyUser
 from .response_event import ResponseEvent

--- a/grizzly/users/blobstorage.py
+++ b/grizzly/users/blobstorage.py
@@ -37,8 +37,9 @@ from azure.storage.blob import BlobServiceClient
 from locust.exception import StopUser
 from locust.env import Environment
 
+from grizzly.types import RequestMethod, GrizzlyResponse, RequestType
+
 from .base import GrizzlyUser
-from ..types import RequestMethod, GrizzlyResponse, RequestType
 from ..tasks import RequestTask
 from ..utils import merge_dicts
 

--- a/grizzly/users/iothub.py
+++ b/grizzly/users/iothub.py
@@ -36,9 +36,10 @@ from azure.storage.blob import BlobClient
 from locust.exception import StopUser
 from locust.env import Environment
 
+from grizzly.types import RequestMethod, GrizzlyResponse, RequestType
+
 from . import logger
 from .base import GrizzlyUser
-from ..types import RequestMethod, GrizzlyResponse, RequestType
 from ..tasks import RequestTask
 from ..utils import merge_dicts
 

--- a/grizzly/users/messagequeue.py
+++ b/grizzly/users/messagequeue.py
@@ -138,7 +138,8 @@ from gevent import sleep as gsleep
 from grizzly_extras.async_message import AsyncMessageContext, AsyncMessageRequest, AsyncMessageResponse, AsyncMessageError
 from grizzly_extras.arguments import get_unsupported_arguments, parse_arguments
 
-from ..types import GrizzlyResponse, RequestDirection, RequestType
+from grizzly.types import GrizzlyResponse, RequestDirection, RequestType
+
 from ..tasks import RequestTask
 from ..utils import merge_dicts
 from .base import GrizzlyUser, ResponseHandler, RequestLogger

--- a/grizzly/users/restapi.py
+++ b/grizzly/users/restapi.py
@@ -88,9 +88,9 @@ import requests
 
 from grizzly_extras.transformer import TransformerContentType
 
-from ..types import GrizzlyResponse, RequestType, WrappedFunc, GrizzlyResponseContextManager
+from grizzly.types import GrizzlyResponse, RequestType, RequestMethod, WrappedFunc, GrizzlyResponseContextManager
+
 from ..utils import merge_dicts
-from ..types import RequestMethod
 from ..tasks import RequestTask
 from ..clients import ResponseEventSession
 from .base import RequestLogger, ResponseHandler, GrizzlyUser, HttpRequests, AsyncRequests

--- a/grizzly/users/servicebus.py
+++ b/grizzly/users/servicebus.py
@@ -84,7 +84,8 @@ from gevent import sleep as gsleep
 from grizzly_extras.async_message import AsyncMessageContext, AsyncMessageResponse, AsyncMessageRequest, AsyncMessageError
 from grizzly_extras.arguments import parse_arguments, get_unsupported_arguments
 
-from ..types import RequestMethod, RequestDirection, GrizzlyResponse, RequestType
+from grizzly.types import RequestMethod, RequestDirection, GrizzlyResponse, RequestType
+
 from ..tasks import RequestTask
 from ..utils import merge_dicts
 from .base import GrizzlyUser, ResponseHandler, RequestLogger

--- a/grizzly/users/sftp.py
+++ b/grizzly/users/sftp.py
@@ -38,10 +38,11 @@ from os import path, environ, mkdir
 from locust.exception import StopUser
 from locust.env import Environment
 
+from grizzly.types import RequestMethod, GrizzlyResponse, RequestType
+
 from .base import GrizzlyUser, FileRequests, ResponseHandler, RequestLogger
 from ..utils import merge_dicts
 from ..clients import SftpClientSession
-from ..types import RequestMethod, GrizzlyResponse, RequestType
 from ..tasks import RequestTask
 
 

--- a/grizzly/utils.py
+++ b/grizzly/utils.py
@@ -16,7 +16,7 @@ from behave.runner import Context
 from behave.model import Scenario, Status
 from locust.stats import STATS_NAME_WIDTH
 
-from .types import WrappedFunc, T
+from grizzly.types import WrappedFunc, T
 
 if TYPE_CHECKING:  # pragma: no cover
     from .context import GrizzlyContextScenario

--- a/tests/test_grizzly/test_locust.py
+++ b/tests/test_grizzly/test_locust.py
@@ -477,7 +477,6 @@ def test_print_scenario_summary(behave_fixture: BehaveFixture, capsys: CaptureFi
     print_scenario_summary(grizzly)
 
     summary = capsys.readouterr().out
-    print(summary)
     assert '''Scenario
 ident   iter  status      description
 ------|-----|-----------|-------------|
@@ -499,7 +498,6 @@ ident   iter  status      description
     print_scenario_summary(grizzly)
 
     summary = capsys.readouterr().out
-    print(summary)
     assert '''Scenario
 ident   iter  status   description
 ------|-----|--------|-----------------------------|
@@ -519,8 +517,6 @@ ident   iter  status   description
     print_scenario_summary(grizzly)
 
     summary = capsys.readouterr().out
-    print(summary)
-
     assert '''Scenario
 ident      iter  status   description
 ------|--------|--------|-----------------------------|
@@ -538,8 +534,6 @@ ident      iter  status   description
     print_scenario_summary(grizzly)
 
     summary = capsys.readouterr().out
-    print(summary)
-
     assert '''Scenario
 ident      iter  status      description
 ------|--------|-----------|-----------------------------|
@@ -644,7 +638,7 @@ def test_run_master(behave_fixture: BehaveFixture, capsys: CaptureFixture, mocke
             return_value=None,
         )
 
-    for printer in ['print_error_report', 'print_percentile_stats', 'grizzly_print_stats', 'grizzly_stats_printer', 'stats_history']:
+    for printer in ['lstats.print_error_report', 'lstats.print_percentile_stats', 'grizzly_print_stats', 'grizzly_stats_printer', 'lstats.stats_history']:
         mocker.patch(
             f'grizzly.locust.{printer}',
             return_value=None,
@@ -789,7 +783,6 @@ def test_grizzly_print_stats(caplog: LogCaptureFixture, mocker: MockerFixture) -
 
     grizzly_stats = caplog.messages
     caplog.clear()
-    print(grizzly_stats[0:5])
 
     # print stats, locust style
     with caplog.at_level(logging.INFO):


### PR DESCRIPTION
start CSV stats file writer if `-Dcsv-prefix=<prefix>` is supplied to behave

also control interval statistics is collected with `-Dcsv-interval=<seconds>`
and how often they are flushed to disk with `-Dcsv-flush-interval=<seconds>`.

e2e tests should be implemented when `grizzly-cli` support has been published.