### PR TITLE
handling of SIGINT/SIGTERM to gracefully stop test

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -40,6 +40,12 @@ jobs:
       id: flake8
       run: python -m flake8
 
+    - name: gevent poison check
+      id: gevent-poison
+      run: |
+        find grizzly_extras/ -type f -name '*.py' -exec grep -nHE '^\s?(import|from) grizzly\.' {} \;
+        find grizzly_extras/ -type f -name '*.py' -exec grep -nHE '^\s*(import|from) grizzly\.' {} \;  | awk '/(import|from) grizzly\./ {exit 1}'
+
   test-and-coverage:
     name: "test-and-coverage / ${{ matrix.runs-on }} / python-${{ matrix.python-version }}"
     runs-on: ${{ matrix.runs-on }}

--- a/.gitignore
+++ b/.gitignore
@@ -19,11 +19,12 @@ coverage.xml
 *.hprof
 *.bak
 
+tests/manual/**
+
 # automagically generated
 docs/licenses/*
 docs/changelog/*
 docs/cli.md
 docs/_site
 docs/_build
-
 grizzly/__version__.py

--- a/grizzly/behave.py
+++ b/grizzly/behave.py
@@ -106,7 +106,7 @@ def after_feature(context: Context, feature: Feature, *args: Tuple[Any, ...], **
 
         end_text = 'Aborted' if return_code == 15 else 'Finished'
 
-        print('')
+        print('', flush=True)
         print(f'{"Started":<{len(end_text)}}: {context.started}')
         print(f'{end_text}: {stopped}')
 

--- a/grizzly/exceptions.py
+++ b/grizzly/exceptions.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 from locust.exception import StopUser
+from grizzly_extras.async_message import AsyncMessageAbort
 
 __all__ = [
     'StopUser',
@@ -25,5 +26,5 @@ class RestartScenario(Exception):
     pass
 
 
-class StopScenario(Exception):
+class StopScenario(AsyncMessageAbort):
     pass

--- a/grizzly/gevent.py
+++ b/grizzly/gevent.py
@@ -1,0 +1,34 @@
+from typing import Any, Callable, Dict, Tuple
+from functools import wraps
+
+from gevent import Greenlet, getcurrent
+
+
+class GreenletWithExceptionCatching(Greenlet):
+    started_from: Greenlet
+
+    def __init__(self, *args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> None:
+        super().__init__(*args, **kwargs)
+        self.started_from = getcurrent()
+
+    def handle_exception(self, error: Exception) -> None:
+        self.started_from.throw(error)
+
+    def wrap_exceptions(self, func: Callable) -> Callable:
+        @wraps(func)
+        def exception_handler(*args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> Any:
+            try:
+                return func(*args, **kwargs)
+            except Exception as exception:
+                self.wrap_exceptions(self.handle_exception)(exception)
+                return exception
+
+        return exception_handler
+
+    def spawn(self, func: Callable, *args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> Greenlet:
+        func_wrap = self.wrap_exceptions(func)
+        return super().spawn(func_wrap, *args, **kwargs)
+
+    def spawn_later(self, seconds: int, func: Callable, *args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> Greenlet:
+        func_wrap = self.wrap_exceptions(func)
+        return super().spawn_later(seconds, func_wrap, *args, **kwargs)

--- a/grizzly/listeners/influxdb.py
+++ b/grizzly/listeners/influxdb.py
@@ -155,7 +155,7 @@ class InfluxDbListener:
         self.environment.events.quit.add_listener(self.on_quit)
 
     def on_quit(self, *args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> None:
-        self.finished = True
+        self._finished = True
 
     def create_client(self) -> InfluxDb:
         return InfluxDb(
@@ -199,8 +199,6 @@ class InfluxDbListener:
 
             if not self.finished:
                 gevent.sleep(5.0)
-            else:
-                break
 
     def run_events(self) -> None:
         while not self.finished:
@@ -213,9 +211,9 @@ class InfluxDbListener:
                     self.connection.write(events_buffer)
                 except Exception as e:
                     self.logger.error(str(e))
-            elif self.finished:
-                break
-            gevent.sleep(0.5)
+
+            if not self.finished:
+                gevent.sleep(0.5)
 
     def _log_request(
         self,

--- a/grizzly/listeners/influxdb.py
+++ b/grizzly/listeners/influxdb.py
@@ -203,7 +203,6 @@ class InfluxDbListener:
                 break
 
     def run_events(self) -> None:
-        print(f'run_events: {self.finished=}')
         while not self.finished:
             if self._events:
                 # Buffer samples, so that a locust greenlet will write to the new list
@@ -212,11 +211,9 @@ class InfluxDbListener:
                     events_buffer = self._events
                     self._events = []
                     self.connection.write(events_buffer)
-                    print('wrote')
                 except Exception as e:
                     self.logger.error(str(e))
             elif self.finished:
-                print('finished')
                 break
             gevent.sleep(0.5)
 
@@ -311,8 +308,6 @@ class InfluxDbListener:
             logger_method(message_to_log)
             self._log_request(request_type, name, result, metrics, exception)
         except Exception as e:
-            import traceback
-            traceback.print_exc()
             self.logger.error(f'failed to write metric for "{request_type} {name}": {str(e)}')
 
     def _create_metrics(self, response_time: int, response_length: int) -> Dict[str, Any]:

--- a/grizzly/listeners/influxdb.py
+++ b/grizzly/listeners/influxdb.py
@@ -175,7 +175,7 @@ class InfluxDbListener:
 
         assert runner is not None, 'no runner is set'
 
-        while self.finished:
+        while not self.finished:
             points: List[Any] = []
             timestamp = datetime.now(timezone.utc).isoformat()
 
@@ -203,7 +203,8 @@ class InfluxDbListener:
                 break
 
     def run_events(self) -> None:
-        while self.finished:
+        print(f'run_events: {self.finished=}')
+        while not self.finished:
             if self._events:
                 # Buffer samples, so that a locust greenlet will write to the new list
                 # instead of the one that has been sent into postgres client
@@ -211,9 +212,11 @@ class InfluxDbListener:
                     events_buffer = self._events
                     self._events = []
                     self.connection.write(events_buffer)
+                    print('wrote')
                 except Exception as e:
                     self.logger.error(str(e))
             elif self.finished:
+                print('finished')
                 break
             gevent.sleep(0.5)
 

--- a/grizzly/locust.py
+++ b/grizzly/locust.py
@@ -535,6 +535,10 @@ def run(context: Context) -> int:
                 lstats.print_error_report(runner.stats)
                 print_scenario_summary(grizzly)
 
+                # make sure everything is flushed
+                for handler in stats_logger.handlers:
+                    handler.flush()
+
             def spawning_complete() -> bool:
                 if isinstance(runner, MasterRunner):
                     return runner.spawning_completed
@@ -573,8 +577,8 @@ def run(context: Context) -> int:
                 runner.environment.events.quitting.fire(environment=runner.environment, reverse=True, abort=True)
 
                 # master will quit when all workers has stopped
-                if not isinstance(runner, MasterRunner):
-                    runner.quit()
+                # if not isinstance(runner, MasterRunner):
+                #    runner.quit()
 
             return wrapper
 

--- a/grizzly/locust.py
+++ b/grizzly/locust.py
@@ -504,7 +504,7 @@ def run(context: Context) -> int:
                     gevent.sleep(1.0)
                     count += 1
                     if count % 10 == 0:
-                        logger.debug(f'{runner.user_count=}')
+                        logger.debug(f'{runner.user_count=}, {runner.user_classes_count=}')
                         count = 0
 
                 logger.info(f'{runner.user_count=}, quit {runner.__class__.__name__}, {abort_test=}')

--- a/grizzly/scenarios/__init__.py
+++ b/grizzly/scenarios/__init__.py
@@ -99,7 +99,7 @@ class GrizzlyScenario(SequentialTaskSet):
         running task to stop by throwing an exception in the greenlet where it is running.
         """
         if self.task_greenlet is not None and kwargs.get('abort', False):
-            self.task_greenlet.throw(StopScenario)
+            self.task_greenlet.kill(StopScenario, block=False)
 
     def execute_next_task(self) -> None:
         """

--- a/grizzly/scenarios/__init__.py
+++ b/grizzly/scenarios/__init__.py
@@ -24,6 +24,7 @@ class GrizzlyScenario(SequentialTaskSet):
     grizzly: GrizzlyContext
     task_greenlet: Optional[GreenletWithExceptionCatching]
     task_greenlet_factory: GreenletWithExceptionCatching
+    abort: bool
 
     def __init__(self, parent: 'GrizzlyUser') -> None:
         super().__init__(parent=parent)
@@ -32,6 +33,7 @@ class GrizzlyScenario(SequentialTaskSet):
         self.user.scenario_state = ScenarioState.STOPPED
         self.task_greenlet = None
         self.task_greenlet_factory = GreenletWithExceptionCatching()
+        self.abort = False
         self.parent.environment.events.quitting.add_listener(self.on_quitting)
 
     @property
@@ -99,6 +101,7 @@ class GrizzlyScenario(SequentialTaskSet):
         running task to stop by throwing an exception in the greenlet where it is running.
         """
         if self.task_greenlet is not None and kwargs.get('abort', False):
+            self.abort = True
             self.task_greenlet.kill(StopScenario, block=False)
 
     def execute_next_task(self) -> None:

--- a/grizzly/scenarios/__init__.py
+++ b/grizzly/scenarios/__init__.py
@@ -1,16 +1,18 @@
 import logging
 
-from typing import TYPE_CHECKING, Optional, Dict, Any, cast
+from typing import TYPE_CHECKING, Optional, Dict, Any, Tuple, cast
 from os import environ
 
-from locust.exception import StopUser
 from locust.user.sequential_taskset import SequentialTaskSet
 from jinja2 import Template
 
 from grizzly.types import ScenarioState
+from grizzly.types.locust import StopUser
+from grizzly.exceptions import StopScenario
 from grizzly.context import GrizzlyContext
 from grizzly.testdata.communication import TestdataConsumer
 from grizzly.tasks import GrizzlyTask, grizzlytask
+from grizzly.gevent import GreenletWithExceptionCatching
 
 if TYPE_CHECKING:  # pragma: no cover
     from grizzly.users.base import GrizzlyUser
@@ -20,12 +22,17 @@ class GrizzlyScenario(SequentialTaskSet):
     consumer: TestdataConsumer
     logger: logging.Logger
     grizzly: GrizzlyContext
+    task_greenlet: Optional[GreenletWithExceptionCatching]
+    task_greenlet_factory: GreenletWithExceptionCatching
 
     def __init__(self, parent: 'GrizzlyUser') -> None:
         super().__init__(parent=parent)
         self.logger = logging.getLogger(f'{self.__class__.__name__}/{id(self)}')
         self.grizzly = GrizzlyContext()
         self.user.scenario_state = ScenarioState.STOPPED
+        self.task_greenlet = None
+        self.task_greenlet_factory = GreenletWithExceptionCatching()
+        self.parent.environment.events.quitting.add_listener(self.on_quitting)
 
     @property
     def user(self) -> 'GrizzlyUser':
@@ -33,12 +40,7 @@ class GrizzlyScenario(SequentialTaskSet):
 
     @classmethod
     def populate(cls, task_factory: GrizzlyTask) -> None:
-        task = task_factory()
-
-        if callable(getattr(cls, 'pace', None)):
-            cls.tasks.insert(-1, task)
-        else:  # pragma: no cover
-            cls.tasks.append(task)
+        cls.tasks.append(task_factory())
 
     def render(self, input: str, variables: Optional[Dict[str, Any]] = None) -> str:
         if variables is None:
@@ -47,9 +49,17 @@ class GrizzlyScenario(SequentialTaskSet):
         return Template(input).render(**self.user._context['variables'], **variables)
 
     def prefetch(self) -> None:
+        """
+        Default implementation is to not prefetch anything.
+        """
         pass
 
     def on_start(self) -> None:
+        """
+        When test starts the testdata producer should be started, and if the implementing scenario
+        has some prefetching todo it must also be one. There might be cases where an on_start method
+        needs the first iteration of testdata.
+        """
         producer_address = environ.get('TESTDATA_PRODUCER_ADDRESS', None)
         if producer_address is not None:
             self.consumer = TestdataConsumer(
@@ -69,6 +79,10 @@ class GrizzlyScenario(SequentialTaskSet):
                 task.on_start(self)
 
     def on_stop(self) -> None:
+        """
+        When locust test is stopping, all tasks on_stop methods must be called, even though
+        one might fail, so just log those as errors
+        """
         for task in self.tasks:
             if isinstance(task, grizzlytask):
                 try:
@@ -78,6 +92,25 @@ class GrizzlyScenario(SequentialTaskSet):
 
         self.consumer.stop()
         self.user.scenario_state = ScenarioState.STOPPED
+
+    def on_quitting(self, *args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> None:
+        """
+        When locust is quitting, with abort=True (signal received) we should force the
+        running task to stop by throwing an exception in the greenlet where it is running.
+        """
+        if self.task_greenlet is not None and kwargs.get('abort', False):
+            self.task_greenlet.throw(StopScenario)
+
+    def execute_next_task(self):
+        """
+        Execute task in a greenlet, so that we have the possibility to stop it on demand. Any exceptions
+        raised in the greenlet should be caught else where.
+        """
+        try:
+            self.task_greenlet = self.task_greenlet_factory.spawn(super().execute_next_task)
+            self.task_greenlet.join()
+        finally:
+            self.task_greenlet = None
 
 
 from .iterator import IteratorScenario

--- a/grizzly/scenarios/__init__.py
+++ b/grizzly/scenarios/__init__.py
@@ -101,14 +101,15 @@ class GrizzlyScenario(SequentialTaskSet):
         if self.task_greenlet is not None and kwargs.get('abort', False):
             self.task_greenlet.throw(StopScenario)
 
-    def execute_next_task(self):
+    def execute_next_task(self) -> None:
         """
         Execute task in a greenlet, so that we have the possibility to stop it on demand. Any exceptions
         raised in the greenlet should be caught else where.
         """
         try:
             self.task_greenlet = self.task_greenlet_factory.spawn(super().execute_next_task)
-            self.task_greenlet.join()
+            if self.task_greenlet is not None:  # stupid mypy?!
+                self.task_greenlet.join()
         finally:
             self.task_greenlet = None
 

--- a/grizzly/scenarios/iterator.py
+++ b/grizzly/scenarios/iterator.py
@@ -93,7 +93,7 @@ class IteratorScenario(GrizzlyScenario):
                     # tasks will wrap the grizzly.exceptions.StopScenario thrown when aborting to what ever
                     # the scenario has specified todo when failing, we must force it to stop scenario
                     if self.abort:
-                        raise StopScenario()
+                        raise StopUser()
 
                     self.logger.info(f'restarting scenario at task {self.current_task_index+1} of {self.task_count}')
                     # move locust.user.sequential_task.SequentialTaskSet index pointer the number of tasks left until end, so it will start over

--- a/grizzly/tasks/until.py
+++ b/grizzly/tasks/until.py
@@ -52,6 +52,7 @@ from grizzly_extras.transformer import Transformer, TransformerContentType, Tran
 from grizzly_extras.arguments import get_unsupported_arguments, parse_arguments, split_value
 
 from grizzly.types import RequestType
+from grizzly.types.locust import StopUser
 from grizzly.utils import safe_del
 
 from . import GrizzlyTask, GrizzlyMetaRequestTask, template, grizzlytask
@@ -161,6 +162,9 @@ class UntilRequestTask(GrizzlyTask):
                         if exception is None:
                             exception = e
                         number_of_matches = 0
+
+                        if isinstance(e, StopUser):
+                            break
                     finally:
                         if number_of_matches == self.expected_matches:
                             break

--- a/grizzly/users/base/grizzly_user.py
+++ b/grizzly/users/base/grizzly_user.py
@@ -56,7 +56,7 @@ class GrizzlyUser(User):
     def on_quitting(self, *args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> None:
         # if it already has been called with True, do not change it back to False
         if not self.abort:
-            self.abort = kwargs.get('abort', False)
+            self.abort = cast(bool, kwargs.get('abort', False))
 
     @property
     def scenario_state(self) -> Optional[ScenarioState]:

--- a/grizzly/utils.py
+++ b/grizzly/utils.py
@@ -202,6 +202,9 @@ def check_mq_client_logs(context: Context) -> None:
         stats_logger.info(separator)
         stats_logger.info('')
 
+        for handler in stats_logger.handlers:
+            handler.flush()
+
     if not hasattr(context, 'started'):
         return
 

--- a/grizzly_extras/async_message/__init__.py
+++ b/grizzly_extras/async_message/__init__.py
@@ -17,6 +17,7 @@ import zmq.green as zmq
 from zmq.error import Again as ZMQAgain
 from zmq.sugar.constants import NOBLOCK as ZMQ_NOBLOCK
 from grizzly_extras.transformer import JsonBytesEncoder
+from grizzly.exceptions import StopScenario
 
 __all__: List[str] = []
 
@@ -229,6 +230,6 @@ def async_message_request(client: zmq.Socket, request: AsyncMessageRequest) -> A
 
         return response
     except Exception as e:
-        if not isinstance(e, AsyncMessageError):
+        if not isinstance(e, (AsyncMessageError, StopScenario,)):
             logger.error(f'failed to send {request=}', exc_info=True)
         raise

--- a/grizzly_extras/async_message/__init__.py
+++ b/grizzly_extras/async_message/__init__.py
@@ -17,7 +17,7 @@ import zmq.green as zmq
 from zmq.error import Again as ZMQAgain
 from zmq.sugar.constants import NOBLOCK as ZMQ_NOBLOCK
 from grizzly_extras.transformer import JsonBytesEncoder
-from grizzly.exceptions import StopScenario
+
 
 __all__: List[str] = []
 
@@ -118,6 +118,10 @@ class AsyncMessageResponse(TypedDict, total=False):
 
 
 class AsyncMessageError(Exception):
+    pass
+
+
+class AsyncMessageAbort(Exception):
     pass
 
 
@@ -230,6 +234,6 @@ def async_message_request(client: zmq.Socket, request: AsyncMessageRequest) -> A
 
         return response
     except Exception as e:
-        if not isinstance(e, (AsyncMessageError, StopScenario,)):
+        if not isinstance(e, (AsyncMessageError, AsyncMessageAbort,)):
             logger.error(f'failed to send {request=}', exc_info=True)
         raise

--- a/grizzly_extras/async_message/daemon.py
+++ b/grizzly_extras/async_message/daemon.py
@@ -31,7 +31,7 @@ def signal_handler(signum: Union[int, Signals], frame: Optional[FrameType]) -> N
     logger.debug(f'received signal {signum}')
 
     global abort
-    if abort:
+    if not abort:
         abort = True
 
 

--- a/grizzly_extras/async_message/daemon.py
+++ b/grizzly_extras/async_message/daemon.py
@@ -27,6 +27,13 @@ run: bool = True
 
 
 def signal_handler(signum: Union[int, Signals], frame: Optional[FrameType]) -> None:
+    logger = ThreadLogger('signal_handler')
+    logger.debug(f'received signal {signum}')
+
+    if signum == signal.SIGTERM:
+        logger.debug('ignoring')
+        return
+
     global run
     if run:
         run = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "locust >=2.15.0,<2.16",
     "aenum >3.1.8",
     "azure-core >=1.24.0,<2.0.0",
-    "azure-servicebus >=7.6.0,<8.0.0",
+    "azure-servicebus >=7.6.0,<7.10.0",
     "azure-storage-blob >=12.9.0,<13.0.0",
     "azure-iot-device >=2.12.0,<3.0.0",
     "behave >=1.2.6,<2.0.0",

--- a/tests/e2e/steps/scenario/test_results.py
+++ b/tests/e2e/steps/scenario/test_results.py
@@ -29,13 +29,13 @@ def test_e2e_step_results_avg_response_time(e2e_fixture: End2EndFixture) -> None
     def validate_avg_response_time(context: Context) -> None:
         grizzly = cast(GrizzlyContext, context.grizzly)
 
-        assert grizzly.scenario.validation.avg_response_time == 200, f'{grizzly.scenario.validation.avg_response_time} != 200'
+        assert grizzly.scenario.validation.avg_response_time == 500, f'{grizzly.scenario.validation.avg_response_time} != 500'
 
     e2e_fixture.add_validator(validate_avg_response_time)
 
     feature_file = e2e_fixture.test_steps(
         scenario=[
-            'When average response time is greater than "200" milliseconds fail scenario',
+            'When average response time is greater than "500" milliseconds fail scenario',
         ],
     )
 

--- a/tests/unit/test_grizzly/listeners/test___init__.py
+++ b/tests/unit/test_grizzly/listeners/test___init__.py
@@ -258,12 +258,14 @@ def test_init_statistics_listener(mocker: MockerFixture, locust_fixture: LocustF
         init_statistics_listener(grizzly.setup.statistics_url)(environment)
         assert len(environment.events.request._handlers) == 1
         assert len(environment.events.quitting._handlers) == 0
+        assert len(environment.events.quit._handlers) == 0
         assert len(environment.events.spawning_complete._handlers) == 0
 
         grizzly.setup.statistics_url = 'influxdb://test/database?Testplan=test'
         init_statistics_listener(grizzly.setup.statistics_url)(environment)
         assert len(environment.events.request._handlers) == 2
-        assert len(environment.events.quitting._handlers) == 1
+        assert len(environment.events.quitting._handlers) == 0
+        assert len(environment.events.quit._handlers) == 1
         assert len(environment.events.spawning_complete._handlers) == 0
 
         grizzly.setup.statistics_url = 'insights://?InstrumentationKey=b9601868-cbf8-43ea-afaf-0a2b820ae1c5'
@@ -273,7 +275,8 @@ def test_init_statistics_listener(mocker: MockerFixture, locust_fixture: LocustF
         grizzly.setup.statistics_url = 'insights://insights.example.se/?InstrumentationKey=b9601868-cbf8-43ea-afaf-0a2b820ae1c5'
         init_statistics_listener(grizzly.setup.statistics_url)(environment)
         assert len(environment.events.request._handlers) == 3
-        assert len(environment.events.quitting._handlers) == 1
+        assert len(environment.events.quitting._handlers) == 0
+        assert len(environment.events.quit._handlers) == 1
         assert len(environment.events.spawning_complete._handlers) == 0
     finally:
         GrizzlyContext.destroy()

--- a/tests/unit/test_grizzly/listeners/test___init__.py
+++ b/tests/unit/test_grizzly/listeners/test___init__.py
@@ -263,7 +263,7 @@ def test_init_statistics_listener(mocker: MockerFixture, locust_fixture: LocustF
         grizzly.setup.statistics_url = 'influxdb://test/database?Testplan=test'
         init_statistics_listener(grizzly.setup.statistics_url)(environment)
         assert len(environment.events.request._handlers) == 2
-        assert len(environment.events.quitting._handlers) == 0
+        assert len(environment.events.quitting._handlers) == 1
         assert len(environment.events.spawning_complete._handlers) == 0
 
         grizzly.setup.statistics_url = 'insights://?InstrumentationKey=b9601868-cbf8-43ea-afaf-0a2b820ae1c5'
@@ -273,7 +273,7 @@ def test_init_statistics_listener(mocker: MockerFixture, locust_fixture: LocustF
         grizzly.setup.statistics_url = 'insights://insights.example.se/?InstrumentationKey=b9601868-cbf8-43ea-afaf-0a2b820ae1c5'
         init_statistics_listener(grizzly.setup.statistics_url)(environment)
         assert len(environment.events.request._handlers) == 3
-        assert len(environment.events.quitting._handlers) == 0
+        assert len(environment.events.quitting._handlers) == 1
         assert len(environment.events.spawning_complete._handlers) == 0
     finally:
         GrizzlyContext.destroy()

--- a/tests/unit/test_grizzly/listeners/test_influxdb.py
+++ b/tests/unit/test_grizzly/listeners/test_influxdb.py
@@ -233,7 +233,7 @@ class TestInfluxDbListener:
         mocker.patch(
             'grizzly.listeners.influxdb.InfluxDbListener.finished',
             new_callable=mocker.PropertyMock,
-            side_effect=[True] + [False, True],
+            side_effect=[False, True] + [False, False, False, True],
         )
 
         listener = InfluxDbListener(
@@ -315,6 +315,8 @@ class TestInfluxDbListener:
             'grizzly.listeners.influxdb.InfluxDb.write',
             write,
         )
+
+        print(f'{listener.finished=}')
 
         listener._log_request('GET', '/api/v1/test', 'Success', {'response_time': 133.7}, None)
         assert len(listener._events) == 1

--- a/tests/unit/test_grizzly/listeners/test_influxdb.py
+++ b/tests/unit/test_grizzly/listeners/test_influxdb.py
@@ -233,7 +233,7 @@ class TestInfluxDbListener:
         mocker.patch(
             'grizzly.listeners.influxdb.InfluxDbListener.finished',
             new_callable=mocker.PropertyMock,
-            side_effect=[False, True] + [False, False, False, True],
+            side_effect=[False, True, True] + [False, False, False, True, True],
         )
 
         listener = InfluxDbListener(

--- a/tests/unit/test_grizzly/test_locust.py
+++ b/tests/unit/test_grizzly/test_locust.py
@@ -636,7 +636,6 @@ def test_run_worker(behave_fixture: BehaveFixture, capsys: CaptureFixture, mocke
     capture = capsys.readouterr()
 
     assert 'failed to connect to the locust master' in capture.err
-    assert 'grizzly.returncode=1' not in capture.out
 
     assert messagequeue_process_spy.call_count == 0
 
@@ -696,7 +695,6 @@ def test_run_master(behave_fixture: BehaveFixture, capsys: CaptureFixture, mocke
 
     capture = capsys.readouterr()
     assert 'cannot be both master and worker' in capture.err
-    assert 'grizzly.returncode=254' in capture.out
 
     behave.config.userdata = {'master': 'true'}
 
@@ -707,7 +705,6 @@ def test_run_master(behave_fixture: BehaveFixture, capsys: CaptureFixture, mocke
 
     capture = capsys.readouterr()
     assert 'spawn rate is not set' in capture.err
-    assert 'grizzly.returncode=254' in capture.out
 
     grizzly.setup.spawn_rate = 1
 
@@ -715,7 +712,6 @@ def test_run_master(behave_fixture: BehaveFixture, capsys: CaptureFixture, mocke
 
     capture = capsys.readouterr()
     assert 'step \'Given "user_count" users\' is not in the feature file' in capture.err
-    assert 'grizzly.returncode=254' in capture.out
 
     grizzly.setup.user_count = 2
     grizzly.scenarios.create(behave_fixture.create_scenario('test'))

--- a/tests/unit/test_grizzly/test_utils.py
+++ b/tests/unit/test_grizzly/test_utils.py
@@ -1,6 +1,6 @@
 import logging
 
-from typing import Optional, Type, cast
+from typing import Type, cast
 from types import FunctionType
 from datetime import datetime, timedelta, timezone
 from os import utime
@@ -15,7 +15,6 @@ from locust import TaskSet
 
 from grizzly.utils import ModuleLoader
 from grizzly.utils import (
-    catch,
     create_scenario_class_type,
     create_user_class_type,
     fail_direct,
@@ -26,7 +25,7 @@ from grizzly.utils import (
     safe_del,
 )
 from grizzly.types import RequestMethod
-from grizzly.types.behave import Context, Scenario, Status
+from grizzly.types.behave import Context
 from grizzly.context import GrizzlyContext, GrizzlyContextScenario
 from grizzly.tasks import RequestTask
 from grizzly.users import RestApiUser
@@ -85,56 +84,6 @@ class TestModuleLoader:
                 assert hasattr(user_class_instance, 'tasks')
         finally:
             GrizzlyContext.destroy()
-
-
-def test_catch(behave_fixture: BehaveFixture) -> None:
-    behave = behave_fixture.context
-    behave_scenario = Scenario(filename=None, line=None, keyword='', name='')
-
-    @catch(KeyboardInterrupt)
-    def raises_KeyboardInterrupt(context: Context, scenario: Scenario) -> None:
-        raise KeyboardInterrupt()
-
-    try:
-        raises_KeyboardInterrupt(behave, behave_scenario)
-    except KeyboardInterrupt:
-        pytest.fail('function raised KeyboardInterrupt, when it should not have')
-
-    assert behave.failed
-    assert behave_scenario.status == Status.failed
-    behave._set_root_attribute(Status.failed.name, False)
-    behave_scenario.set_status(Status.undefined)
-
-    @catch(ValueError)
-    def raises_ValueError_not(context: Context, scenario: Scenario) -> None:
-        raise KeyboardInterrupt()
-
-    with pytest.raises(KeyboardInterrupt):
-        raises_ValueError_not(behave, behave_scenario)
-
-    assert not behave.failed
-    assert not behave_scenario.status == Status.failed
-    behave._set_root_attribute(Status.failed.name, False)
-    behave_scenario.set_status(Status.undefined)
-
-    @catch(ValueError)
-    def raises_ValueError(context: Context, scenario: Optional[Scenario] = None) -> None:
-        raise ValueError()
-
-    with pytest.raises(ValueError):
-        raises_ValueError(behave)
-
-    @catch(NotImplementedError)
-    def no_scenario_argument(context: Context, other: str) -> None:
-        raise NotImplementedError()
-
-    with pytest.raises(NotImplementedError):
-        no_scenario_argument(behave, 'not a scenario')
-
-    try:
-        raises_ValueError(behave, behave_scenario)
-    except ValueError:
-        pytest.fail('function raised ValueError, when it should not have')
 
 
 def test_fail_directly(behave_fixture: BehaveFixture) -> None:

--- a/tests/unit/test_grizzly/users/base/test_grizzly_user.py
+++ b/tests/unit/test_grizzly/users/base/test_grizzly_user.py
@@ -83,7 +83,7 @@ class TestGrizzlyUser:
                     'host': 'http://example.io',
                 },
             )
-            user = user_type(locust_fixture)
+            user = user_type(locust_fixture.env)
             assert issubclass(user.__class__, (FileRequests,))
 
             request.source = f'{str(test_file)}'

--- a/tests/unit/test_grizzly_extras/async_message/test_daemon.py
+++ b/tests/unit/test_grizzly_extras/async_message/test_daemon.py
@@ -130,7 +130,7 @@ def test_worker(mocker: MockerFixture, capsys: CaptureFixture, scheme: str, impl
     import grizzly_extras.async_message.daemon as daemon
 
     def hack(*args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> None:
-        daemon.run = False
+        daemon.abort = True
 
     worker_mock.send_multipart = hack
 

--- a/tests/unit/test_grizzly_extras/async_message/test_daemon.py
+++ b/tests/unit/test_grizzly_extras/async_message/test_daemon.py
@@ -17,11 +17,11 @@ from grizzly_extras.async_message.daemon import router, worker, main, signal_han
 def test_signal_handler() -> None:
     import grizzly_extras.async_message.daemon as daemon
 
-    assert getattr(daemon, 'run')
+    assert not getattr(daemon, 'abort')
 
     signal_handler(SIGINT, None)
 
-    assert not getattr(daemon, 'run')
+    assert getattr(daemon, 'abort')
 
     reload(daemon)
 


### PR DESCRIPTION
implementation of `grizzly` parts of #196.

this feature required tasks to run in a new greenlet, so it was possible to abort them by throwing an exception in it to stop any "long going" executions (such as sleep, waiting for messages from async-messaged etc).

when a test is aborted, it will stop IteratorScenario from continuing until all tasks in an scenario iteration is complete.

handling it gracefully will then also mean that all on_stop logic will run and any resources that should be cleaned up is indeed cleaned up.

scenarios will get status "skipped" when aborted, but the feature will still have status failed.

instead of "Ended" timestamp, it will be "Aborted". And if a test is not aborted it will be "Finished".