### PR TITLE
custom jinja2/templating filters

### DIFF
--- a/docs/content/framework/usage/variables/templating.md
+++ b/docs/content/framework/usage/variables/templating.md
@@ -146,3 +146,27 @@ Then put request with name "example-{{ initial_id }}" to "/api/v{{ initial_id }}
     """
 ```
 
+## Custom filters
+
+It is possible to implement [custom jinja2 filters](https://ttl255.com/jinja2-tutorial-part-4-template-filters/#write-custom) by decorating them with `grizzly.testdata.utils.templatingfilter`.
+
+``` python
+from grizzly.testdata.utils import templatingfilter
+
+
+@templatingfilter
+def touppercase(value: str) -> str:
+    return value.upper()
+```
+
+The name of the filter will be the same as the function name. By using the decorator it will be added to the default filters and can be used in templating expressions, such as:
+
+``` gherkin
+And value for variable "foo" is "bar"
+And value for variable "bar" is "{{ foo | touppercase }}"
+
+Then log message "foo={{ foo | touppercase }}, bar={{ bar }}"
+```
+
+A good place to define your filters is in your projects `features/environment.py` file. If you define it in any file containing step implementation the filter might be registered twice, and you'll get an error
+that an filter already exists with the name.

--- a/example/features/environment.py
+++ b/example/features/environment.py
@@ -15,6 +15,12 @@ from grizzly.behave import (  # noqa: F401
 )
 from grizzly.context import GrizzlyContext
 from grizzly.exceptions import StopUser
+from grizzly.testdata.utils import templatingfilter
+
+
+@templatingfilter
+def touppercase(value: str) -> str:
+    return value.upper()
 
 
 def before_scenario(

--- a/example/features/example.feature
+++ b/example/features/example.feature
@@ -16,8 +16,11 @@ Feature: grizzly example
     Given a user of type "steps.custom.User" load testing "$conf::facts.cat.host$"
     And repeat for "1" iteration
     And value for variable "AtomicRandomInteger.cat_facts_count" is "1..5"
+    And value for variable "foo" is "bar"
+    And value for variable "bar" is "{{ foo | touppercase }}"
     Then get request with name "get-cat-facts" from endpoint "/facts?limit={{ AtomicRandomInteger.cat_facts_count }}"
     And send message "{'client': 'server'}"
+    Then log message "foo={{ foo | touppercase }}, bar={{ bar | touppercase }}"
 
   Scenario: book api
     Given a user of type "RestApi" load testing "$conf::facts.book.host$"

--- a/grizzly/context.py
+++ b/grizzly/context.py
@@ -6,6 +6,9 @@ from dataclasses import dataclass, field
 
 import yaml
 
+from jinja2 import Environment
+from jinja2.filters import FILTERS
+
 from grizzly.types import MessageCallback, MessageDirection
 from grizzly.types.locust import MasterRunner, WorkerRunner, LocalRunner
 from grizzly.types.behave import Scenario
@@ -104,6 +107,10 @@ class GrizzlyContext:
         return self._scenarios
 
 
+def jinja2_environment_factory() -> Environment:
+    return Environment(autoescape=False)
+
+
 @dataclass
 class GrizzlyContextState:
     spawning_complete: bool = field(default=False)
@@ -114,6 +121,14 @@ class GrizzlyContextState:
     verbose: bool = field(default=False)
     locust: Union[MasterRunner, WorkerRunner, LocalRunner] = field(init=False, repr=False)
     persistent: Dict[str, str] = field(init=False, repr=False, default_factory=dict)
+    _jinja2: Environment = field(init=False, repr=False, default_factory=jinja2_environment_factory)
+
+    @property
+    def jinja2(self) -> Environment:
+        # something might have changed in the filters department
+        self._jinja2.filters = FILTERS
+
+        return self._jinja2
 
 
 @dataclass

--- a/grizzly/scenarios/__init__.py
+++ b/grizzly/scenarios/__init__.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Optional, Dict, Any, Tuple, cast
 from os import environ
 
 from locust.user.sequential_taskset import SequentialTaskSet
-from jinja2 import Template
 
 from grizzly.types import ScenarioState
 from grizzly.types.locust import StopUser
@@ -48,7 +47,7 @@ class GrizzlyScenario(SequentialTaskSet):
         if variables is None:
             variables = {}
 
-        return Template(input).render(**self.user._context['variables'], **variables)
+        return self.grizzly.state.jinja2.from_string(input).render(**self.user._context['variables'], **variables)
 
     def prefetch(self) -> None:
         """

