### PR TITLE
 ServiceBusTaskClient: fixed documentation for missing path and fragment variables

### DIFF
--- a/grizzly/tasks/clients/servicebus.py
+++ b/grizzly/tasks/clients/servicebus.py
@@ -27,7 +27,7 @@
 Value of this is basically the "Connection String" from Azure (without `Endpoint=` prefix), with some additional information.
 
 ``` plain
-sb://<sbns resource name>.servicebus.windows.net/[queue:<queue name>|topic:<topic name>[/subscription:<subscription name>]];SharedAccessKeyName=<policy name>;SharedAccessKey=<access key>[#[Consume=<consume>][&][MessageWait=<wait>]]
+sb://<sbns resource name>.servicebus.windows.net/[queue:<queue name>|topic:<topic name>[/subscription:<subscription name>]][/expression:<expression>];SharedAccessKeyName=<policy name>;SharedAccessKey=<access key>[#[Consume=<consume>][&][MessageWait=<wait>][&][ContentType<content type>]]
 ```
 
 All variables in the endpoint have support for {@link framework.usage.variables.templating}.
@@ -44,6 +44,8 @@ Path:
 
 * `<subscription name>` _str_ - name of an subscription on `topic name`, either an existing, or one to be created (if step text containing SQL Filter rule is specified)
 
+* `<expression>` _str_ - JSON or XPath expression to filter out message on payload, only applicable when receiving messages
+
 <sup>1</sup> Either specify `queue:` or `topic`, not both
 
 Query:
@@ -57,6 +59,8 @@ Fragment:
 * `<consume>` _bool_ - if messages should be consumed (removed from endpoint), or only peeked at (left on endpoint) (default: `True`)
 
 * `<wait>` _int_ - how many seconds to wait for a message to arrive on the endpoint (default: `∞`)
+
+* `<content type>` _str_ - content type of response payload, should be used in combination with `<expression>`
 """  # noqa: E501
 from typing import Optional, cast
 from urllib.parse import urlparse, parse_qs

--- a/tests/unit/test_grizzly/tasks/clients/test_servicebus.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_servicebus.py
@@ -66,8 +66,8 @@ class TestServiceBusClientTask:
         task = ServiceBusClientTask(
             RequestDirection.FROM,
             (
-                'sb://$conf::sbns.host$/topic:my-topic/subscription:my-subscription-{{ id }}'
-                ';SharedAccessKeyName=$conf::sbns.key.name$;SharedAccessKey=$conf::sbns.key.secret$#Consume=True;MessageWait=300'
+                'sb://$conf::sbns.host$/topic:my-topic/subscription:my-subscription-{{ id }}/expression:$.hello.world'
+                ';SharedAccessKeyName=$conf::sbns.key.name$;SharedAccessKey=$conf::sbns.key.secret$#Consume=True&MessageWait=300&ContentType=json'
             ),
             'test',
             text='foobar',
@@ -78,15 +78,16 @@ class TestServiceBusClientTask:
         assert task.context == {
             'url': task.endpoint,
             'connection': 'receiver',
-            'endpoint': 'topic:my-topic, subscription:my-subscription-{{ id }}',
+            'endpoint': 'topic:my-topic, subscription:my-subscription-{{ id }}, expression:$.hello.world',
             'consume': True,
             'message_wait': 300,
+            'content_type': 'JSON'
         }
         assert task.text == 'foobar'
         assert task.variable == 'foobar'
         assert task.source is None
         assert task.worker_id is None
-        assert sorted(task.get_templates()) == sorted(['topic:my-topic, subscription:my-subscription-{{ id }}', '{{ foobar }}'])
+        assert sorted(task.get_templates()) == sorted(['topic:my-topic, subscription:my-subscription-{{ id }}, expression:$.hello.world', '{{ foobar }}'])
         context_mock.assert_called_once_with()
         context_mock.return_value.socket.assert_called_once_with(ZMQ_REQ)
         context_mock.return_value.socket.return_value.connect.assert_called_once_with('tcp://127.0.0.1:5554')


### PR DESCRIPTION
added to unit tests.

`async-messaged` has support to filter messages based on payload experssion, and there was nothing explicit in `ServiceBusTaskClient` disallowing it, just added documentation on how to use it.