### PR TITLE
RestApiUser, oauth2 token v2.0 flow

### DIFF
--- a/grizzly/users/restapi.py
+++ b/grizzly/users/restapi.py
@@ -255,9 +255,6 @@ class RestApiUser(ResponseHandler, RequestLogger, GrizzlyUser, HttpRequests, Asy
             'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:88.0) Gecko/20100101 Firefox/88.0'
         }
 
-        # this is added when successful
-        safe_del(self.headers, 'Authorization')
-
         auth_user_context = self._context['auth']['user']
         start_time = time_perf_counter()
         total_response_length = 0
@@ -790,7 +787,7 @@ class RestApiUser(ResponseHandler, RequestLogger, GrizzlyUser, HttpRequests, Asy
 
     def add_context(self, context: Dict[str, Any]) -> None:
         # something change in auth context, we need to re-authenticate
-        if context.get('auth', {}) is not None:
+        if context.get('auth', {}).get('user', {}).get('username', None) is not None:
             self.headers['Authorization'] = None
 
         super().add_context(context)

--- a/grizzly/utils.py
+++ b/grizzly/utils.py
@@ -296,3 +296,10 @@ def async_message_request_wrapper(parent: GrizzlyScenario, client: zmq.Socket, r
     request = jsonloads(parent.render(request_json))
 
     return async_message_request(client, request)
+
+
+def safe_del(struct: Dict[str, Any], key: str) -> None:
+    try:
+        del struct[key]
+    except KeyError:
+        pass

--- a/tests/unit/test_grizzly/test_utils.py
+++ b/tests/unit/test_grizzly/test_utils.py
@@ -188,12 +188,11 @@ def test_create_user_class_type(locust_fixture: LocustFixture) -> None:
         'verify_certificates': True,
         'auth': {
             'refresh_time': 3000,
-            'url': None,
+            'provider': None,
             'client': {
                 'id': None,
                 'secret': None,
                 'resource': None,
-                'tenant': None,
             },
             'user': {
                 'username': None,
@@ -216,12 +215,11 @@ def test_create_user_class_type(locust_fixture: LocustFixture) -> None:
         'verify_certificates': True,
         'auth': {
             'refresh_time': 3000,
-            'url': None,
+            'provider': None,
             'client': {
                 'id': None,
                 'secret': None,
                 'resource': None,
-                'tenant': None,
             },
             'user': {
                 'username': None,
@@ -249,7 +247,7 @@ def test_create_user_class_type(locust_fixture: LocustFixture) -> None:
             'log_all_requests': True,
             'auth': {
                 'refresh_time': 1337,
-                'url': 'https://auth.example.com',
+                'provider': 'https://auth.example.com',
                 'user': {
                     'username': 'grizzly-user',
                 }
@@ -273,12 +271,11 @@ def test_create_user_class_type(locust_fixture: LocustFixture) -> None:
         'verify_certificates': True,
         'auth': {
             'refresh_time': 1337,
-            'url': 'https://auth.example.com',
+            'provider': 'https://auth.example.com',
             'client': {
                 'id': None,
                 'secret': None,
                 'resource': None,
-                'tenant': None,
             },
             'user': {
                 'username': 'grizzly-user',
@@ -308,12 +305,11 @@ def test_create_user_class_type(locust_fixture: LocustFixture) -> None:
         'verify_certificates': True,
         'auth': {
             'refresh_time': 1337,
-            'url': 'https://auth.example.com',
+            'provider': 'https://auth.example.com',
             'client': {
                 'id': None,
                 'secret': None,
                 'resource': None,
-                'tenant': None,
             },
             'user': {
                 'username': 'grizzly-user',
@@ -350,12 +346,11 @@ def test_create_user_class_type(locust_fixture: LocustFixture) -> None:
         'verify_certificates': True,
         'auth': {
             'refresh_time': 3000,
-            'url': None,
+            'provider': None,
             'client': {
                 'id': None,
                 'secret': None,
                 'resource': None,
-                'tenant': None,
             },
             'user': {
                 'username': None,
@@ -387,12 +382,11 @@ def test_create_user_class_type(locust_fixture: LocustFixture) -> None:
         'verify_certificates': True,
         'auth': {
             'refresh_time': 3000,
-            'url': None,
+            'provider': None,
             'client': {
                 'id': None,
                 'secret': None,
                 'resource': None,
-                'tenant': None,
             },
             'user': {
                 'username': None,

--- a/tests/unit/test_grizzly/test_utils.py
+++ b/tests/unit/test_grizzly/test_utils.py
@@ -23,6 +23,7 @@ from grizzly.utils import (
     parse_timespan,
     check_mq_client_logs,
     async_message_request_wrapper,
+    safe_del,
 )
 from grizzly.types import RequestMethod
 from grizzly.types.behave import Context, Scenario, Status
@@ -704,3 +705,19 @@ def test_async_message_request_wrapper(grizzly_fixture: GrizzlyFixture, mocker: 
 
     async_message_request_wrapper(scenario, client_mock, request)
     async_message_request_mock.assert_called_once_with(client_mock, {'context': {'endpoint': 'hello foobar!'}})
+
+
+def test_safe_del() -> None:
+    struct = {'hello': 'world', 'foo': 'bar'}
+
+    safe_del(struct, 'bar')
+    assert struct == {'hello': 'world', 'foo': 'bar'}
+
+    safe_del(struct, 'hello')
+    assert struct == {'foo': 'bar'}
+
+    safe_del(struct, 'foo')
+    assert struct == {}
+
+    safe_del(struct, 'hello')
+    assert struct == {}


### PR DESCRIPTION
support for using oauth2 v2.0 tokens when authenticating.

Non-backward compatible changes:
- context variable `auth.client.tenant` is deprecated/removed
- context variable `auth.url` is deprecated/removed
- context variable `auth.provider` is added, and must be set to the base URL for the oauth2 provider (`/authorize` and `/token` must be able to be prefixed, and reached)

for now, the v2.0 flow is selected if `v2.0` is in `auth.provider` value.