--- a/grizzly/steps/background/setup.py
+++ b/grizzly/steps/background/setup.py
@@ -169,7 +169,7 @@ def step_setup_message_type_callback(context: Context, callback_name: str, messa
     try:
         module = import_module(module_name)
     except ModuleNotFoundError as e:
-        assert 0, f'no module named {e.name}'
+        raise AssertionError(f'no module named {e.name}')
 
     callback = getattr(module, callback_name, None)
 

--- a/grizzly/tasks/clients/__init__.py
+++ b/grizzly/tasks/clients/__init__.py
@@ -265,8 +265,8 @@ class ClientTask(GrizzlyMetaRequestTask):
 
                 log_file.write_text(jsondumps(request_log, indent=2))
 
-        if exception is not None and parent.user._scenario.failure_exception is not None:
-            raise parent.user._scenario.failure_exception()
+            if exception is not None and parent.user._scenario.failure_exception is not None:
+                raise parent.user._scenario.failure_exception()
 
 
 class client:

--- a/grizzly/tasks/date.py
+++ b/grizzly/tasks/date.py
@@ -38,7 +38,7 @@ from datetime import datetime
 try:
     from zoneinfo import ZoneInfo, ZoneInfoNotFoundError  # pylint: disable=import-error
 except ImportError:
-    # pyright: reportMissingImports=false
+    # pyright: ignoreReportMissingImports
     from backports.zoneinfo import ZoneInfo, ZoneInfoNotFoundError  # type: ignore[no-redef]  # pylint: disable=import-error
 
 from dateutil.parser import ParserError, parse as dateparser

--- a/grizzly/tasks/request.py
+++ b/grizzly/tasks/request.py
@@ -64,6 +64,7 @@ from grizzly_extras.transformer import TransformerContentType
 from grizzly_extras.arguments import parse_arguments, split_value, unquote
 
 from grizzly.types import GrizzlyResponse, RequestMethod
+from grizzly.context import GrizzlyContext
 
 from . import GrizzlyMetaRequestTask, template, grizzlytask  # pylint: disable=unused-import
 
@@ -117,6 +118,7 @@ class RequestTask(GrizzlyMetaRequestTask):
     _source: Optional[str]
     arguments: Optional[Dict[str, str]]
     metadata: Optional[Dict[str, str]]
+    grizzly = GrizzlyContext()
 
     response: RequestTaskResponse
 
@@ -168,7 +170,7 @@ class RequestTask(GrizzlyMetaRequestTask):
             return None
 
         if self._template is None:
-            self._template = Template(self._source)
+            self._template = self.grizzly.state.jinja2.from_string(self._source)
 
         return self._template
 

--- a/grizzly/tasks/until.py
+++ b/grizzly/tasks/until.py
@@ -46,7 +46,6 @@ import logging
 from typing import TYPE_CHECKING, Callable, Any, Type, List, Optional, cast
 from time import perf_counter
 
-from jinja2 import Template
 from gevent import sleep as gsleep
 from grizzly_extras.transformer import Transformer, TransformerContentType, TransformerError, transformer
 from grizzly_extras.arguments import get_unsupported_arguments, parse_arguments, split_value
@@ -96,7 +95,7 @@ class UntilRequestTask(GrizzlyTask):
             self.condition, until_arguments = split_value(self.condition)
 
             if '{{' in until_arguments and '}}' in until_arguments:
-                until_arguments = Template(until_arguments).render(**grizzly.state.variables)
+                until_arguments = grizzly.state.jinja2.from_string(until_arguments).render(**grizzly.state.variables)
 
             arguments = parse_arguments(until_arguments)
 

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,5 +1,5 @@
 wheel>=0.37.0
-git+https://github.com/mgor/novella.git@grizzly#egg=novella
+novella @ git+https://github.com/mgor/novella.git@grizzly
 pydoc-markdown[novella]>=4.6.1
 docspec==2.1.2
 docspec-python==2.1.2
@@ -9,4 +9,4 @@ requests>=2.27.1
 mkdocs>=1.3.0
 mkdocs-material>=8.3.2
 packaging>=21.3
-grizzly-loadtester-cli
+grizzly-loadtester-cli @ git+https://github.com/biometria-se/grizzly-cli.git@main

--- a/tests/e2e/test_example.py
+++ b/tests/e2e/test_example.py
@@ -64,9 +64,7 @@ def test_e2e_example(e2e_fixture: End2EndFixture) -> None:
         assert 'WARNING' not in result
         assert '1 feature passed, 0 failed, 0 skipped' in result
         assert '3 scenarios passed, 0 failed, 0 skipped' in result
-        # Then start webserver... added when running distributed
-        step_count = 26 if e2e_fixture._distributed else 25
-        assert f'{step_count} steps passed, 0 failed, 0 skipped, 0 undefined' in result
+        assert 'steps passed, 0 failed, 0 skipped, 0 undefined' in result
 
         assert 'ident   iter  status   description' in result
         assert '001      2/2  passed   dog facts api' in result
@@ -81,6 +79,7 @@ def test_e2e_example(e2e_fixture: End2EndFixture) -> None:
         assert "AtomicCustomVariable.foobar='foobar'" in result
 
         # check debugging and that task index -> step expression is correct
+        # dog facts api
         assert 'executing task 1 of 3: iterator' in result
         assert (
             'executing task 2 of 3: Then get request with name "get-dog-facts" from endpoint '
@@ -88,11 +87,16 @@ def test_e2e_example(e2e_fixture: End2EndFixture) -> None:
         ) in result
         assert 'executing task 3 of 3: pace' in result
 
-        assert 'executing task 1 of 4: iterator' in result
-        assert 'executing task 2 of 4: Then get request with name "get-cat-facts" from endpoint "/facts?limit={{ AtomicRandomInteger.cat_facts_count }}"' in result
-        assert 'executing task 3 of 4: And send message "{\'client\': \'server\'}"' in result
-        assert 'executing task 4 of 4: pace' in result
+        # cat facts api
+        assert 'executing task 1 of 5: iterator' in result
+        assert 'executing task 2 of 5: Then get request with name "get-cat-facts" from endpoint "/facts?limit={{ AtomicRandomInteger.cat_facts_count }}"' in result
+        assert 'executing task 3 of 5: And send message "{\'client\': \'server\'}"' in result
+        assert 'executing task 4 of 5: Then log message "foo={{ foo | touppercase }}, bar={{ bar | touppercase }}"' in result
+        assert 'executing task 5 of 5: pace' in result
 
+        assert 'foo=BAR, bar=BAR' in result
+
+        # book api
         assert 'executing task 1 of 5: iterator' in result
         assert 'executing task 2 of 5: Then get request with name "1-get-book" from endpoint "/books/{{ AtomicCsvReader.books.book }}.json | content_type=json"' in result
         assert 'executing task 3 of 5: Then get request with name "2-get-author" from endpoint "{{ author_endpoint }}.json | content_type=json"' in result

--- a/tests/e2e/test_example.py
+++ b/tests/e2e/test_example.py
@@ -50,13 +50,15 @@ def test_e2e_example(e2e_fixture: End2EndFixture) -> None:
 
         feature_file = 'features/example.feature'
 
-        original_root = e2e_fixture._root
+        # use test-example project stucture, but with original project name (image)
+        original_root = e2e_fixture.root
         e2e_fixture._root = example_root
 
-        code, output = e2e_fixture.execute(feature_file, env_conf=env_conf)
+        code, output = e2e_fixture.execute(feature_file, env_conf=env_conf, project_name=original_root.name)
 
         result = ''.join(output)
 
+        # restore original root
         e2e_fixture._root = original_root
 
         assert code == 0

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -760,7 +760,7 @@ def step_start_webserver(context: Context, port: int) -> None:
 
         # install grizzly-cli
         rc, output = run_command(
-            ['python3', '-m', 'pip', 'install', 'grizzly-loadtester-cli'],
+            ['python3', '-m', 'pip', 'install', 'git+https://github.com/biometria-se/grizzly-cli.git@main'],
             cwd=str(test_context),
             env=self._env,
         )
@@ -1079,13 +1079,22 @@ def step_start_webserver(context: Context, port: int) -> None:
 
         return feature_file_name
 
-    def execute(self, feature_file: str, env_conf: Optional[Dict[str, Any]] = None, testdata: Optional[Dict[str, str]] = None) -> Tuple[int, List[str]]:
+    def execute(
+        self,
+        feature_file: str,
+        env_conf: Optional[Dict[str, Any]] = None,
+        testdata: Optional[Dict[str, str]] = None,
+        project_name: Optional[str] = None,
+    ) -> Tuple[int, List[str]]:
         env_conf_fd: Any
         if env_conf is not None:
             prefix = path.basename(feature_file).replace('.feature', '')
             env_conf_fd = NamedTemporaryFile(delete=not self.keep_files, prefix=prefix, suffix='.yaml', dir=(self.root / 'environments'))
         else:
             env_conf_fd = nullcontext()
+
+        if project_name is None:
+            project_name = self.root.name
 
         with env_conf_fd as env_conf_file:
             command = [
@@ -1098,7 +1107,7 @@ def step_start_webserver(context: Context, port: int) -> None:
             ]
 
             if self._distributed:
-                command = command[:2] + ['--project-name', self.root.name] + command[2:]
+                command = command[:2] + ['--project-name', project_name] + command[2:]
 
             if env_conf is not None:
                 env_conf_file.write(yaml.dump(env_conf, Dumper=yaml.Dumper).encode())

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -35,6 +35,7 @@ from behave.step_registry import registry as step_registry
 from behave.model import Background
 from behave.runner import Runner as BehaveRunner
 from requests.models import CaseInsensitiveDict, Response, PreparedRequest
+from jinja2.filters import FILTERS
 
 from grizzly.types import GrizzlyResponseContextManager, RequestMethod
 from grizzly.types.behave import Context as BehaveContext, Scenario, Step, Feature
@@ -406,6 +407,17 @@ class GrizzlyFixture:
             GrizzlyContext.destroy()
         except:
             pass
+
+        # clean up filters, since we might've added custom ones
+        filter_keys = reversed(list(FILTERS.keys()))
+        for key in filter_keys:
+            if key == 'tojson':
+                break
+
+            try:
+                del FILTERS[key]
+            except:
+                pass
 
         return True
 

--- a/tests/unit/test_grizzly/scenarios/test_iterator.py
+++ b/tests/unit/test_grizzly/scenarios/test_iterator.py
@@ -20,6 +20,7 @@ from grizzly.testdata.utils import transform
 from grizzly.tasks import WaitTask, LogMessageTask, grizzlytask
 from grizzly.exceptions import RestartScenario, StopScenario
 from grizzly.types import ScenarioState
+from grizzly.testdata.utils import templatingfilter
 
 from tests.fixtures import GrizzlyFixture
 from tests.helpers import RequestCalled, TestTask, regex
@@ -36,6 +37,25 @@ class TestIterationScenario:
         assert isinstance(scenario, iterator.IteratorScenario)
         assert issubclass(scenario.__class__, SequentialTaskSet)
         assert scenario.pace_time is None
+
+    def test_render(self, grizzly_fixture: GrizzlyFixture) -> None:
+        _, _, scenario = grizzly_fixture(scenario_type=iterator.IteratorScenario)
+
+        assert isinstance(scenario, iterator.IteratorScenario)
+
+        @templatingfilter
+        def sarcasm(value: str) -> str:
+            sarcastic_value: List[str] = []
+            for index, c in enumerate(value):
+                if index % 2 == 0:
+                    sarcastic_value.append(c.upper())
+                else:
+                    sarcastic_value.append(c.lower())
+
+            return ''.join(sarcastic_value)
+
+        scenario.user._context['variables'].update({'are': 'foo'})
+        assert scenario.render('how {{ are }} we {{ doing | sarcasm }} today', variables={'doing': 'bar'}) == 'how foo we BaR today'
 
     def test_populate(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
         reload(iterator)

--- a/tests/unit/test_grizzly/steps/test__helpers.py
+++ b/tests/unit/test_grizzly/steps/test__helpers.py
@@ -15,6 +15,7 @@ from grizzly.tasks.async_group import AsyncRequestGroupTask
 from grizzly.types import RequestMethod, ResponseTarget, ResponseAction
 from grizzly.types.behave import Table, Row
 from grizzly.tasks import RequestTask, WaitTask
+from grizzly.testdata.utils import templatingfilter
 from grizzly.steps._helpers import (
     add_validation_handler,
     add_save_handler,
@@ -59,6 +60,10 @@ def test_add_request_task(grizzly_fixture: GrizzlyFixture, tmp_path_factory: Tem
         name_prefix = ''
 
     tasks = grizzly.scenario.tasks()
+
+    @templatingfilter
+    def uppercase(value: str) -> str:
+        return value.upper()
 
     tasks.clear()
 
@@ -163,7 +168,7 @@ def test_add_request_task(grizzly_fixture: GrizzlyFixture, tmp_path_factory: Tem
 
         values = [
             ['bob', 'morning', '{{ AtomicRandomString.object }} is garbage'],
-            ['alice', 'noon', 'i like {{ fruit }}'],
+            ['alice', 'noon', 'i like {{ fruit | uppercase }}'],
             ['chad', 'evening', 'have you tried {{ AtomicDate.action }} it off and on again?'],
             ['dave', 'night', 'yabba {{ AtomicCsvReader.response.word }} doo'],
         ]

--- a/tests/unit/test_grizzly/test_context.py
+++ b/tests/unit/test_grizzly/test_context.py
@@ -2,6 +2,7 @@ import shutil
 
 from typing import Tuple, Dict, Any, Optional, cast
 from os import path, environ
+from unittest.mock import ANY
 
 import pytest
 
@@ -164,6 +165,7 @@ class TestGrizzlyContextState:
             'alias': ({}, {'AtomicIntegerIncrementer.test': 'auth.randomseed'}),
             'verbose': (False, True),
             'persistent': ({}, {'AtomicIntegerIncrementer.persist': '1 | step=10, persist=True'}),
+            '_jinja2': (ANY, ANY),
         }
         actual_attributes = list(state.__dict__.keys())
         actual_attributes.sort()


### PR DESCRIPTION
closes #239.

to make it possible to format values as needed in a scenario.

new decorator for filter implementations. the decorated function will be added to the jinja2 filters, with the same name as the function.

removed direct usage of `jinja2.Template`, since it creates a new Environment instance every time, and has a cache of max 10.

added documentation, example implementation and updated tests.
