### PR TITLE
abort if `async-messaged` process is gone

### DIFF
--- a/grizzly/locust.py
+++ b/grizzly/locust.py
@@ -595,7 +595,11 @@ def _grizzly_sort_stats(stats: lstats.RequestStats) -> List[Tuple[str, str, int]
     scenario_keys: List[Tuple[str, str]] = []
     scenario_sorted_keys: List[Tuple[str, str, int]] = []
     for index, key in enumerate(locust_keys):
-        ident, _ = key[0].split(' ', 1)
+        try:
+            ident, _ = key[0].split(' ', 1)
+        except ValueError:
+            ident = '999'
+
         is_last = index == len(locust_keys) - 1
         if (previous_ident is not None and previous_ident != ident) or is_last:
             if is_last:

--- a/grizzly/locust.py
+++ b/grizzly/locust.py
@@ -405,13 +405,7 @@ def run(context: Context) -> int:
                         for dependency, process in _processes.items():
                             if process.poll() is not None:
                                 logger.error(f'{dependency} is not running, restarting')
-                                processes.update({dependency: subprocess.Popen(
-                                    [dependency],
-                                    env=env,
-                                    shell=False,
-                                    stdout=subprocess.DEVNULL,
-                                    stderr=subprocess.DEVNULL,
-                                )})
+                                raise SystemExit(1)
 
                         gevent.sleep(10.0)
 

--- a/tests/unit/test_grizzly/test_locust.py
+++ b/tests/unit/test_grizzly/test_locust.py
@@ -785,7 +785,7 @@ def test_grizzly_print_stats(caplog: LogCaptureFixture, mocker: MockerFixture) -
     request_types_sequence_count = 5
     scenario_count = 10
 
-    for ident in range(1, scenario_count):
+    for ident in range(1, scenario_count + 1):
         for index, method in enumerate(request_types_sequence * request_types_sequence_count, 1):
             name = f'{ident:03} {index:02}-{method.lower()}-test'
 
@@ -795,6 +795,9 @@ def test_grizzly_print_stats(caplog: LogCaptureFixture, mocker: MockerFixture) -
                 response_time=randint(200, 300),
                 content_length=(index * randint(10, 20)),
             )
+
+        stats.log_request('DOC', 'TPM report OUT', response_time=randint(200, 300), content_length=999)
+        stats.log_request('DOC', 'TPM report IN', response_time=randint(200, 300), content_length=999)
 
         for method in ['SCEN', 'TSTD', 'VAR', 'CLTSK']:
             stats.log_request(
@@ -830,6 +833,11 @@ def test_grizzly_print_stats(caplog: LogCaptureFixture, mocker: MockerFixture) -
         assert re.match(fr'^TSTD\s+{ident:03}', grizzly_stats[index + 1].strip())
         assert re.match(fr'^GET\s+{ident:03} 01-get-test', grizzly_stats[index + 2].strip())
         assert re.match(fr'^VAR\s+{ident:03} var-test', grizzly_stats[index + (len(request_types_sequence) * request_types_sequence_count) + 3].strip())
+
+    last_stat_row = len(grizzly_stats) - 4
+
+    assert re.match(r'^DOC\s+TPM report OUT\s+10', grizzly_stats[last_stat_row].strip())
+    assert re.match(r'^DOC\s+TPM report IN\s+10', grizzly_stats[last_stat_row - 1].strip())
 
     for stat in grizzly_stats:
         assert stat in locust_stats


### PR DESCRIPTION
restarting the process will not solve anything right now, since the clients have no idea that it is gone and a new is started, and the new has no idea about the old clients.

also, handle sorting of statistics which does not belong (is prefixed) to a scenario (id).
these are sorted with `ident` 999 meaning they will be in the end of the statistics.