### PR TITLE
task `on_start` and `on_stop` functionality

### DIFF
--- a/grizzly/scenarios/__init__.py
+++ b/grizzly/scenarios/__init__.py
@@ -62,12 +62,12 @@ class GrizzlyScenario(SequentialTaskSet):
 
         for task in self.tasks:
             if isinstance(task, grizzlytask):
-                task.on.start()
+                task.on_start()
 
     def on_stop(self) -> None:
         for task in self.tasks:
             if isinstance(task, grizzlytask):
-                task.on.stop()
+                task.on_stop()
 
         self.consumer.stop()
         self.user.scenario_state = ScenarioState.STOPPED

--- a/grizzly/scenarios/__init__.py
+++ b/grizzly/scenarios/__init__.py
@@ -11,9 +11,9 @@ from grizzly.types import ScenarioState
 
 from ..context import GrizzlyContext
 from ..testdata.communication import TestdataConsumer
-from ..tasks import GrizzlyTask
+from ..tasks import GrizzlyTask, grizzlytask
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from ..users.base import GrizzlyUser
 
 
@@ -38,7 +38,7 @@ class GrizzlyScenario(SequentialTaskSet):
 
         if callable(getattr(cls, 'pace', None)):
             cls.tasks.insert(-1, task)
-        else:
+        else:  # pragma: no cover
             cls.tasks.append(task)
 
     def render(self, input: str, variables: Optional[Dict[str, Any]] = None) -> str:
@@ -60,7 +60,15 @@ class GrizzlyScenario(SequentialTaskSet):
             self.logger.error('no address to testdata producer specified')
             raise StopUser()
 
+        for task in self.tasks:
+            if isinstance(task, grizzlytask):
+                task.on.start()
+
     def on_stop(self) -> None:
+        for task in self.tasks:
+            if isinstance(task, grizzlytask):
+                task.on.stop()
+
         self.consumer.stop()
         self.user.scenario_state = ScenarioState.STOPPED
 

--- a/grizzly/tasks/__init__.py
+++ b/grizzly/tasks/__init__.py
@@ -69,40 +69,39 @@ GrizzlyTaskOnType = Optional[Callable[[], None]]
 class grizzlytask:
     __name__ = 'grizzlytask'
 
+    _on_start: Optional['OnGrizzlyTask'] = None
+    _on_stop: Optional['OnGrizzlyTask'] = None
+
     class OnGrizzlyTask:
-        def __init__(self, holder: 'grizzlytask') -> None:
-            self._holder = holder
+        _on_func: Optional[GrizzlyTaskOnType] = None
 
-        def start(self) -> None:
-            if self._holder._on_start is not None:
-                self._holder._on_start()
+        def __init__(self, on_func: GrizzlyTaskOnType) -> None:
+            self._on_func = on_func
 
-        def stop(self) -> None:
-            if self._holder._on_stop is not None:
-                self._holder._on_stop()
+        def __call__(self) -> None:
+            if self._on_func is not None:
+                self._on_func()
 
-    def __init__(self, task: GrizzlyTaskType, on_start: GrizzlyTaskOnType = None, on_stop: GrizzlyTaskOnType = None, doc: Optional[str] = None) -> None:
+    def __init__(self, task: GrizzlyTaskType, doc: Optional[str] = None) -> None:
         self._task = task
-        self._on_start = on_start
-        self._on_stop = on_stop
 
         if doc is None and task is not None:
             self.__doc__ = doc
 
-        self._on = self.OnGrizzlyTask(self)
-
-    @property
-    def on(self) -> OnGrizzlyTask:
-        return self._on
-
     def __call__(self, parent: 'GrizzlyScenario') -> Any:
         return self._task(parent)
 
-    def on_start(self, on_start: GrizzlyTaskOnType) -> None:
-        self._on_start = on_start
+    def on_start(self, on_start: GrizzlyTaskOnType = None) -> None:
+        if self._on_start is None:
+            self._on_start = self.OnGrizzlyTask(on_start)
+        else:
+            self._on_start()
 
-    def on_stop(self, on_stop: GrizzlyTaskOnType) -> None:
-        self._on_stop = on_stop
+    def on_stop(self, on_stop: GrizzlyTaskOnType = None) -> None:
+        if self._on_stop is None:
+            self._on_stop = self.OnGrizzlyTask(on_stop)
+        else:
+            self._on_stop()
 
 
 class GrizzlyTask(ABC):

