### PR TITLE
async messaged improvments

### DIFF
--- a/grizzly/tasks/clients/servicebus.py
+++ b/grizzly/tasks/clients/servicebus.py
@@ -227,6 +227,9 @@ class ServiceBusClientTask(ClientTask):
         logger.debug(f'{id(self.parent.user)}::sb connected to worker {self.worker_id} at {hostname()}')
 
     def disconnect(self) -> None:
+        if self._client is None:
+            return
+
         request: AsyncMessageRequest = {
             'worker': self.worker_id,
             'action': RequestType.DISCONNECT.name,

--- a/grizzly/tasks/clients/servicebus.py
+++ b/grizzly/tasks/clients/servicebus.py
@@ -204,10 +204,13 @@ class ServiceBusClientTask(ClientTask):
 
     def connect(self) -> None:
         if self.worker_id is not None:
+            logger.debug(f'{id(self.parent.user)}::sb already connected')
             return
 
         if self._first_response is not None:
-            self.worker_id = self._first_response['worker']
+            self.worker_id = self._first_response.get('worker', None)
+
+        logger.debug(f'{id(self.parent.user)}::sb connecting, {self.worker_id=}')
 
         request: AsyncMessageRequest = {
             'worker': self.worker_id,
@@ -221,7 +224,7 @@ class ServiceBusClientTask(ClientTask):
             self.worker_id = response['worker']
             self._first_response = response
 
-        logger.debug(f'connected to worker {self.worker_id} at {hostname()}')
+        logger.debug(f'{id(self.parent.user)}::sb connected to worker {self.worker_id} at {hostname()}')
 
     def disconnect(self) -> None:
         request: AsyncMessageRequest = {

--- a/grizzly/users/messagequeue.py
+++ b/grizzly/users/messagequeue.py
@@ -385,6 +385,7 @@ class MessageQueueUser(ResponseHandler, RequestLogger, GrizzlyUser):
         am_request: AsyncMessageRequest = {
             'action': request.method.name,
             'worker': self.worker_id,
+            'client': id(self),
             'context': {
                 'endpoint': endpoint,
                 'metadata': metadata,

--- a/grizzly/users/servicebus.py
+++ b/grizzly/users/servicebus.py
@@ -213,7 +213,6 @@ class ServiceBusUser(ResponseHandler, RequestLogger, GrizzlyUser):
         })
 
         request: AsyncMessageRequest = {
-            'worker': self.worker_id,
             'action': RequestType.DISCONNECT.name,
             'context': context,
         }
@@ -242,7 +241,6 @@ class ServiceBusUser(ResponseHandler, RequestLogger, GrizzlyUser):
         })
 
         request: AsyncMessageRequest = {
-            'worker': self.worker_id,
             'action': RequestType.HELLO.name,
             'context': context,
         }
@@ -287,7 +285,12 @@ class ServiceBusUser(ResponseHandler, RequestLogger, GrizzlyUser):
 
         if len(name) > 65:
             name = f'{name[:65]}...'
-        request.update({'worker': self.worker_id})
+
+        request.update({
+            'worker': self.worker_id,
+            'client': id(self),
+        })
+
         connection = 'sender' if task.method.direction == RequestDirection.TO else 'receiver'
         request['context'].update({'connection': connection})
         action: Dict[str, Any] = {

--- a/grizzly/utils.py
+++ b/grizzly/utils.py
@@ -295,6 +295,9 @@ def async_message_request_wrapper(parent: GrizzlyScenario, client: zmq.Socket, r
     request_json = jsondumps(request)
     request = jsonloads(parent.render(request_json))
 
+    if request.get('client', None) is None:
+        request.update({'client': id(parent.user)})
+
     return async_message_request(client, request)
 
 

--- a/grizzly/utils.py
+++ b/grizzly/utils.py
@@ -298,6 +298,8 @@ def async_message_request_wrapper(parent: GrizzlyScenario, client: zmq.Socket, r
     if request.get('client', None) is None:
         request.update({'client': id(parent.user)})
 
+    parent.logger.debug(f'{request=}')
+
     return async_message_request(client, request)
 
 

--- a/grizzly_extras/async_message/__init__.py
+++ b/grizzly_extras/async_message/__init__.py
@@ -98,6 +98,7 @@ class AsyncMessageContext(TypedDict, total=False):
 class AsyncMessageRequest(TypedDict, total=False):
     action: str
     worker: Optional[str]
+    client: int
     context: AsyncMessageContext
     payload: AsyncMessagePayload
 

--- a/grizzly_extras/async_message/__init__.py
+++ b/grizzly_extras/async_message/__init__.py
@@ -216,7 +216,8 @@ def async_message_request(client: zmq.Socket, request: AsyncMessageRequest) -> A
             except ZMQAgain:
                 sleep(0.1)
             delta = perf_counter() - start
-            logger.debug(f'async_message_request::recv_json took {delta} seconds')
+            if delta > 1.0:
+                logger.debug(f'async_message_request::recv_json took {delta} seconds')
 
         if response is None:
             raise AsyncMessageError('no response')

--- a/grizzly_extras/async_message/daemon.py
+++ b/grizzly_extras/async_message/daemon.py
@@ -68,6 +68,8 @@ def router() -> None:
 
     spawn_worker()
 
+    worker_id: str
+
     while run:
         socks = dict(poller.poll(timeout=1000))
 
@@ -88,11 +90,13 @@ def router() -> None:
                 continue
 
             reply = backend_response[2:]
+            worker_id = backend_response[0].decode()
+
             if reply[0] != LRU_READY.encode():
                 frontend.send_multipart(reply)
+                logger.debug(f'forwarding backend response from {worker_id}')
             else:
-                worker_id = backend_response[0]
-                logger.info(f'worker {worker_id.decode()} ready')
+                logger.info(f'worker {worker_id} ready')
                 workers_available.append(worker_id)
 
         if socks.get(frontend) == zmq.POLLIN:
@@ -104,34 +108,50 @@ def router() -> None:
                 continue
 
             request_id = msg[0]
-            payload = jsonloads(msg[-1].decode())
+            payload = cast(AsyncMessageRequest, jsonloads(msg[-1].decode()))
 
-            worker_id = payload.get('worker', None)
-            client_id = payload.get('client', None)
+            request_worker_id = payload.get('worker', None)
+            request_client_id = payload.get('client', None)
+            client_key: Optional[str] = None
 
-            integration_url = payload.get('context', {}).get('url', None)
-            parsed = urlparse(integration_url)
-            client_key = f'{client_id}::{parsed.scheme}'
+            logger.debug(f'{request_worker_id=} ({type(request_worker_id)}), {request_client_id=} ({type(request_client_id)})')
 
-            if worker_id is None:
-                worker_id = client_worker_map.get(client_key, None)
+            if request_client_id is not None:
+                integration_url = payload.get('context', {}).get('url', None)
+                parsed = urlparse(integration_url)
+                scheme = parsed.scheme
+                if isinstance(scheme, bytes):
+                    scheme = scheme.decode()
 
-            if worker_id is None:
+                client_key = f'{request_client_id}::{scheme}'
+
+            if request_worker_id is None and client_key is not None:
+                request_worker_id = client_worker_map.get(client_key, None)
+
+            if request_worker_id is None:
                 worker_id = workers_available.pop()
-                client_worker_map.update({client_key: worker_id})
-                payload['worker'] = worker_id.decode()
+
+                if client_key is not None:
+                    client_worker_map.update({client_key: worker_id})
+
+                payload['worker'] = worker_id
                 logger.info(f'assigned worker {payload["worker"]} to {client_key}')
-                request = jsondumps(payload).encode()
+
                 if len(workers_available) == 0:
                     logger.debug('spawning an additional worker, for next client')
                     spawn_worker()
             else:
-                logger.debug(f'{client_id} is assigned {worker_id}')
-                worker_id = worker_id.encode()
-                request = msg[-1]
+                logger.debug(f'{request_client_id} is assigned {request_worker_id}')
+                worker_id = request_worker_id
 
-            backend_request = [worker_id, SPLITTER_FRAME, request_id, SPLITTER_FRAME, request]
+                if payload.get('worker', None) is None:
+                    payload['worker'] = worker_id
+
+            request = jsondumps(payload).encode()
+            backend_request = [worker_id.encode(), SPLITTER_FRAME, request_id, SPLITTER_FRAME, request]
+            logger.debug(f'{backend_request=}')
             backend.send_multipart(backend_request)
+            logger.debug(f'forwarding frontend request to worker {request_worker_id}')
 
     logger.info('stopping')
     for worker_thread in worker_threads:
@@ -174,13 +194,13 @@ def worker(context: zmq.Context, identity: str) -> None:
             jsonloads(request_proto[-1].decode()),
         )
 
-        if request['worker'] != identity:
-            logger.error(f'got {request["worker"]}, expected {identity}')
-            continue
-
         response: Optional[AsyncMessageResponse] = None
-        if integration is None:
-            try:
+
+        try:
+            if request['worker'] != identity:
+                raise RuntimeError(f'got {request["worker"]}, expected {identity}')
+
+            if integration is None:
                 integration_url = request.get('context', {}).get('url', None)
                 if integration_url is None:
                     raise RuntimeError('no url found in request context')
@@ -195,14 +215,13 @@ def worker(context: zmq.Context, identity: str) -> None:
                     integration = AsyncServiceBusHandler(identity)
                 else:
                     raise RuntimeError(f'integration for {str(parsed.scheme)}:// is not implemented')
-
-            except Exception as e:
-                response = {
-                    'worker': identity,
-                    'response_time': 0,
-                    'success': False,
-                    'message': str(e),
-                }
+        except Exception as e:
+            response = {
+                'worker': identity,
+                'response_time': 0,
+                'success': False,
+                'message': str(e),
+            }
 
         if response is None and integration is not None:
             logger.debug('send request to handler')

--- a/grizzly_extras/async_message/daemon.py
+++ b/grizzly_extras/async_message/daemon.py
@@ -200,21 +200,31 @@ def worker(context: zmq.Context, identity: str) -> None:
             if request['worker'] != identity:
                 raise RuntimeError(f'got {request["worker"]}, expected {identity}')
 
+            action = request.get('action', None)
+
             if integration is None:
-                integration_url = request.get('context', {}).get('url', None)
-                if integration_url is None:
-                    raise RuntimeError('no url found in request context')
+                if action not in ['DISCONNECT', 'DISC']:
+                    integration_url = request.get('context', {}).get('url', None)
+                    if integration_url is None:
+                        raise RuntimeError('no url found in request context')
 
-                parsed = urlparse(integration_url)
+                    parsed = urlparse(integration_url)
 
-                if parsed.scheme in ['mq', 'mqs']:
-                    from .mq import AsyncMessageQueueHandler
-                    integration = AsyncMessageQueueHandler(identity)
-                elif parsed.scheme == 'sb':
-                    from .sb import AsyncServiceBusHandler
-                    integration = AsyncServiceBusHandler(identity)
+                    if parsed.scheme in ['mq', 'mqs']:
+                        from .mq import AsyncMessageQueueHandler
+                        integration = AsyncMessageQueueHandler(identity)
+                    elif parsed.scheme == 'sb':
+                        from .sb import AsyncServiceBusHandler
+                        integration = AsyncServiceBusHandler(identity)
+                    else:
+                        raise RuntimeError(f'integration for {str(parsed.scheme)}:// is not implemented')
                 else:
-                    raise RuntimeError(f'integration for {str(parsed.scheme)}:// is not implemented')
+                    response = {
+                        'worker': identity,
+                        'response_time': 0,
+                        'success': True,
+                        'message': f'already handled {action}',
+                    }
         except Exception as e:
             response = {
                 'worker': identity,
@@ -228,8 +238,7 @@ def worker(context: zmq.Context, identity: str) -> None:
             response = integration.handle(request)
             logger.debug('got response from handler')
 
-            if request.get('action', None) in ['DISCONNECT', 'DISC']:
-                integration.close()
+            if action in ['DISCONNECT', 'DISC']:
                 integration = None
 
         response_proto = [

--- a/grizzly_extras/async_message/mq/__init__.py
+++ b/grizzly_extras/async_message/mq/__init__.py
@@ -75,12 +75,14 @@ class AsyncMessageQueueHandler(AsyncMessageHandler):
 
     @register(handlers, 'CONN')
     def connect(self, request: AsyncMessageRequest) -> AsyncMessageResponse:
-        if self.qmgr is not None:
-            raise AsyncMessageError('already connected')
-
         context = request.get('context', None)
         if context is None:
             raise AsyncMessageError('no context in request')
+
+        if self.qmgr is not None:
+            return {
+                'message': 're-used connection',
+            }
 
         connection = context['connection']
         queue_manager = context['queue_manager']

--- a/grizzly_extras/async_message/sb.py
+++ b/grizzly_extras/async_message/sb.py
@@ -560,7 +560,6 @@ class AsyncServiceBusHandler(AsyncMessageHandler):
                         raise StopIteration()
 
                     break
-
                 except StopIteration:
                     delta = perf_counter() - wait_start
 

--- a/tests/unit/test_grizzly/tasks/clients/test_messagequeue.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_messagequeue.py
@@ -332,6 +332,7 @@ class TestMessageQueueClientTask:
                 args, kwargs = send_json_mock.call_args_list[-1]
                 assert args == ({
                     'action': 'CONN',
+                    'client': 111111,
                     'context': {
                         'url': task_factory.endpoint,
                         'connection': 'mq.example.io(1414)',
@@ -395,6 +396,7 @@ class TestMessageQueueClientTask:
                 args, kwargs = send_json_mock.call_args_list[-1]
                 assert args == ({
                     'action': 'CONN',
+                    'client': 444444,
                     'context': {
                         'url': task_factory.endpoint,
                         'connection': 'mq.example.io(1414)',
@@ -450,12 +452,13 @@ class TestMessageQueueClientTask:
 
             assert scenario.user._context['variables'].get('mq-client-var', None) is None
             assert scenario.user._context['variables'].get('mq-client-metadata', None) is None
-            assert task_factory._worker.get(id(scenario), None) == 'dddd-eeee-ffff-9999'
+            assert task_factory._worker.get(id(scenario.user), None) == 'dddd-eeee-ffff-9999'
             assert send_json_mock.call_count == 2
             args, kwargs = send_json_mock.call_args_list[-1]
             assert args == ({
                 'action': 'GET',
                 'worker': 'dddd-eeee-ffff-9999',
+                'client': id(scenario.user),
                 'context': {
                     'endpoint': 'topic:INCOMING.MSG',
                 },
@@ -492,6 +495,7 @@ class TestMessageQueueClientTask:
             assert args == ({
                 'action': 'GET',
                 'worker': 'dddd-eeee-ffff-9999',
+                'client': id(scenario.user),
                 'context': {
                     'endpoint': 'topic:INCOMING.MSG, max_message_size:13337',
                 },
@@ -603,7 +607,7 @@ class TestMessageQueueClientTask:
 
             task(scenario)
 
-            assert task_factory._worker.get(id(scenario), None) == 'dddd-eeee-ffff-9999'
+            assert task_factory._worker.get(id(scenario.user), None) == 'dddd-eeee-ffff-9999'
 
             assert recv_json_mock.call_count == 2
             assert send_json_mock.call_count == 2
@@ -611,6 +615,7 @@ class TestMessageQueueClientTask:
             assert args == ({
                 'action': 'PUT',
                 'worker': 'dddd-eeee-ffff-9999',
+                'client': id(scenario.user),
                 'context': {
                     'endpoint': 'queue:INCOMING.MSG',
                 },
@@ -644,6 +649,7 @@ class TestMessageQueueClientTask:
             assert args == ({
                 'action': 'PUT',
                 'worker': 'dddd-eeee-ffff-9999',
+                'client': id(scenario.user),
                 'context': {
                     'endpoint': 'queue:INCOMING.MSG',
                 },

--- a/tests/unit/test_grizzly/tasks/clients/test_messagequeue.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_messagequeue.py
@@ -15,6 +15,7 @@ from zmq.error import Again as ZMQAgain
 
 from grizzly.tasks.clients import MessageQueueClientTask
 from grizzly.types import RequestDirection
+from grizzly_extras.async_message import AsyncMessageError
 
 try:
     import pymqi
@@ -303,13 +304,8 @@ class TestMessageQueueClientTask:
             if zmq_context is not None:
                 zmq_context.destroy()
 
-    def test_connect(self, grizzly_fixture: GrizzlyFixture, noop_zmq: NoopZmqFixture) -> None:
+    def test_connect(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture, noop_zmq: NoopZmqFixture) -> None:
         noop_zmq('grizzly.tasks.clients.messagequeue')
-
-        recv_json_mock = noop_zmq.get_mock('recv_json')
-        send_json_mock = noop_zmq.get_mock('send_json')
-
-        recv_json_mock.side_effect = [ZMQAgain, None]
 
         zmq_context: Optional[zmq.Context] = None
         try:
@@ -320,10 +316,14 @@ class TestMessageQueueClientTask:
             zmq_context = task_factory._zmq_context
 
             with task_factory.create_client() as client:
+                recv_json_mock = mocker.patch.object(client, 'recv_json')
+                send_json_mock = mocker.patch.object(client, 'send_json')
+                recv_json_mock.side_effect = [ZMQAgain, None]
+
                 meta: Dict[str, Any] = {}
-                with pytest.raises(RuntimeError) as re:
+                with pytest.raises(AsyncMessageError) as ame:
                     task_factory.connect(111111, client, meta)
-                assert str(re.value) == 'no response when trying to connect'
+                assert str(ame.value) == 'no response'
                 assert meta.get('response_length', None) == 0
                 assert meta.get('action', None) == 'topic:INCOMING.MSG'
                 assert meta.get('direction', None) == '<->'
@@ -357,9 +357,9 @@ class TestMessageQueueClientTask:
                 message = {'success': False, 'message': 'unknown error yo'}
                 recv_json_mock.side_effect = [message]
 
-                with pytest.raises(RuntimeError) as re:
+                with pytest.raises(AsyncMessageError) as ame:
                     task_factory.connect(222222, client, meta)
-                assert str(re.value) == 'unknown error yo'
+                assert str(ame.value) == 'unknown error yo'
 
                 assert send_json_mock.call_count == 2
                 assert recv_json_mock.call_count == 3
@@ -390,9 +390,13 @@ class TestMessageQueueClientTask:
             zmq_context = task_factory._zmq_context
 
             with task_factory.create_client() as client:
+                recv_json_mock = mocker.patch.object(client, 'recv_json')
+                send_json_mock = mocker.patch.object(client, 'send_json')
+
                 task_factory.connect(444444, client, meta)
-                assert send_json_mock.call_count == 4
-                assert recv_json_mock.call_count == 5
+
+                assert send_json_mock.call_count == 1
+                assert recv_json_mock.call_count == 1
                 args, kwargs = send_json_mock.call_args_list[-1]
                 assert args == ({
                     'action': 'CONN',
@@ -413,7 +417,6 @@ class TestMessageQueueClientTask:
                     },
                 },)
                 assert kwargs == {}
-
         finally:
             if zmq_context is not None:
                 zmq_context.destroy()
@@ -475,7 +478,7 @@ class TestMessageQueueClientTask:
             assert kwargs.get('response_length', None) == 0
             assert kwargs.get('context', None) == scenario.user._context
             exception = kwargs.get('exception', None)
-            assert isinstance(exception, RuntimeError)
+            assert isinstance(exception, AsyncMessageError)
             assert str(exception) == 'no response'
 
             messages = [{'success': False, 'message': 'memory corruption'}]
@@ -512,7 +515,7 @@ class TestMessageQueueClientTask:
             assert kwargs.get('response_length', None) == 0
             assert kwargs.get('context', None) == scenario.user._context
             exception = kwargs.get('exception', None)
-            assert isinstance(exception, RuntimeError)
+            assert isinstance(exception, AsyncMessageError)
             assert str(exception) == 'memory corruption'
 
             messages = [{'success': True, 'payload': None}]

--- a/tests/unit/test_grizzly/tasks/clients/test_servicebus.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_servicebus.py
@@ -249,11 +249,9 @@ class TestServiceBusClientTask:
         task = ServiceBusClientTask(RequestDirection.FROM, 'sb://my-sbns.servicebus.windows.net/;SharedAccessKeyName=AccessKey;SharedAccessKey=37aabb777f454324=', 'test')
         task._parent = scenario
 
-        # not connected
+        # not connected, don't do anything
         task._client = None
-        with pytest.raises(ConnectionError) as ce:
-            task.disconnect()
-        assert str(ce.value) == 'not connected to async-messaged'
+        task.disconnect()
 
         client_mock.close.assert_not_called()
 

--- a/tests/unit/test_grizzly/tasks/clients/test_servicebus.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_servicebus.py
@@ -233,18 +233,21 @@ class TestServiceBusClientTask:
 
         async_message_request_mock.assert_called_once_with(task.client, {
             'worker': None,
+            'client': id(scenario.user),
             'action': 'HELLO',
             'context': task.context,
         })
 
     def test_disconnect(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
+        _, _, scenario = grizzly_fixture()
+        assert scenario is not None
+
         client_mock = mocker.MagicMock()
 
-        async_message_request_mock = mocker.patch('grizzly.tasks.clients.servicebus.async_message_request_wrapper')
+        async_message_request_mock = mocker.patch('grizzly.utils.async_message_request')
 
         task = ServiceBusClientTask(RequestDirection.FROM, 'sb://my-sbns.servicebus.windows.net/;SharedAccessKeyName=AccessKey;SharedAccessKey=37aabb777f454324=', 'test')
-
-        task._parent = mocker.MagicMock()
+        task._parent = scenario
 
         # not connected
         task._client = None
@@ -260,8 +263,9 @@ class TestServiceBusClientTask:
 
         task.disconnect()
 
-        async_message_request_mock.assert_called_once_with(task.parent, client_mock, {
+        async_message_request_mock.assert_called_once_with(client_mock, {
             'worker': 'foo-bar-baz-foo',
+            'client': id(task.parent.user),
             'action': 'DISCONNECT',
             'context': task.context,
         })
@@ -301,15 +305,19 @@ class TestServiceBusClientTask:
         assert caplog.messages == ['foobar!']
         async_message_request_mock.assert_called_once_with(client_mock, {
             'worker': 'foo-bar-baz',
+            'client': id(scenario.user),
             'action': 'SUBSCRIBE',
             'context': expected_context,
             'payload': '1=2'
         })
 
     def test_unsubscribe(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture, caplog: LogCaptureFixture) -> None:
+        _, _, scenario = grizzly_fixture()
+        assert scenario is not None
+
         client_mock = mocker.MagicMock()
 
-        async_message_request_mock = mocker.patch('grizzly.tasks.clients.servicebus.async_message_request_wrapper', return_value={'message': 'hello world!'})
+        async_message_request_mock = mocker.patch('grizzly.utils.async_message_request', return_value={'message': 'hello world!'})
 
         task = ServiceBusClientTask(
             RequestDirection.FROM,
@@ -317,7 +325,7 @@ class TestServiceBusClientTask:
             'test',
         )
 
-        task._parent = mocker.MagicMock()
+        task._parent = scenario
 
         task._client = client_mock
         task.worker_id = 'foo-bar-baz'
@@ -327,8 +335,9 @@ class TestServiceBusClientTask:
 
         assert caplog.messages == ['hello world!']
 
-        async_message_request_mock.assert_called_once_with(task.parent, client_mock, {
+        async_message_request_mock.assert_called_once_with(client_mock, {
             'worker': 'foo-bar-baz',
+            'client': id(task.parent.user),
             'action': 'UNSUBSCRIBE',
             'context': task.context,
         })
@@ -402,19 +411,22 @@ class TestServiceBusClientTask:
         unsubscribe_mock.assert_called_once_with()
 
     def test_request(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
+        _, _, scenario = grizzly_fixture()
+
+        assert scenario is not None
+
         client_mock = mocker.MagicMock()
 
-        async_message_request_mock = mocker.patch('grizzly.tasks.clients.servicebus.async_message_request_wrapper', return_value={'message': 'foobar!'})
+        async_message_request_mock = mocker.patch('grizzly.utils.async_message_request', return_value={'message': 'foobar!'})
 
         task = ServiceBusClientTask(
             RequestDirection.FROM,
             'sb://my-sbns.servicebus.windows.net/topic:my-topic/subscription:my-subscription;SharedAccessKeyName=AccessKey;SharedAccessKey=37aabb777f454324=',
             'test',
         )
-        task._parent = mocker.MagicMock()
         task._client = client_mock
+        task._parent = scenario
 
-        parent_mock = mocker.MagicMock()
         action_mock = mocker.MagicMock()
         meta_mock: Dict[str, Any] = {}
         action_mock.__enter__.return_value = meta_mock
@@ -425,10 +437,13 @@ class TestServiceBusClientTask:
             'context': task.context,
         }
 
-        assert task.request(parent_mock, request) == {'message': 'foobar!'}
+        assert task.request(task.parent, request) == {'message': 'foobar!'}
 
-        context_mock.assert_called_once_with(parent_mock)
-        async_message_request_mock.assert_called_once_with(parent_mock, client_mock, request)
+        context_mock.assert_called_once_with(task.parent)
+        request.update({'client': id(task.parent.user)})
+        async_message_request_mock.assert_called_once_with(client_mock, request)
+        del request['client']
+
         assert meta_mock == {
             'action': 'topic:my-topic, subscription:my-subscription',
             'request': request,
@@ -444,10 +459,10 @@ class TestServiceBusClientTask:
         del request['context']['url']
         async_message_request_mock = mocker.patch('grizzly.tasks.clients.servicebus.async_message_request_wrapper', return_value={'message': 'foobar!', 'payload': '1234567890'})
 
-        assert task.request(parent_mock, request) == {'message': 'foobar!', 'payload': '1234567890'}
+        assert task.request(task.parent, request) == {'message': 'foobar!', 'payload': '1234567890'}
 
-        context_mock.assert_called_once_with(parent_mock)
-        async_message_request_mock.assert_called_once_with(parent_mock, client_mock, request)
+        context_mock.assert_called_once_with(task.parent)
+        async_message_request_mock.assert_called_once_with(task.parent, client_mock, request)
         assert meta_mock == {
             'action': 'topic:my-topic, subscription:my-subscription',
             'request': request,
@@ -456,9 +471,12 @@ class TestServiceBusClientTask:
         }
 
     def test_get(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
+        _, _, scenario = grizzly_fixture()
+
+        assert scenario is not None
+
         client_mock = mocker.MagicMock()
-        parent_mock = mocker.MagicMock()
-        parent_mock.user._context = {'variables': {}}
+        scenario.user._context = {'variables': {}}
 
         task = ServiceBusClientTask(
             RequestDirection.FROM,
@@ -466,6 +484,7 @@ class TestServiceBusClientTask:
             'test',
         )
         task._client = client_mock
+        task._parent = scenario
         task.worker_id = 'foo-bar'
 
         request_mock = mocker.patch.object(task, 'request', return_value={'metadata': None, 'payload': 'foobar'})
@@ -473,57 +492,55 @@ class TestServiceBusClientTask:
         # no variables
         task.payload_variable = None
 
-        assert task.get(parent_mock) == (None, 'foobar',)
+        assert task.get(task.parent) == (None, 'foobar',)
 
-        request_mock.assert_called_once_with(parent_mock, {
+        request_mock.assert_called_once_with(task.parent, {
             'action': 'RECEIVE',
             'worker': 'foo-bar',
             'context': task.context,
             'payload': None,
         })
 
-        assert parent_mock.user._context['variables'] == {}
+        assert task.parent.user._context['variables'] == {}
 
         request_mock.reset_mock()
 
         # with payload variable
         task.payload_variable = 'foobaz'
 
-        assert task.get(parent_mock) == (None, 'foobar',)
+        assert task.get(task.parent) == (None, 'foobar',)
 
-        request_mock.assert_called_once_with(parent_mock, {
+        request_mock.assert_called_once_with(task.parent, {
             'action': 'RECEIVE',
             'worker': 'foo-bar',
             'context': task.context,
             'payload': None,
         })
 
-        assert parent_mock.user._context['variables'] == {'foobaz': 'foobar'}
+        assert task.parent.user._context['variables'] == {'foobaz': 'foobar'}
 
         # with payload and metadata variable
         task.payload_variable = 'foobaz'
         task.metadata_variable = 'bazfoo'
         request_mock = mocker.patch.object(task, 'request', return_value={'metadata': {'x-foo-bar': 'hello'}, 'payload': 'foobar'})
 
-        assert task.get(parent_mock) == ({'x-foo-bar': 'hello'}, 'foobar',)
+        assert task.get(task.parent) == ({'x-foo-bar': 'hello'}, 'foobar',)
 
-        request_mock.assert_called_once_with(parent_mock, {
+        request_mock.assert_called_once_with(task.parent, {
             'action': 'RECEIVE',
             'worker': 'foo-bar',
             'context': task.context,
             'payload': None,
         })
 
-        assert parent_mock.user._context['variables'] == {'foobaz': 'foobar', 'bazfoo': jsondumps({'x-foo-bar': 'hello'})}
+        assert task.parent.user._context['variables'] == {'foobaz': 'foobar', 'bazfoo': jsondumps({'x-foo-bar': 'hello'})}
 
     def test_put(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
         _, _, scenario = grizzly_fixture()
         assert scenario is not None
 
         client_mock = mocker.MagicMock()
-        parent_mock = mocker.MagicMock()
         scenario.user._context = {'variables': {}}
-        parent_mock.render = scenario.render
 
         task = ServiceBusClientTask(
             RequestDirection.TO,
@@ -532,14 +549,15 @@ class TestServiceBusClientTask:
             source='hello world',
         )
         task._client = client_mock
+        task._parent = scenario
         task.worker_id = 'foo-baz'
 
         request_mock = mocker.patch.object(task, 'request', return_value={'metadata': None, 'payload': 'foobar'})
 
         # inline source, no file
-        assert task.put(parent_mock) == (None, 'foobar',)
+        assert task.put(task.parent) == (None, 'foobar',)
 
-        request_mock.assert_called_once_with(parent_mock, {
+        request_mock.assert_called_once_with(task.parent, {
             'action': 'SEND',
             'worker': 'foo-baz',
             'context': task.context,
@@ -552,9 +570,9 @@ class TestServiceBusClientTask:
         task.source = '{{ foobar }}'
         scenario.user._context['variables'].update({'foobar': 'hello world'})
 
-        assert task.put(parent_mock) == (None, 'foobar',)
+        assert task.put(task.parent) == (None, 'foobar',)
 
-        request_mock.assert_called_once_with(parent_mock, {
+        request_mock.assert_called_once_with(task.parent, {
             'action': 'SEND',
             'worker': 'foo-baz',
             'context': task.context,
@@ -568,9 +586,9 @@ class TestServiceBusClientTask:
         (grizzly_fixture.test_context / 'source.json').write_text('hello world')
         task.source = 'source.json'
 
-        assert task.put(parent_mock) == (None, 'foobar',)
+        assert task.put(task.parent) == (None, 'foobar',)
 
-        request_mock.assert_called_once_with(parent_mock, {
+        request_mock.assert_called_once_with(task.parent, {
             'action': 'SEND',
             'worker': 'foo-baz',
             'context': task.context,
@@ -584,9 +602,9 @@ class TestServiceBusClientTask:
         (grizzly_fixture.test_context / 'source.j2.json').write_text('{{ foobar }}')
         task.source = '{{ filename }}'
 
-        assert task.put(parent_mock) == (None, 'foobar',)
+        assert task.put(task.parent) == (None, 'foobar',)
 
-        request_mock.assert_called_once_with(parent_mock, {
+        request_mock.assert_called_once_with(task.parent, {
             'action': 'SEND',
             'worker': 'foo-baz',
             'context': task.context,

--- a/tests/unit/test_grizzly/tasks/clients/test_servicebus.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_servicebus.py
@@ -594,3 +594,30 @@ class TestServiceBusClientTask:
         })
 
         request_mock.reset_mock()
+
+    def test_parent(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
+        _, _, scenario = grizzly_fixture()
+        assert scenario is not None
+
+        client_mock = mocker.MagicMock()
+
+        task = ServiceBusClientTask(
+            RequestDirection.TO,
+            'sb://my-sbns.servicebus.windows.net/topic:my-topic;SharedAccessKeyName=AccessKey;SharedAccessKey=37aabb777f454324=',
+            'test',
+            source='hello world',
+        )
+
+        task._client = client_mock
+
+        with pytest.raises(AttributeError) as ae:
+            _ = task.parent
+        assert str(ae.value) == 'no parent set'
+
+        task.parent = mocker.MagicMock()
+
+        _ = task.parent
+
+        with pytest.raises(AttributeError) as ae:
+            task.parent = scenario
+        assert str(ae.value) == 'parent already set, why are a different parent being set?'

--- a/tests/unit/test_grizzly/test_utils.py
+++ b/tests/unit/test_grizzly/test_utils.py
@@ -680,8 +680,12 @@ def test_async_message_request_wrapper(grizzly_fixture: GrizzlyFixture, mocker: 
 
     async_message_request_wrapper(scenario, client_mock, request)
 
+    request.update({'client': id(scenario.user)})
+
     async_message_request_mock.assert_called_once_with(client_mock, request)
     async_message_request_mock.reset_mock()
+
+    del request['client']
 
     # template to render, variable not set
     request = {
@@ -691,14 +695,16 @@ def test_async_message_request_wrapper(grizzly_fixture: GrizzlyFixture, mocker: 
     }
 
     async_message_request_wrapper(scenario, client_mock, request)
-    async_message_request_mock.assert_called_once_with(client_mock, {'context': {'endpoint': 'hello !'}})
+
+    async_message_request_mock.assert_called_once_with(client_mock, {'context': {'endpoint': 'hello !'}, 'client': id(scenario.user)})
     async_message_request_mock.reset_mock()
 
     # template to render, variable set
     scenario.user._context['variables'].update({'world': 'foobar'})
 
     async_message_request_wrapper(scenario, client_mock, request)
-    async_message_request_mock.assert_called_once_with(client_mock, {'context': {'endpoint': 'hello foobar!'}})
+
+    async_message_request_mock.assert_called_once_with(client_mock, {'context': {'endpoint': 'hello foobar!'}, 'client': id(scenario.user)})
 
 
 def test_safe_del() -> None:

--- a/tests/unit/test_grizzly/users/test_servicebus.py
+++ b/tests/unit/test_grizzly/users/test_servicebus.py
@@ -174,7 +174,6 @@ class TestServiceBusUser:
             assert len(args) == 3
             assert len(kwargs) == 0
             assert args[1] == {
-                'worker': None,
                 'action': 'DISCONNECT',
                 'context': {
                     'endpoint': 'queue:test-queue',
@@ -243,7 +242,6 @@ class TestServiceBusUser:
         assert len(kwargs) == 0
         assert args[1] is task
         assert args[2] == {
-            'worker': None,
             'action': 'HELLO',
             'context': {
                 'endpoint': 'topic:test-topic',
@@ -274,7 +272,6 @@ class TestServiceBusUser:
         assert len(kwargs) == 0
         assert args[1] is task
         assert args[2] == {
-            'worker': None,
             'action': 'HELLO',
             'context': {
                 'endpoint': 'topic:test-topic, subscription:test-subscription',
@@ -420,6 +417,7 @@ class TestServiceBusUser:
         assert kwargs == {}
         assert args == ({
             'worker': 'asdf-asdf-asdf',
+            'client': id(user),
             'action': 'SEND',
             'payload': 'hello',
             'context': {
@@ -474,6 +472,7 @@ class TestServiceBusUser:
         assert kwargs == {}
         assert args == ({
             'worker': 'asdf-asdf-asdf',
+            'client': id(user),
             'action': 'RECEIVE',
             'payload': None,
             'context': {
@@ -529,6 +528,7 @@ class TestServiceBusUser:
         assert kwargs == {}
         assert args == ({
             'worker': 'asdf-asdf-asdf',
+            'client': id(user),
             'action': 'RECEIVE',
             'payload': None,
             'context': {

--- a/tests/unit/test_grizzly_extras/async_message/test___init__.py
+++ b/tests/unit/test_grizzly_extras/async_message/test___init__.py
@@ -16,6 +16,7 @@ from grizzly_extras.async_message import (
     AsyncMessageResponse,
     AsyncMessageRequest,
     AsyncMessageHandler,
+    AsyncMessageError,
     ThreadLogger,
     register,
     async_message_request,
@@ -195,7 +196,7 @@ def test_async_message_request(mocker: MockerFixture) -> None:
         'action': 'HELLO',
     }
 
-    with pytest.raises(RuntimeError) as re:
+    with pytest.raises(AsyncMessageError) as re:
         async_message_request(client_mock, request)
     assert str(re.value) == 'no response'
 
@@ -215,7 +216,7 @@ def test_async_message_request(mocker: MockerFixture) -> None:
     client_mock.recv_json.side_effect = None
     client_mock.recv_json.return_value = {'success': False, 'message': 'error! error! error!'}
 
-    with pytest.raises(RuntimeError) as re:
+    with pytest.raises(AsyncMessageError) as re:
         async_message_request(client_mock, request)
     assert str(re.value) == 'error! error! error!'
 

--- a/tests/unit/test_grizzly_extras/async_message/test_sb.py
+++ b/tests/unit/test_grizzly_extras/async_message/test_sb.py
@@ -406,36 +406,32 @@ class TestAsyncServiceBusHandler:
         assert isinstance(receiver, ServiceBusReceiver)
         assert topic_spy.call_count == 0
         assert queue_spy.call_count == 1
-        _, kwargs = queue_spy.call_args_list[-1]
-        assert len(kwargs) == 1
-        assert kwargs.get('queue_name', None) == 'test-queue'
+        args, kwargs = queue_spy.call_args_list[-1]
+        assert args == ()
+        assert kwargs == {'queue_name': 'test-queue'}
 
         handler.get_receiver_instance(client, dict({'wait': '100'}, **handler.get_endpoint_arguments('receiver', 'queue:test-queue')))
         assert topic_spy.call_count == 0
         assert queue_spy.call_count == 2
-        _, kwargs = queue_spy.call_args_list[-1]
-        assert len(kwargs) == 2
-        assert kwargs.get('queue_name', None) == 'test-queue'
-        assert kwargs.get('max_wait_time', None) == 100
+        args, kwargs = queue_spy.call_args_list[-1]
+        assert args == ()
+        assert kwargs == {'queue_name': 'test-queue', 'max_wait_time': 100}
 
         receiver = handler.get_receiver_instance(client, handler.get_endpoint_arguments('receiver', 'topic:test-topic, subscription: test-subscription'))
         assert topic_spy.call_count == 1
         assert queue_spy.call_count == 2
-        _, kwargs = topic_spy.call_args_list[-1]
-        assert len(kwargs) == 2
-        assert kwargs.get('topic_name', None) == 'test-topic'
-        assert kwargs.get('subscription_name', None) == 'test-subscription'
+        args, kwargs = topic_spy.call_args_list[-1]
+        assert args == ()
+        assert kwargs == {'topic_name': 'test-topic', 'subscription_name': 'test-subscription'}
 
         receiver = handler.get_receiver_instance(client, dict({'wait': '100'}, **handler.get_endpoint_arguments(
             'receiver', 'topic:test-topic, subscription:test-subscription, expression:$.foo.bar',
         )))
         assert topic_spy.call_count == 2
         assert queue_spy.call_count == 2
-        _, kwargs = topic_spy.call_args_list[-1]
-        assert len(kwargs) == 3
-        assert kwargs.get('topic_name', None) == 'test-topic'
-        assert kwargs.get('subscription_name', None) == 'test-subscription'
-        assert kwargs.get('max_wait_time', None) == 100
+        args, kwargs = topic_spy.call_args_list[-1]
+        assert args == ()
+        assert kwargs == {'topic_name': 'test-topic', 'subscription_name': 'test-subscription', 'max_wait_time': 100}
 
     def test_hello(self, mocker: MockerFixture) -> None:
         from grizzly_extras.async_message.sb import handlers

--- a/tests/unit/test_grizzly_extras/async_message/test_sb.py
+++ b/tests/unit/test_grizzly_extras/async_message/test_sb.py
@@ -47,6 +47,7 @@ class TestAsyncServiceBusHandler:
         from grizzly_extras.async_message.sb import handlers
 
         handler = AsyncServiceBusHandler(worker='asdf-asdf-asdf')
+        handler._client = mocker.MagicMock()
         request: AsyncMessageRequest = {
             'action': 'DISCONNECT',
         }
@@ -374,21 +375,23 @@ class TestAsyncServiceBusHandler:
 
         handler = AsyncServiceBusHandler('asdf-asdf-asdf')
 
-        sender = handler.get_sender_instance(client, handler.get_endpoint_arguments('sender', 'queue:test-queue'))
+        handler._client = client
+
+        sender = handler.get_sender_instance(handler.get_endpoint_arguments('sender', 'queue:test-queue'))
         assert isinstance(sender, ServiceBusSender)
         assert topic_spy.call_count == 0
         assert queue_spy.call_count == 1
-        _, kwargs = queue_spy.call_args_list[0]
-        assert len(kwargs) == 1
-        assert kwargs.get('queue_name', None) == 'test-queue'
+        args, kwargs = queue_spy.call_args_list[0]
+        assert args == ()
+        assert kwargs == {'client_identifier': 'asdf-asdf-asdf', 'queue_name': 'test-queue'}
 
-        sender = handler.get_sender_instance(client, handler.get_endpoint_arguments('sender', 'topic:test-topic'))
+        sender = handler.get_sender_instance(handler.get_endpoint_arguments('sender', 'topic:test-topic'))
         assert isinstance(sender, ServiceBusSender)
         assert queue_spy.call_count == 1
         assert topic_spy.call_count == 1
-        _, kwargs = topic_spy.call_args_list[0]
-        assert len(kwargs) == 1
-        assert kwargs.get('topic_name', None) == 'test-topic'
+        args, kwargs = topic_spy.call_args_list[0]
+        assert args == ()
+        assert kwargs == {'client_identifier': 'asdf-asdf-asdf', 'topic_name': 'test-topic'}
 
     def test_get_receiver_instance(self, mocker: MockerFixture) -> None:
         url = 'Endpoint=sb://sb.example.org/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc123def456ghi789='
@@ -401,37 +404,38 @@ class TestAsyncServiceBusHandler:
         topic_spy = mocker.spy(client, 'get_subscription_receiver')
 
         handler = AsyncServiceBusHandler('asdf-asdf-asdf')
+        handler._client = client
 
-        receiver = handler.get_receiver_instance(client, handler.get_endpoint_arguments('receiver', 'queue:test-queue'))
+        receiver = handler.get_receiver_instance(handler.get_endpoint_arguments('receiver', 'queue:test-queue'))
         assert isinstance(receiver, ServiceBusReceiver)
         assert topic_spy.call_count == 0
         assert queue_spy.call_count == 1
         args, kwargs = queue_spy.call_args_list[-1]
         assert args == ()
-        assert kwargs == {'queue_name': 'test-queue'}
+        assert kwargs == {'client_identifier': 'asdf-asdf-asdf', 'queue_name': 'test-queue'}
 
-        handler.get_receiver_instance(client, dict({'wait': '100'}, **handler.get_endpoint_arguments('receiver', 'queue:test-queue')))
+        handler.get_receiver_instance(dict({'wait': '100'}, **handler.get_endpoint_arguments('receiver', 'queue:test-queue')))
         assert topic_spy.call_count == 0
         assert queue_spy.call_count == 2
         args, kwargs = queue_spy.call_args_list[-1]
         assert args == ()
-        assert kwargs == {'queue_name': 'test-queue', 'max_wait_time': 100}
+        assert kwargs == {'client_identifier': 'asdf-asdf-asdf', 'queue_name': 'test-queue', 'max_wait_time': 100}
 
-        receiver = handler.get_receiver_instance(client, handler.get_endpoint_arguments('receiver', 'topic:test-topic, subscription: test-subscription'))
+        receiver = handler.get_receiver_instance(handler.get_endpoint_arguments('receiver', 'topic:test-topic, subscription: test-subscription'))
         assert topic_spy.call_count == 1
         assert queue_spy.call_count == 2
         args, kwargs = topic_spy.call_args_list[-1]
         assert args == ()
-        assert kwargs == {'topic_name': 'test-topic', 'subscription_name': 'test-subscription'}
+        assert kwargs == {'client_identifier': 'asdf-asdf-asdf', 'topic_name': 'test-topic', 'subscription_name': 'test-subscription'}
 
-        receiver = handler.get_receiver_instance(client, dict({'wait': '100'}, **handler.get_endpoint_arguments(
+        receiver = handler.get_receiver_instance(dict({'wait': '100'}, **handler.get_endpoint_arguments(
             'receiver', 'topic:test-topic, subscription:test-subscription, expression:$.foo.bar',
         )))
         assert topic_spy.call_count == 2
         assert queue_spy.call_count == 2
         args, kwargs = topic_spy.call_args_list[-1]
         assert args == ()
-        assert kwargs == {'topic_name': 'test-topic', 'subscription_name': 'test-subscription', 'max_wait_time': 100}
+        assert kwargs == {'client_identifier': 'asdf-asdf-asdf', 'topic_name': 'test-topic', 'subscription_name': 'test-subscription', 'max_wait_time': 100}
 
     def test_hello(self, mocker: MockerFixture) -> None:
         from grizzly_extras.async_message.sb import handlers
@@ -445,7 +449,7 @@ class TestAsyncServiceBusHandler:
             handlers[request['action']](handler, request)
         assert 'no context in request' in str(ame)
 
-        assert handler.client is None
+        assert handler._client is None
 
         servicebusclient_connect_spy = mocker.spy(ServiceBusClient, 'from_connection_string')
 
@@ -485,10 +489,9 @@ class TestAsyncServiceBusHandler:
         assert sender_instance_spy.return_value.__enter__.call_count == 1
         assert receiver_instance_spy.call_count == 0
 
-        args, _ = sender_instance_spy.call_args_list[0]
-        assert len(args) == 2
-        assert args[0] is handler.client
-        assert args[1] == {'endpoint_type': 'queue', 'endpoint': 'test-queue'}
+        args, kwargs = sender_instance_spy.call_args_list[0]
+        assert args == ({'endpoint_type': 'queue', 'endpoint': 'test-queue'},)
+        assert kwargs == {}
 
         assert handler._sender_cache.get('queue:test-queue', None) is not None
         assert handler._receiver_cache == {}
@@ -516,10 +519,9 @@ class TestAsyncServiceBusHandler:
         assert receiver_instance_spy.call_count == 1
         assert receiver_instance_spy.return_value.__enter__.call_count == 1
 
-        args, _ = receiver_instance_spy.call_args_list[0]
-        assert len(args) == 2
-        assert args[0] is handler.client
-        assert args[1] == {'endpoint_type': 'topic', 'endpoint': 'test-topic', 'subscription': 'test-subscription', 'wait': '10'}
+        args, kwargs = receiver_instance_spy.call_args_list[0]
+        assert kwargs == {}
+        assert args == ({'endpoint_type': 'topic', 'endpoint': 'test-topic', 'subscription': 'test-subscription', 'wait': '10'},)
 
         assert handler._sender_cache.get('queue:test-queue', None) is not None
         assert handler._receiver_cache.get('topic:test-topic, subscription:test-subscription', None) is not None
@@ -568,7 +570,7 @@ class TestAsyncServiceBusHandler:
             handlers[request['action']](handler, request)
         assert 'no context in request' in str(ame)
 
-        assert handler.client is None
+        assert handler._client is None
 
         # sender request
         request = {


### PR DESCRIPTION
fixed non-expensive workaround if reading a message from a receiver takes more than `max_wait_time` seconds. the first read will directly return no messages, but when reading it again it will get expected messages.

more improvements around `async-messaged` and how grizzly communicates with it.