### PR TITLE
only allow writing a complete row at a time in AtomicCsvWriter

### DIFF
--- a/grizzly/tasks/set_variable.py
+++ b/grizzly/tasks/set_variable.py
@@ -74,7 +74,8 @@ class SetVariableTask(GrizzlyTask):
 
             if self._variable_instance is not None:
                 self._variable_instance[self._variable_key] = value
-            else:
-                parent.user._context['variables'][self.variable] = value
+
+            # always update user context with new value
+            parent.user._context['variables'][self.variable] = value
 
         return task

--- a/grizzly/testdata/communication.py
+++ b/grizzly/testdata/communication.py
@@ -238,7 +238,10 @@ class TestdataProducer:
 
                                                     value = loaded_variable_datatypes[testdata_type][data_attribute]
                                                 else:
-                                                    value = variable[variable_name]
+                                                    try:
+                                                        value = variable[variable_name]
+                                                    except NotImplementedError:
+                                                        continue
                                             else:
                                                 value = variable
 

--- a/tests/e2e/steps/test_setup.py
+++ b/tests/e2e/steps/test_setup.py
@@ -45,15 +45,14 @@ def test_e2e_step_setup_variable_value(e2e_fixture: End2EndFixture) -> None:
         grizzly = cast(GrizzlyContext, context.grizzly)
 
         assert grizzly.state.variables['AtomicCsvWriter.output'] == "output.csv | headers='foo, bar'"
-        assert len(grizzly.scenario.tasks()) == 3 + 1
+        assert len(grizzly.scenario.tasks()) == 2 + 1
 
     e2e_fixture.add_validator(validate_variables)
 
     feature_file = e2e_fixture.test_steps(
         scenario=[
             'And value for variable "AtomicCsvWriter.output" is "output.csv | headers=\'foo, bar\'"',
-            'And value for variable "AtomicCsvWriter.output.foo" is "bar"',
-            'And value for variable "AtomicCsvWriter.output.bar" is "foo"',
+            'And value for variable "AtomicCsvWriter.output" is "bar, foo"',
             'And value for variable "foobar" is "foobar"',
             'And value for variable "foobar" is "foobaz"',
         ]

--- a/tests/unit/test_grizzly/tasks/test_set_variable.py
+++ b/tests/unit/test_grizzly/tasks/test_set_variable.py
@@ -81,13 +81,13 @@ class TestSetVariableTask:
 
             grizzly_fixture.grizzly.state.variables.update({'AtomicCsvWriter.output': 'output.csv | headers="foo,bar"'})
             GrizzlyVariables.initialize_variable(grizzly_fixture.grizzly, 'AtomicCsvWriter.output')
-            task_factory_foo = SetVariableTask('AtomicCsvWriter.output.foo', '{{ value }}')
-            scenario.user._context['variables'].update({'value': 'hello world!'})
+            task_factory_foo = SetVariableTask('AtomicCsvWriter.output', '{{ value }}')
+            scenario.user._context['variables'].update({'value': 'hello, world!'})
 
             task = task_factory_foo()
             task(scenario)
 
-            set_value_mock.assert_called_once_with('output.foo', 'hello world!')
+            set_value_mock.assert_called_once_with('output', 'hello, world!')
             assert 'AtomicCsvWriter.output.foo' not in scenario.user._context['variables']
         finally:
             cleanup()


### PR DESCRIPTION
so there are no race-conditions, if the scenario is running on a worker with more than 1 user.