--- a/grizzly/tasks/__init__.py
+++ b/grizzly/tasks/__init__.py
@@ -13,6 +13,41 @@ a previous response or fetching additional test data from a different endpoint (
 It is possible to implement custom tasks, the only requirement is that they inherit `grizzly.tasks.GrizzlyTask`. To get them to be executed by `grizzly`,
 a step implementation is also needed.
 
+Boilerplate example of a custom task:
+
+```python
+from typing import Any, cast
+
+from grizzly.context import GrizzlyContext
+from grizzly.tasks import GrizzlyTask, grizzlytask
+from grizzly.scenarios import GrizzlyScenario
+from behave import then
+from behave.runner import Context
+
+
+class TestTask(GrizzlyTask):
+    def __call__(self) -> grizzlytask:
+        @grizzlytask
+        def task(parent: GrizzlyScenario) -> Any:
+            print(f'{self.__class__.__name__}::task called')
+
+        @task.on_start
+        def on_start() -> None:
+            print(f'{self.__class__.__name__}::on_start called')
+
+        @task.on_stop
+        def on_stop() -> None:
+            print(f'{self.__class__.__name__}::on_stop called')
+
+        return task
+
+
+@then(u'run `TestTask`')
+def step_run_testtask(context: Context) -> None:
+    grizzly = cast(GrizzlyContext, context.grizzly)
+    grizzly.scenario.tasks.add(TestTask())
+```
+
 There are examples of this in the {@link framework.example}.
 '''
 from abc import ABC, ABCMeta, abstractmethod
@@ -31,20 +66,21 @@ GrizzlyTaskType = Callable[['GrizzlyScenario'], Any]
 GrizzlyTaskOnType = Optional[Callable[[], None]]
 
 
-class OnGrizzlyTask:
-    def __init__(self, holder: 'grizzlytask') -> None:
-        self._holder = holder
-
-    def start(self) -> None:
-        if self._holder._on_start is not None:
-            self._holder._on_start()
-
-    def stop(self) -> None:
-        if self._holder._on_stop is not None:
-            self._holder._on_stop()
-
-
 class grizzlytask:
+    __name__ = 'grizzlytask'
+
+    class OnGrizzlyTask:
+        def __init__(self, holder: 'grizzlytask') -> None:
+            self._holder = holder
+
+        def start(self) -> None:
+            if self._holder._on_start is not None:
+                self._holder._on_start()
+
+        def stop(self) -> None:
+            if self._holder._on_stop is not None:
+                self._holder._on_stop()
+
     def __init__(self, task: GrizzlyTaskType, on_start: GrizzlyTaskOnType = None, on_stop: GrizzlyTaskOnType = None, doc: Optional[str] = None) -> None:
         self._task = task
         self._on_start = on_start
@@ -53,7 +89,7 @@ class grizzlytask:
         if doc is None and task is not None:
             self.__doc__ = doc
 
-        self._on = OnGrizzlyTask(self)
+        self._on = self.OnGrizzlyTask(self)
 
     @property
     def on(self) -> OnGrizzlyTask:
@@ -75,6 +111,7 @@ class GrizzlyTask(ABC):
     _context_root: str
 
     scenario: 'GrizzlyContextScenario'
+    step: str
 
     def __init__(self, scenario: Optional['GrizzlyContextScenario'] = None) -> None:
         self._context_root = environ.get('GRIZZLY_CONTEXT_ROOT', '.')
@@ -82,7 +119,7 @@ class GrizzlyTask(ABC):
             self.scenario = scenario
 
     @abstractmethod
-    def __call__(self) -> Callable[['GrizzlyScenario'], Any]:
+    def __call__(self) -> grizzlytask:
         raise NotImplementedError(f'{self.__class__.__name__} has not been implemented')
 
     def get_templates(self) -> List[str]:

--- a/grizzly/tasks/__init__.py
+++ b/grizzly/tasks/__init__.py
@@ -27,6 +27,47 @@ if TYPE_CHECKING:  # pragma: no cover
     from ..scenarios import GrizzlyScenario
     from ..context import GrizzlyContextScenario
 
+GrizzlyTaskType = Callable[['GrizzlyScenario'], Any]
+GrizzlyTaskOnType = Optional[Callable[[], None]]
+
+
+class OnGrizzlyTask:
+    def __init__(self, holder: 'grizzlytask') -> None:
+        self._holder = holder
+
+    def start(self) -> None:
+        if self._holder._on_start is not None:
+            self._holder._on_start()
+
+    def stop(self) -> None:
+        if self._holder._on_stop is not None:
+            self._holder._on_stop()
+
+
+class grizzlytask:
+    def __init__(self, task: GrizzlyTaskType, on_start: GrizzlyTaskOnType = None, on_stop: GrizzlyTaskOnType = None, doc: Optional[str] = None) -> None:
+        self._task = task
+        self._on_start = on_start
+        self._on_stop = on_stop
+
+        if doc is None and task is not None:
+            self.__doc__ = doc
+
+        self._on = OnGrizzlyTask(self)
+
+    @property
+    def on(self) -> OnGrizzlyTask:
+        return self._on
+
+    def __call__(self, parent: 'GrizzlyScenario') -> Any:
+        return self._task(parent)
+
+    def on_start(self, on_start: GrizzlyTaskOnType) -> None:
+        self._on_start = on_start
+
+    def on_stop(self, on_stop: GrizzlyTaskOnType) -> None:
+        self._on_stop = on_stop
+
 
 class GrizzlyTask(ABC):
     __template_attributes__: List[str] = []

--- a/grizzly/tasks/async_group.py
+++ b/grizzly/tasks/async_group.py
@@ -31,12 +31,12 @@ from os import environ
 
 import gevent
 
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple
 from time import perf_counter as time_perf_counter
 
 from grizzly.types import RequestType
 
-from . import GrizzlyTask, GrizzlyTaskWrapper, RequestTask, template
+from . import GrizzlyTask, GrizzlyTaskWrapper, RequestTask, template, grizzlytask
 from ..users.base import AsyncRequests
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -64,7 +64,8 @@ class AsyncRequestGroupTask(GrizzlyTaskWrapper):
     def peek(self) -> List[GrizzlyTask]:
         return self.tasks
 
-    def __call__(self) -> Callable[['GrizzlyScenario'], Any]:
+    def __call__(self) -> grizzlytask:
+        @grizzlytask
         def task(parent: 'GrizzlyScenario') -> Any:
             if not isinstance(parent.user, AsyncRequests):
                 raise NotImplementedError(f'{parent.user.__class__.__name__} does not inherit AsyncRequests')

--- a/grizzly/tasks/conditional.py
+++ b/grizzly/tasks/conditional.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from ..scenarios import GrizzlyScenario
     from ..context import GrizzlyContextScenario
 
-from . import GrizzlyTask, GrizzlyTaskWrapper, template
+from . import GrizzlyTask, GrizzlyTaskWrapper, template, grizzlytask
 from ..exceptions import StopUser, RestartScenario
 
 
@@ -85,12 +85,13 @@ class ConditionalTask(GrizzlyTaskWrapper):
 
         return []
 
-    def __call__(self) -> Callable[['GrizzlyScenario'], Any]:
+    def __call__(self) -> grizzlytask:
         tasks: Dict[bool, List[Callable[['GrizzlyScenario'], Any]]] = {}
 
         for pointer, pointer_tasks in self.tasks.items():
             tasks.update({pointer: list(map(lambda t: t(), pointer_tasks))})
 
+        @grizzlytask
         def task(parent: 'GrizzlyScenario') -> Any:
             condition_rendered = parent.render(self.condition)
             exception: Optional[Exception] = None

--- a/grizzly/tasks/date.py
+++ b/grizzly/tasks/date.py
@@ -32,7 +32,7 @@ and saves the result as a date/time string in an variable.
 * `offset` _str_ (optional) - a time span string describing the offset, Y = years, M = months, D = days, h = hours, m = minutes, s = seconds, e.g. `1Y-2M10D`
 '''  # noqa: E501
 # pylint: enable=line-too-long
-from typing import TYPE_CHECKING, Callable, Dict, Any, Optional, cast
+from typing import TYPE_CHECKING, Dict, Any, Optional, cast
 from datetime import datetime
 
 try:
@@ -47,7 +47,7 @@ from dateutil.relativedelta import relativedelta
 from grizzly_extras.arguments import get_unsupported_arguments, split_value, parse_arguments
 
 from ..utils import parse_timespan
-from . import GrizzlyTask, template
+from . import GrizzlyTask, template, grizzlytask
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..context import GrizzlyContextScenario
@@ -77,7 +77,8 @@ class DateTask(GrizzlyTask):
         else:
             raise ValueError('no arguments specified')
 
-    def __call__(self) -> Callable[['GrizzlyScenario'], Any]:
+    def __call__(self) -> grizzlytask:
+        @grizzlytask
         def task(parent: 'GrizzlyScenario') -> Any:
             value_rendered = parent.render(self.value, dict(datetime=datetime))
 

--- a/grizzly/tasks/log_message.py
+++ b/grizzly/tasks/log_message.py
@@ -15,9 +15,9 @@ This task does not have any request statistics entries.
 
 * `message` _str_ - message to log at `INFO` level, can be a template
 '''
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
-from . import GrizzlyTask, template
+from . import GrizzlyTask, template, grizzlytask
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..context import GrizzlyContextScenario
@@ -33,7 +33,8 @@ class LogMessageTask(GrizzlyTask):
 
         self.message = message
 
-    def __call__(self) -> Callable[['GrizzlyScenario'], Any]:
+    def __call__(self) -> grizzlytask:
+        @grizzlytask
         def task(parent: 'GrizzlyScenario') -> Any:
             message = parent.render(self.message)
             parent.logger.info(message)

--- a/grizzly/tasks/loop.py
+++ b/grizzly/tasks/loop.py
@@ -24,7 +24,7 @@ is the number of wrapped tasks. Each wrapped task will have its own entry in the
 
 * `variable` _str_: name of variable that a value from `input_list` will be accessible in
 """
-from typing import TYPE_CHECKING, Any, Callable, List, Optional
+from typing import TYPE_CHECKING, Any, List, Optional
 from time import perf_counter
 from json import loads as jsonloads
 
@@ -34,7 +34,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from ..scenarios import GrizzlyScenario
     from ..context import GrizzlyContextScenario, GrizzlyContext
 
-from . import GrizzlyTask, GrizzlyTaskWrapper, template
+from . import GrizzlyTask, GrizzlyTaskWrapper, template, grizzlytask
 
 
 @template('values', 'tasks')
@@ -66,9 +66,10 @@ class LoopTask(GrizzlyTaskWrapper):
     def peek(self) -> List[GrizzlyTask]:
         return self.tasks
 
-    def __call__(self) -> Callable[['GrizzlyScenario'], Any]:
+    def __call__(self) -> grizzlytask:
         tasks = [task() for task in self.tasks]
 
+        @grizzlytask
         def task(parent: 'GrizzlyScenario') -> Any:
             orig_value = parent.user._context['variables'].get(self.variable, None)
             start = perf_counter()

--- a/grizzly/tasks/request.py
+++ b/grizzly/tasks/request.py
@@ -57,7 +57,7 @@ And set response content type to "application/json"
 ```
 
 '''
-from typing import TYPE_CHECKING, Dict, List, Optional, Any, Callable
+from typing import TYPE_CHECKING, Dict, List, Optional, Any
 
 from jinja2.environment import Template
 from grizzly_extras.transformer import TransformerContentType
@@ -65,7 +65,7 @@ from grizzly_extras.arguments import parse_arguments, split_value, unquote
 
 from grizzly.types import GrizzlyResponse, RequestMethod
 
-from . import GrizzlyMetaRequestTask, template  # pylint: disable=unused-import
+from . import GrizzlyMetaRequestTask, template, grizzlytask  # pylint: disable=unused-import
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..context import GrizzlyContextScenario
@@ -178,7 +178,8 @@ class RequestTask(GrizzlyMetaRequestTask):
         else:
             self.metadata[key] = value
 
-    def __call__(self) -> Callable[['GrizzlyScenario'], Any]:
+    def __call__(self) -> grizzlytask:
+        @grizzlytask
         def task(parent: 'GrizzlyScenario') -> Any:
             return parent.user.request(self)
 

--- a/grizzly/tasks/task_wait.py
+++ b/grizzly/tasks/task_wait.py
@@ -26,11 +26,11 @@ This task does not have any request statistics entries.
 
 * `max_time` _float_ (optional) - maximum time to wait
 '''
-from typing import TYPE_CHECKING, Optional, Callable, Any
+from typing import TYPE_CHECKING, Optional, Any
 
 from locust import between, constant
 
-from . import GrizzlyTask
+from . import GrizzlyTask, grizzlytask
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..scenarios import GrizzlyScenario
@@ -47,7 +47,8 @@ class TaskWaitTask(GrizzlyTask):
         self.min_time = min_time
         self.max_time = max_time
 
-    def __call__(self) -> Callable[['GrizzlyScenario'], Any]:
+    def __call__(self) -> grizzlytask:
+        @grizzlytask
         def task(parent: 'GrizzlyScenario') -> Any:
             if self.max_time is None:
                 wait_time = constant(self.min_time)

--- a/grizzly/tasks/timer.py
+++ b/grizzly/tasks/timer.py
@@ -23,11 +23,11 @@ run.
 
 * `name` _str_ - name of the timer
 '''
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Optional
 from hashlib import sha1
 from time import perf_counter
 
-from . import GrizzlyTask
+from . import GrizzlyTask, grizzlytask
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..scenarios import GrizzlyScenario
@@ -46,9 +46,10 @@ class TimerTask(GrizzlyTask):
         self.name = name
         self.variable = f'{name_hash}::{name}'
 
-    def __call__(self) -> Callable[['GrizzlyScenario'], Any]:
+    def __call__(self) -> grizzlytask:
         name = f'{self.scenario.identifier} {self.name}'
 
+        @grizzlytask
         def task(parent: 'GrizzlyScenario') -> Any:
             variable = parent.user._context['variables'].get(self.variable, None)
 

--- a/grizzly/tasks/transformer.py
+++ b/grizzly/tasks/transformer.py
@@ -33,7 +33,7 @@ from typing import TYPE_CHECKING, List, Callable, Any, Type, Optional
 from grizzly_extras.transformer import Transformer, transformer, TransformerContentType, TransformerError
 
 from ..exceptions import TransformerLocustError
-from . import GrizzlyTask, template
+from . import GrizzlyTask, template, grizzlytask
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..context import GrizzlyContextScenario, GrizzlyContext
@@ -81,7 +81,8 @@ class TransformerTask(GrizzlyTask):
 
         setattr(self, '_parser', self._transformer.parser(self.expression))
 
-    def __call__(self) -> Callable[['GrizzlyScenario'], Any]:
+    def __call__(self) -> grizzlytask:
+        @grizzlytask
         def task(parent: 'GrizzlyScenario') -> Any:
             start = perf_counter()
             response_length = 0

--- a/grizzly/tasks/until.py
+++ b/grizzly/tasks/until.py
@@ -54,7 +54,7 @@ from grizzly_extras.transformer import Transformer, TransformerContentType, Tran
 from grizzly_extras.arguments import get_unsupported_arguments, parse_arguments, split_value
 
 from ..types import RequestType
-from . import GrizzlyTask, GrizzlyMetaRequestTask, template
+from . import GrizzlyTask, GrizzlyMetaRequestTask, template, grizzlytask
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..context import GrizzlyContextScenario, GrizzlyContext
@@ -136,12 +136,13 @@ class UntilRequestTask(GrizzlyTask):
             if self.wait < 0.1:
                 raise ValueError('wait argument cannot be less than 0.1 seconds')
 
-    def __call__(self) -> Callable[['GrizzlyScenario'], Any]:
+    def __call__(self) -> grizzlytask:
         if self.transform is None:
             raise TypeError(f'could not find a transformer for {self.request.content_type.name}')
 
         transform = cast(Transformer, self.transform)
 
+        @grizzlytask
         def task(parent: 'GrizzlyScenario') -> Any:
             task_name = f'{self.scenario.identifier} {self.request.name}, w={self.wait}s, r={self.retries}, em={self.expected_matches}'
             condition_rendered = parent.render(self.condition)

--- a/grizzly/tasks/wait.py
+++ b/grizzly/tasks/wait.py
@@ -10,12 +10,12 @@ This task executes a `gevent.sleep` and is used to manually create delays betwee
 
 * `time_expression` _str_ - float as string or a {@pydocfractions of seconds to excplicitly sleep in the scenario
 '''
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from gevent import sleep as gsleep
 
 from ..exceptions import StopUser
-from . import GrizzlyTask, template
+from . import GrizzlyTask, template, grizzlytask
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..context import GrizzlyContextScenario
@@ -31,7 +31,8 @@ class WaitTask(GrizzlyTask):
 
         self.time_expression = time_expression
 
-    def __call__(self) -> Callable[['GrizzlyScenario'], Any]:
+    def __call__(self) -> grizzlytask:
+        @grizzlytask
         def task(parent: 'GrizzlyScenario') -> Any:
             try:
                 time_rendered = parent.render(self.time_expression)

--- a/tests/test_grizzly/tasks/test___init__.py
+++ b/tests/test_grizzly/tasks/test___init__.py
@@ -1,18 +1,23 @@
 from os import environ
-from typing import TYPE_CHECKING, Callable, Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple
 
 import pytest
 
 from pytest_mock import MockerFixture
 
-from grizzly.tasks import GrizzlyTask, LoopTask, ConditionalTask, RequestTask, AsyncRequestGroupTask, template
+from grizzly.tasks import (
+    GrizzlyTask,
+    LoopTask,
+    ConditionalTask,
+    RequestTask,
+    AsyncRequestGroupTask,
+    template,
+    grizzlytask,
+)
 from grizzly.types import RequestMethod
 from grizzly.context import GrizzlyContextScenario
 
 from ...fixtures import GrizzlyFixture
-
-if TYPE_CHECKING:
-    from grizzly.scenarios import GrizzlyScenario
 
 
 @template('string_template', 'list_template', 'dict_template')
@@ -30,13 +35,12 @@ class DummyTask(GrizzlyTask):
             'dict_template_2': '{{ dict_template_2 }}',
         }
 
-    def __call__(self) -> Callable[['GrizzlyScenario'], Any]:
+    def __call__(self) -> grizzlytask:
         raise NotImplementedError(f'{self.__class__.__name__} has not been implemented')
 
 
 class TestGrizzlyTask:
     def test___init__(self) -> None:
-
         try:
             del environ['GRIZZLY_CONTEXT_ROOT']
         except KeyError:

--- a/tests/test_grizzly/tasks/test_conditional.py
+++ b/tests/test_grizzly/tasks/test_conditional.py
@@ -1,10 +1,10 @@
-from typing import Callable, Any, cast
+from typing import Any, cast
 
 import pytest
 
 from pytest_mock import MockerFixture
 from _pytest.logging import LogCaptureFixture
-from grizzly.tasks import ConditionalTask
+from grizzly.tasks import ConditionalTask, grizzlytask
 from grizzly.scenarios import GrizzlyScenario
 from grizzly.context import GrizzlyContextScenario
 from grizzly.exceptions import RestartScenario, StopUser
@@ -71,7 +71,8 @@ class TestConditionalTask:
         _, _, scenario = grizzly_fixture()
 
         class TestRestartScenarioTask(TestTask):
-            def __call__(self) -> Callable[['GrizzlyScenario'], Any]:
+            def __call__(self) -> grizzlytask:
+                @grizzlytask
                 def task(parent: 'GrizzlyScenario') -> Any:
                     parent.user.environment.events.request.fire(
                         request_type='TSTSK',
@@ -86,7 +87,8 @@ class TestConditionalTask:
                 return task
 
         class TestStopUserTask(TestTask):
-            def __call__(self) -> Callable[['GrizzlyScenario'], Any]:
+            def __call__(self) -> grizzlytask:
+                @grizzlytask
                 def task(parent: 'GrizzlyScenario') -> Any:
                     parent.user.environment.events.request.fire(
                         request_type='TSTSK',

--- a/tests/test_grizzly/tasks/test_loop.py
+++ b/tests/test_grizzly/tasks/test_loop.py
@@ -1,11 +1,11 @@
-from typing import TYPE_CHECKING, Callable, Any, cast
+from typing import TYPE_CHECKING, Any, cast
 from json import JSONDecodeError
 
 import pytest
 
 from pytest_mock import MockerFixture
 
-from grizzly.tasks import LoopTask, GrizzlyTask
+from grizzly.tasks import LoopTask, GrizzlyTask, grizzlytask
 from grizzly.context import GrizzlyContextScenario
 from grizzly.exceptions import RestartScenario
 
@@ -17,9 +17,10 @@ if TYPE_CHECKING:
 
 
 class TestErrorTask(TestTask):
-    def __call__(self) -> Callable[['GrizzlyScenario'], Any]:
+    def __call__(self) -> grizzlytask:
         super_task = super().__call__()
 
+        @grizzlytask
         def task(parent: 'GrizzlyScenario') -> Any:
             if self.task_call_count > 0:
                 raise ValueError('error')


### PR DESCRIPTION
force implementations of `GrizzlyTask` to implement `__call__`  with return type `grizzlytask`
    
decorate existing task functions with `@grizzlytask`.
    
run task `on` functions in all scenarios implementing `GrizzlyScenario`.
    
updated example and documentation.
    
preparation to begin implementing `on_start / on_stop` for tasks.