### PR TITLE
write user count per user class name to influx every 5 seconds

### DIFF
--- a/tests/test_grizzly/listeners/test___init__.py
+++ b/tests/test_grizzly/listeners/test___init__.py
@@ -231,7 +231,12 @@ def test_init_statistics_listener(mocker: MockerFixture, locust_fixture: LocustF
     )
 
     mocker.patch(
-        'grizzly.listeners.influxdb.InfluxDbListener.run',
+        'grizzly.listeners.influxdb.InfluxDbListener.run_events',
+        return_value=None,
+    )
+
+    mocker.patch(
+        'grizzly.listeners.influxdb.InfluxDbListener.run_user_count',
         return_value=None,
     )
 


### PR DESCRIPTION
seperate table for user metrics, which is written to every 5 seconds by a greenlet in the `InfluxDbListener` listener.