### PR TITLE
rewrite `grizzly.tasks.clients.servicebus` to support more than one parent

### DIFF
--- a/grizzly/auth/aad.py
+++ b/grizzly/auth/aad.py
@@ -473,7 +473,10 @@ class AAD(RefreshToken):
             exception = e
             logger.error(str(e), exc_info=True)
         finally:
-            name = client.__class__.__name__.rsplit('_', 1)[-1]
+            if client.parent is not None:
+                scenario_index = client.parent.user._scenario.identifier
+            else:
+                scenario_index = client.__class__.__name__.rsplit('_', 1)[-1]
 
             if is_token_v2_0 is None:
                 version = ''
@@ -483,7 +486,7 @@ class AAD(RefreshToken):
             request_meta = {
                 'request_type': 'AUTH',
                 'response_time': int((time_perf_counter() - start_time) * 1000),
-                'name': f'{name} {cls.__name__} OAuth2 user token {version}',
+                'name': f'{scenario_index} {cls.__name__} OAuth2 user token {version}',
                 'context': client._context,
                 'response': None,
                 'exception': exception,

--- a/grizzly_extras/async_message/__init__.py
+++ b/grizzly_extras/async_message/__init__.py
@@ -128,7 +128,7 @@ class AsyncMessageHandler(ABC):
     def __init__(self, worker: str) -> None:
         self.worker = worker
         self.message_wait = None
-        self.logger = ThreadLogger(f'handler::{worker}')
+        self.logger = ThreadLogger(f'handler::{self.__class__.__name__}::{worker}')
 
         # silence uamqp loggers
         for uamqp_logger_name in ['uamqp', 'uamqp.c_uamqp']:

--- a/grizzly_extras/async_message/daemon.py
+++ b/grizzly_extras/async_message/daemon.py
@@ -149,9 +149,7 @@ def router() -> None:
 
             request = jsondumps(payload).encode()
             backend_request = [worker_id.encode(), SPLITTER_FRAME, request_id, SPLITTER_FRAME, request]
-            logger.debug(f'{backend_request=}')
             backend.send_multipart(backend_request)
-            logger.debug(f'forwarding frontend request to worker {request_worker_id}')
 
     logger.info('stopping')
     for worker_thread in worker_threads:


### PR DESCRIPTION
one instance of `ServiceBusClientTask` is created per scenario, if running multiple users, there will be more than one unique scenario executing the task. hence the task needs have support to run with different parent scenarios.

this is done by keeping a state in the instance for each scenario it has been executed with.

there's a 1:1 mapping between a worker and a scenario/user, so the `async-messaged` requests must use correct context, client, worker, etc.