### PR TITLE
refactoring regarding `GrizzlyContextScenario` references for users

### DIFF
--- a/example/features/steps/custom.py
+++ b/example/features/steps/custom.py
@@ -12,10 +12,10 @@ from grizzly.testdata.variables import AtomicVariable
 
 
 class User(RestApiUser):
-    def request(self, request: RequestTask) -> GrizzlyResponse:
+    def request(self, parent: GrizzlyScenario, request: RequestTask) -> GrizzlyResponse:
         self.logger.info(f'executing custom.User.request for {request.name} and {request.endpoint}')
 
-        return super().request(request)
+        return super().request(parent, request)
 
 
 class Task(GrizzlyTask):

--- a/grizzly/auth/aad.py
+++ b/grizzly/auth/aad.py
@@ -2,7 +2,7 @@ import re
 import json
 import logging
 
-from typing import Dict, Any, Tuple, Optional, List, cast
+from typing import Dict, Any, Tuple, Optional, List, cast, TYPE_CHECKING
 from urllib.parse import parse_qs, urlparse
 from uuid import uuid4
 from secrets import token_urlsafe
@@ -16,6 +16,10 @@ import requests
 from grizzly.utils import safe_del
 from grizzly.types.locust import StopUser
 from . import RefreshToken, GrizzlyHttpAuthClient, AuthType
+
+
+if TYPE_CHECKING:  # pragma: no cover
+    from grizzly.scenarios import GrizzlyScenario
 
 
 logger = logging.getLogger(__name__)
@@ -72,7 +76,7 @@ class FormPostParser(HTMLParser):
 
 class AAD(RefreshToken):
     @classmethod
-    def get_oauth_authorization(cls, client: GrizzlyHttpAuthClient) -> Tuple[AuthType, str]:
+    def get_oauth_authorization(cls, parent: 'GrizzlyScenario', client: GrizzlyHttpAuthClient) -> Tuple[AuthType, str]:
         def _parse_response_config(response: requests.Response) -> Dict[str, Any]:
             match = re.search(r'Config={(.*?)};', response.text, re.MULTILINE)
 
@@ -427,7 +431,7 @@ class AAD(RefreshToken):
                         assert code_verifier is not None, 'no code verifier has been generated!'
                         assert 'code' in fragments, f'could not find code in {token_url}'
                         code = fragments['code'][0]
-                        return cls.get_oauth_token(client, (code, code_verifier,))
+                        return cls.get_oauth_token(parent, client, (code, code_verifier,))
                     else:
                         assert 'id_token' in fragments, f'could not find id_token in {token_url}'
                         token = fragments['id_token'][0]
@@ -473,10 +477,7 @@ class AAD(RefreshToken):
             exception = e
             logger.error(str(e), exc_info=True)
         finally:
-            if client.parent is not None:
-                scenario_index = client.parent.user._scenario.identifier
-            else:
-                scenario_index = client.__class__.__name__.rsplit('_', 1)[-1]
+            scenario_index = parent.user._scenario.identifier
 
             if is_token_v2_0 is None:
                 version = ''
@@ -493,13 +494,13 @@ class AAD(RefreshToken):
                 'response_length': total_response_length,
             }
 
-            client.environment.events.request.fire(**request_meta)
+            parent.user.environment.events.request.fire(**request_meta)
 
             if exception is not None:
                 raise StopUser()
 
     @classmethod
-    def get_oauth_token(cls, client: GrizzlyHttpAuthClient, pkcs: Optional[Tuple[str, str]] = None) -> Tuple[AuthType, str]:
+    def get_oauth_token(cls, parent: 'GrizzlyScenario', client: GrizzlyHttpAuthClient, pkcs: Optional[Tuple[str, str]] = None) -> Tuple[AuthType, str]:
         auth_context = client._context.get('auth', None)
         assert auth_context is not None, 'context variable auth is not set'
         provider_url = auth_context.get('provider', None)
@@ -607,10 +608,7 @@ class AAD(RefreshToken):
             exception = e
             logger.error(str(e), exc_info=True)
         finally:
-            if client.parent is not None:
-                scenario_index = client.parent.user._scenario.identifier
-            else:
-                scenario_index = client.__class__.__name__.rsplit('_', 1)[-1]
+            scenario_index = parent.user._scenario.identifier
 
             request_meta = {
                 'request_type': 'AUTH',
@@ -623,7 +621,7 @@ class AAD(RefreshToken):
             }
 
             if pkcs is None:
-                client.environment.events.request.fire(**request_meta)
+                parent.user.environment.events.request.fire(**request_meta)
 
             if exception is not None:
                 raise StopUser()

--- a/grizzly/context.py
+++ b/grizzly/context.py
@@ -98,7 +98,7 @@ class GrizzlyContext:
     @property
     def scenario(self) -> 'GrizzlyContextScenario':
         if len(self._scenarios) < 1:
-            self._scenarios.append(GrizzlyContextScenario(1))
+            raise ValueError('no scenarios created!')
 
         return self._scenarios[-1]
 
@@ -222,14 +222,12 @@ class GrizzlyContextTasksTmp:
 
 
 class GrizzlyContextTasks(List['GrizzlyTask']):
-    scenario: 'GrizzlyContextScenario'
     _tmp: GrizzlyContextTasksTmp
     behave_steps: Dict[int, str]
 
-    def __init__(self, scenario: 'GrizzlyContextScenario', *args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> None:
+    def __init__(self, *args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> None:
         super().__init__(*args, **kwargs)
 
-        self.scenario = scenario
         self._tmp = GrizzlyContextTasksTmp()
         self.behave_steps = {}
 
@@ -244,9 +242,6 @@ class GrizzlyContextTasks(List['GrizzlyTask']):
             return cast(List['GrizzlyTask'], self)
 
     def add(self, task: 'GrizzlyTask') -> None:
-        if not hasattr(task, 'scenario') or task.scenario is None or task.scenario is not self.scenario:
-            task.scenario = self.scenario
-
         if len(self.tmp.__stack__) > 0:
             self.tmp.__stack__[-1].add(task)
         else:
@@ -262,33 +257,18 @@ class GrizzlyContextScenario:
     iterations: int = field(init=False, repr=False, hash=False, compare=False, default=1)
     pace: Optional[str] = field(init=False, repr=False, hash=False, compare=False, default=None)
 
-    behave: Scenario = field(init=False, repr=False, hash=False, compare=False)
+    behave: Scenario = field(init=True, repr=False, hash=False, compare=False)
     context: Dict[str, Any] = field(init=False, repr=False, hash=False, compare=False, default_factory=dict)
     _tasks: GrizzlyContextTasks = field(init=False, repr=False, hash=False, compare=False)
     validation: GrizzlyContextScenarioValidation = field(init=False, hash=False, compare=False, default_factory=GrizzlyContextScenarioValidation)
-    _failure_exception: Optional[Type[Exception]] = field(init=False, default=None)
+    failure_exception: Optional[Type[Exception]] = field(init=False, default=None)
     orphan_templates: List[str] = field(init=False, repr=False, hash=False, compare=False, default_factory=list)
 
     def __post_init__(self) -> None:
-        self._tasks = GrizzlyContextTasks(self)
-        self._logger = logging.getLogger('grizzly-context-scenario')
+        self.name = self.behave.name
+        self.description = self.behave.name
 
-    @property
-    def failure_exception(self) -> Optional[Type[Exception]]:
-        return self._failure_exception
-
-    @failure_exception.setter
-    def failure_exception(self, value: Optional[Type[Exception]]) -> None:
-        orig_value = self._failure_exception
-        self._failure_exception = value
-        import inspect
-        try:
-            frame = inspect.stack()[1]
-            callee = f'{frame.filename}:{frame.lineno}: {frame.function}'
-        except:
-            callee = 'unknown'
-
-        self._logger.info(f'failure_exception: {orig_value} -> {value} ({callee})')  # @TODO: shouldn't be info, or even exist?
+        self._tasks = GrizzlyContextTasks()
 
     @property
     def tasks(self) -> GrizzlyContextTasks:
@@ -380,9 +360,6 @@ class GrizzlyContextScenarios(List[GrizzlyContextScenario]):
         return None
 
     def create(self, behave_scenario: Scenario) -> None:
-        grizzly_scenario = GrizzlyContextScenario(len(self) + 1)
-        grizzly_scenario.behave = behave_scenario
-        grizzly_scenario.name = behave_scenario.name
-        grizzly_scenario.description = behave_scenario.name
+        grizzly_scenario = GrizzlyContextScenario(len(self) + 1, behave=behave_scenario)
 
         self.append(grizzly_scenario)

--- a/grizzly/context.py
+++ b/grizzly/context.py
@@ -266,11 +266,29 @@ class GrizzlyContextScenario:
     context: Dict[str, Any] = field(init=False, repr=False, hash=False, compare=False, default_factory=dict)
     _tasks: GrizzlyContextTasks = field(init=False, repr=False, hash=False, compare=False)
     validation: GrizzlyContextScenarioValidation = field(init=False, hash=False, compare=False, default_factory=GrizzlyContextScenarioValidation)
-    failure_exception: Optional[Type[Exception]] = field(init=False, default=None)
+    _failure_exception: Optional[Type[Exception]] = field(init=False, default=None)
     orphan_templates: List[str] = field(init=False, repr=False, hash=False, compare=False, default_factory=list)
 
     def __post_init__(self) -> None:
         self._tasks = GrizzlyContextTasks(self)
+        self._logger = logging.getLogger('grizzly-context-scenario')
+
+    @property
+    def failure_exception(self) -> Optional[Type[Exception]]:
+        return self._failure_exception
+
+    @failure_exception.setter
+    def failure_exception(self, value: Optional[Type[Exception]]) -> None:
+        orig_value = self._failure_exception
+        self._failure_exception = value
+        import inspect
+        try:
+            frame = inspect.stack()[1]
+            callee = f'{frame.filename}:{frame.lineno}: {frame.function}'
+        except:
+            callee = 'unknown'
+
+        self._logger.info(f'failure_exception: {orig_value} -> {value} ({callee})')  # @TODO: shouldn't be info, or even exist?
 
     @property
     def tasks(self) -> GrizzlyContextTasks:

--- a/grizzly/gevent.py
+++ b/grizzly/gevent.py
@@ -1,12 +1,7 @@
-import logging
-
 from typing import Any, Callable, Dict, Tuple
 from functools import wraps
 
 from gevent import Greenlet, getcurrent
-
-
-logger = logging.getLogger(__name__)
 
 
 class GreenletWithExceptionCatching(Greenlet):
@@ -25,7 +20,6 @@ class GreenletWithExceptionCatching(Greenlet):
             try:
                 return func(*args, **kwargs)
             except Exception as exception:
-                logger.error(f'{func} raised {exception}')
                 self.wrap_exceptions(self.handle_exception)(exception)
                 return exception
 

--- a/grizzly/gevent.py
+++ b/grizzly/gevent.py
@@ -1,7 +1,12 @@
+import logging
+
 from typing import Any, Callable, Dict, Tuple
 from functools import wraps
 
 from gevent import Greenlet, getcurrent
+
+
+logger = logging.getLogger(__name__)
 
 
 class GreenletWithExceptionCatching(Greenlet):
@@ -20,6 +25,7 @@ class GreenletWithExceptionCatching(Greenlet):
             try:
                 return func(*args, **kwargs)
             except Exception as exception:
+                logger.error(f'{func} raised {exception}')
                 self.wrap_exceptions(self.handle_exception)(exception)
                 return exception
 

--- a/grizzly/locust.py
+++ b/grizzly/locust.py
@@ -21,7 +21,6 @@ from . import __version__, __locust_version__
 from .listeners import init, init_statistics_listener, quitting, validate_result, spawning_complete, locust_test_start, locust_test_stop
 from .testdata.utils import initialize_testdata
 from .context import GrizzlyContext
-from .tasks import GrizzlyTask
 from .utils import create_scenario_class_type, create_user_class_type
 from .types import RequestType, TestdataType
 from .types.locust import Environment, LocustRunner, MasterRunner, WorkerRunner, MessageHandler, Message
@@ -74,9 +73,8 @@ def on_local(context: Context) -> bool:
     return value
 
 
-def setup_locust_scenarios(grizzly: GrizzlyContext) -> Tuple[List[Type[User]], List[GrizzlyTask], Set[str]]:
+def setup_locust_scenarios(grizzly: GrizzlyContext) -> Tuple[List[Type[User]], Set[str]]:
     user_classes: List[Type[User]] = []
-    tasks: List[GrizzlyTask] = []
 
     scenarios = grizzly.scenarios()
 
@@ -125,7 +123,6 @@ def setup_locust_scenarios(grizzly: GrizzlyContext) -> Tuple[List[Type[User]], L
         scenario.name = scenario_type.__name__
         for task in scenario.tasks:
             scenario_type.populate(task)
-            tasks.append(task)
 
             dependencies = getattr(task, '__dependencies__', None)
             if dependencies is not None:
@@ -139,7 +136,7 @@ def setup_locust_scenarios(grizzly: GrizzlyContext) -> Tuple[List[Type[User]], L
 
         user_classes.append(user_class_type)
 
-    return user_classes, tasks, external_dependencies
+    return user_classes, external_dependencies
 
 
 def setup_resource_limits(context: Context) -> None:
@@ -161,7 +158,7 @@ def setup_resource_limits(context: Context) -> None:
             )
 
 
-def setup_environment_listeners(context: Context, tasks: List[GrizzlyTask]) -> Tuple[Set[str], Dict[str, MessageHandler]]:
+def setup_environment_listeners(context: Context) -> Tuple[Set[str], Dict[str, MessageHandler]]:
     grizzly = cast(GrizzlyContext, context.grizzly)
 
     environment = grizzly.state.locust.environment
@@ -179,7 +176,7 @@ def setup_environment_listeners(context: Context, tasks: List[GrizzlyTask]) -> T
 
     # initialize testdata
     try:
-        testdata, external_dependencies, message_handlers = initialize_testdata(grizzly, tasks)
+        testdata, external_dependencies, message_handlers = initialize_testdata(grizzly)
     except TemplateError as e:
         logger.error(e, exc_info=True)
         raise AssertionError(f'error parsing request payload: {e}') from e
@@ -340,10 +337,9 @@ def run(context: Context) -> int:
 
     external_processes: Dict[str, subprocess.Popen] = {}
 
-    user_classes, tasks, external_dependencies = setup_locust_scenarios(grizzly)
+    user_classes, external_dependencies = setup_locust_scenarios(grizzly)
 
     assert len(user_classes) > 0, 'no users specified in feature'
-    assert len(tasks) > 0, 'no tasks specified in feature'
 
     try:
         setup_resource_limits(context)
@@ -383,7 +379,7 @@ def run(context: Context) -> int:
 
         grizzly.state.locust = runner
 
-        variable_dependencies, message_handlers = setup_environment_listeners(context, tasks)
+        variable_dependencies, message_handlers = setup_environment_listeners(context)
         external_dependencies.update(variable_dependencies)
 
         environment.events.init.fire(environment=environment, runner=runner, web_ui=None)

--- a/grizzly/locust.py
+++ b/grizzly/locust.py
@@ -441,7 +441,6 @@ def run(context: Context) -> int:
                 logger.info(f'registered callback for message type "{message_type}"')
 
             runner.register_message('client_aborted', grizzly_test_abort)
-            logger.info('registered callback for message type "client_aborted"')
 
         main_greenlet = runner.greenlet
 

--- a/grizzly/scenarios/__init__.py
+++ b/grizzly/scenarios/__init__.py
@@ -36,7 +36,6 @@ class GrizzlyScenario(SequentialTaskSet):
         self.abort = False
         self.spawning_complete = False
         self.parent.environment.events.quitting.add_listener(self.on_quitting)
-        self.parent.environment.events.spawning_complete.add_listener(self.on_spawning_complete)
 
     @property
     def user(self) -> 'GrizzlyUser':
@@ -105,13 +104,6 @@ class GrizzlyScenario(SequentialTaskSet):
         if self.task_greenlet is not None and kwargs.get('abort', False):
             self.abort = True
             self.task_greenlet.kill(StopScenario, block=False)
-
-    def on_spawning_complete(self, *args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> None:
-        """
-        Set scenario state for spawning complete, so we can control what happens with users before
-        spawning actually is complete.
-        """
-        self.spawning_complete = True
 
     def execute_next_task(self) -> None:
         """

--- a/grizzly/scenarios/iterator.py
+++ b/grizzly/scenarios/iterator.py
@@ -88,7 +88,7 @@ class IteratorScenario(GrizzlyScenario):
                         self.execute_next_task()
                     except Exception as e:
                         if not isinstance(e, StopScenario):
-                            self.logger.error(f'task {self.current_task_index+1} of {self.task_count}: {step}, failed: {e} ({type(e)})')
+                            self.logger.error(f'task {self.current_task_index+1} of {self.task_count}: {step}, failed: {e.__class__.__name__}')
                         raise e
                 except RescheduleTaskImmediately:
                     pass
@@ -104,7 +104,7 @@ class IteratorScenario(GrizzlyScenario):
                     # move locust.user.sequential_task.SequentialTaskSet index pointer the number of tasks left until end, so it will start over
                     tasks_left = self.task_count - (self._task_index % self.task_count)
                     self._task_index += tasks_left
-                    self.logger.info(f'{len(self._task_queue)} tasks in queue')  # @TODO: this should not be info
+                    self.logger.debug(f'{len(self._task_queue)} tasks in queue')
                     self._task_queue.clear()  # we should remove any scheduled tasks when restarting
 
                     self.stats.log_error(None)

--- a/grizzly/scenarios/iterator.py
+++ b/grizzly/scenarios/iterator.py
@@ -84,7 +84,11 @@ class IteratorScenario(GrizzlyScenario):
                         step = 'unknown'
 
                     self.logger.debug(f'executing task {self.current_task_index+1} of {self.task_count}: {step}')
-                    self.execute_next_task()
+                    try:
+                        self.execute_next_task()
+                    except Exception as e:
+                        self.logger.error(f'task {self.current_task_index+1} of {self.task_count}: {step}, failed: {e}')
+                        raise e
                 except RescheduleTaskImmediately:
                     pass
                 except RescheduleTask:

--- a/grizzly/scenarios/iterator.py
+++ b/grizzly/scenarios/iterator.py
@@ -87,7 +87,8 @@ class IteratorScenario(GrizzlyScenario):
                     try:
                         self.execute_next_task()
                     except Exception as e:
-                        self.logger.error(f'task {self.current_task_index+1} of {self.task_count}: {step}, failed: {e}')
+                        if not isinstance(e, StopScenario):
+                            self.logger.error(f'task {self.current_task_index+1} of {self.task_count}: {step}, failed: {e} ({type(e)})')
                         raise e
                 except RescheduleTaskImmediately:
                     pass

--- a/grizzly/steps/_helpers.py
+++ b/grizzly/steps/_helpers.py
@@ -31,11 +31,7 @@ def create_request_task(
     substitutes: Optional[Dict[str, str]] = None,
     content_type: Optional[TransformerContentType] = None,
 ) -> RequestTask:
-    grizzly = cast(GrizzlyContext, context.grizzly)
-    request = _create_request_task(context.config.base_dir, method, source, endpoint, name, substitutes=substitutes, content_type=content_type)
-    request.scenario = grizzly.scenario
-
-    return request
+    return _create_request_task(context.config.base_dir, method, source, endpoint, name, substitutes=substitutes, content_type=content_type)
 
 
 def _create_request_task(
@@ -88,6 +84,8 @@ def _create_request_task(
     request = RequestTask(method, name=cast(str, name), endpoint=endpoint)
     request._source = source
     request._template = template
+    if content_type is not None:
+        request.response.content_type = content_type
 
     return request
 

--- a/grizzly/steps/scenario/tasks.py
+++ b/grizzly/steps/scenario/tasks.py
@@ -436,7 +436,6 @@ def step_task_client_get_endpoint_until(context: Context, endpoint: str, name: s
         RequestDirection.FROM,
         endpoint,
         name,
-        scenario=grizzly.scenario,
         text=context.text,
     )
 

--- a/grizzly/tasks/__init__.py
+++ b/grizzly/tasks/__init__.py
@@ -61,7 +61,6 @@ from grizzly_extras.transformer import TransformerContentType
 if TYPE_CHECKING:  # pragma: no cover
     from grizzly.types import GrizzlyResponse
     from grizzly.scenarios import GrizzlyScenario
-    from grizzly.context import GrizzlyContextScenario
 
 GrizzlyTaskType = Callable[['GrizzlyScenario'], Any]
 GrizzlyTaskOnType = Callable[['GrizzlyScenario'], None]
@@ -140,13 +139,10 @@ class GrizzlyTask(ABC):
 
     _context_root: str
 
-    scenario: 'GrizzlyContextScenario'
     step: str
 
-    def __init__(self, scenario: Optional['GrizzlyContextScenario'] = None) -> None:
+    def __init__(self) -> None:
         self._context_root = environ.get('GRIZZLY_CONTEXT_ROOT', '.')
-        if scenario is not None:
-            self.scenario = scenario
 
     @abstractmethod
     def __call__(self) -> grizzlytask:

--- a/grizzly/tasks/clients/__init__.py
+++ b/grizzly/tasks/clients/__init__.py
@@ -32,7 +32,7 @@ from grizzly_extras.transformer import TransformerContentType
 from grizzly_extras.arguments import split_value, parse_arguments
 
 from grizzly.types import RequestType, RequestDirection, GrizzlyResponse
-from grizzly.context import GrizzlyContext, GrizzlyContextScenario
+from grizzly.context import GrizzlyContext
 from grizzly.scenarios import GrizzlyScenario
 from grizzly.testdata.utils import resolve_variable
 from grizzly.users.base import RequestLogger
@@ -74,9 +74,8 @@ class ClientTask(GrizzlyMetaRequestTask):
         source: Optional[str] = None,
         destination: Optional[str] = None,
         text: Optional[str] = None,
-        scenario: Optional[GrizzlyContextScenario] = None,
     ) -> None:
-        super().__init__(scenario)
+        super().__init__()
 
         self.grizzly = GrizzlyContext()
 

--- a/grizzly/tasks/clients/blobstorage.py
+++ b/grizzly/tasks/clients/blobstorage.py
@@ -51,7 +51,6 @@ from azure.storage.blob import BlobServiceClient, ContentSettings
 
 from grizzly.types import RequestDirection, GrizzlyResponse, bool_type
 from grizzly.scenarios import GrizzlyScenario
-from grizzly.context import GrizzlyContextScenario
 
 from . import client, ClientTask
 
@@ -81,7 +80,6 @@ class BlobStorageClientTask(ClientTask):
         source: Optional[str] = None,
         destination: Optional[str] = None,
         text: Optional[str] = None,
-        scenario: Optional[GrizzlyContextScenario] = None,
     ) -> None:
         super().__init__(
             direction,
@@ -91,7 +89,6 @@ class BlobStorageClientTask(ClientTask):
             metadata_variable=metadata_variable,
             destination=destination,
             source=source,
-            scenario=scenario,
             text=text,
         )
 

--- a/grizzly/tasks/clients/http.py
+++ b/grizzly/tasks/clients/http.py
@@ -51,7 +51,6 @@ from grizzly_extras.arguments import split_value, parse_arguments
 
 from grizzly.types import GrizzlyResponse, RequestDirection, bool_type
 from grizzly.scenarios import GrizzlyScenario
-from grizzly.context import GrizzlyContextScenario
 from grizzly.auth import GrizzlyHttpAuthClient, refresh_token, AAD, GrizzlyHttpContext
 
 from . import client, ClientTask
@@ -65,7 +64,6 @@ class HttpClientTask(ClientTask, GrizzlyHttpAuthClient):
     host: str
 
     _context: GrizzlyHttpContext
-    parent: Optional[GrizzlyScenario]
 
     def __init__(
         self,
@@ -78,7 +76,6 @@ class HttpClientTask(ClientTask, GrizzlyHttpAuthClient):
         source: Optional[str] = None,
         destination: Optional[str] = None,
         text: Optional[str] = None,
-        scenario: Optional[GrizzlyContextScenario] = None,
     ) -> None:
         verify = True
 
@@ -101,7 +98,6 @@ class HttpClientTask(ClientTask, GrizzlyHttpAuthClient):
             metadata_variable=metadata_variable,
             source=source,
             destination=destination,
-            scenario=scenario,
             text=text,
         )
 
@@ -120,14 +116,11 @@ class HttpClientTask(ClientTask, GrizzlyHttpAuthClient):
             'metadata': None,
             'auth': None,
         }
-        self.parent = None
 
     def on_start(self, parent: GrizzlyScenario) -> None:
         super().on_start(parent)
 
         self.session_started = time()
-        self.environment = parent.user.environment
-        self.parent = parent
         metadata = self._context.get('metadata', None)
         if metadata is not None:
             self.headers.update(metadata)

--- a/grizzly/tasks/clients/messagequeue.py
+++ b/grizzly/tasks/clients/messagequeue.py
@@ -85,7 +85,6 @@ from zmq.sugar.constants import REQ as ZMQ_REQ, LINGER as ZMQ_LINGER
 from grizzly_extras.async_message import AsyncMessageContext, AsyncMessageResponse, AsyncMessageRequest, async_message_request
 
 from grizzly.types import GrizzlyResponse, RequestDirection, RequestType
-from grizzly.context import GrizzlyContextScenario
 from grizzly.scenarios import GrizzlyScenario
 from grizzly.testdata.utils import resolve_variable
 
@@ -121,7 +120,6 @@ class MessageQueueClientTask(ClientTask):
         source: Optional[str] = None,
         destination: Optional[str] = None,
         text: Optional[str] = None,
-        scenario: Optional[GrizzlyContextScenario] = None,
     ) -> None:
         if pymqi.__name__ == 'grizzly_extras.dummy_pymqi':
             pymqi.raise_for_error(self.__class__)
@@ -137,7 +135,6 @@ class MessageQueueClientTask(ClientTask):
             metadata_variable=metadata_variable,
             destination=destination,
             source=source,
-            scenario=scenario,
             text=text,
         )
 

--- a/grizzly/tasks/clients/messagequeue.py
+++ b/grizzly/tasks/clients/messagequeue.py
@@ -293,7 +293,6 @@ class MessageQueueClientTask(ClientTask):
 
                 try:
                     response = async_message_request(client, request)
-
                     parent.logger.debug(f'got response from {worker} at {hostname()}')
                 except:
                     raise
@@ -308,7 +307,7 @@ class MessageQueueClientTask(ClientTask):
                     })
 
                 payload = response.get('payload', None)
-                if payload is None or len(payload) < 1:
+                if payload is None or len(payload.encode()) < 1:
                     raise RuntimeError('response did not contain any payload')
 
                 return response

--- a/grizzly/tasks/clients/servicebus.py
+++ b/grizzly/tasks/clients/servicebus.py
@@ -80,7 +80,6 @@ from grizzly_extras.transformer import TransformerContentType
 from grizzly_extras.arguments import parse_arguments
 
 from grizzly.types import GrizzlyResponse, RequestDirection, RequestType
-from grizzly.context import GrizzlyContextScenario
 from grizzly.scenarios import GrizzlyScenario
 from grizzly.tasks import template
 from grizzly.utils import async_message_request_wrapper
@@ -133,7 +132,6 @@ class ServiceBusClientTask(ClientTask):
         source: Optional[str] = None,
         destination: Optional[str] = None,
         text: Optional[str] = None,
-        scenario: Optional[GrizzlyContextScenario] = None,
     ) -> None:
         super().__init__(
             direction,
@@ -144,7 +142,6 @@ class ServiceBusClientTask(ClientTask):
             destination=destination,
             source=source,
             text=text,
-            scenario=scenario,
         )
 
         url = self.endpoint.replace(';', '?', 1).replace(';', '&')

--- a/grizzly/tasks/conditional.py
+++ b/grizzly/tasks/conditional.py
@@ -41,7 +41,6 @@ from . import GrizzlyTask, GrizzlyTaskWrapper, template, grizzlytask
 
 if TYPE_CHECKING:  # pragma: no cover
     from grizzly.scenarios import GrizzlyScenario
-    from grizzly.context import GrizzlyContextScenario
 
 
 @template('condition', 'tasks', 'name')
@@ -53,8 +52,8 @@ class ConditionalTask(GrizzlyTaskWrapper):
 
     _pointer: Optional[bool]
 
-    def __init__(self, name: str, condition: str, scenario: Optional['GrizzlyContextScenario'] = None) -> None:
-        super().__init__(scenario)
+    def __init__(self, name: str, condition: str) -> None:
+        super().__init__()
 
         self.name = name
         self.condition = condition
@@ -122,7 +121,7 @@ class ConditionalTask(GrizzlyTaskWrapper):
                 exception = e
             finally:
                 response_time = int((perf_counter() - start) * 1000)
-                name = f'{self.scenario.identifier} {self.name}: {condition_rendered} ({task_count})'
+                name = f'{parent.user._scenario.identifier} {self.name}: {condition_rendered} ({task_count})'
 
                 # do not log these exceptions if thrown from wrapped task, just log the error for this task
                 if not isinstance(exception, (StopUser, RestartScenario,)):
@@ -138,8 +137,8 @@ class ConditionalTask(GrizzlyTaskWrapper):
                     stats = parent.user.environment.stats.get(name, 'COND')
                     stats.log_error(None)
 
-                if exception is not None and self.scenario.failure_exception is not None:
-                    raise self.scenario.failure_exception()
+                if exception is not None and parent.user._scenario.failure_exception is not None:
+                    raise parent.user._scenario.failure_exception()
 
         @task.on_start
         def on_start(parent: 'GrizzlyScenario') -> None:

--- a/grizzly/tasks/date.py
+++ b/grizzly/tasks/date.py
@@ -51,7 +51,6 @@ from grizzly.utils import parse_timespan
 from . import GrizzlyTask, template, grizzlytask
 
 if TYPE_CHECKING:  # pragma: no cover
-    from grizzly.context import GrizzlyContextScenario
     from grizzly.scenarios import GrizzlyScenario
 
 
@@ -61,8 +60,8 @@ class DateTask(GrizzlyTask):
     value: str
     arguments: Dict[str, Optional[str]]
 
-    def __init__(self, variable: str, value: str, scenario: Optional['GrizzlyContextScenario'] = None) -> None:
-        super().__init__(scenario)
+    def __init__(self, variable: str, value: str) -> None:
+        super().__init__()
 
         self.variable = variable
         self.value = value

--- a/grizzly/tasks/log_message.py
+++ b/grizzly/tasks/log_message.py
@@ -15,12 +15,11 @@ This task does not have any request statistics entries.
 
 * `message` _str_ - message to log at `INFO` level, can be a template
 '''
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from . import GrizzlyTask, template, grizzlytask
 
 if TYPE_CHECKING:  # pragma: no cover
-    from grizzly.context import GrizzlyContextScenario
     from grizzly.scenarios import GrizzlyScenario
 
 
@@ -28,8 +27,8 @@ if TYPE_CHECKING:  # pragma: no cover
 class LogMessageTask(GrizzlyTask):
     message: str
 
-    def __init__(self, message: str, scenario: Optional['GrizzlyContextScenario'] = None) -> None:
-        super().__init__(scenario)
+    def __init__(self, message: str) -> None:
+        super().__init__()
 
         self.message = message
 

--- a/grizzly/tasks/loop.py
+++ b/grizzly/tasks/loop.py
@@ -34,7 +34,7 @@ from . import GrizzlyTask, GrizzlyTaskWrapper, template, grizzlytask
 
 if TYPE_CHECKING:  # pragma: no cover
     from grizzly.scenarios import GrizzlyScenario
-    from grizzly.context import GrizzlyContextScenario, GrizzlyContext
+    from grizzly.context import GrizzlyContext
 
 
 @template('values', 'tasks')
@@ -45,8 +45,8 @@ class LoopTask(GrizzlyTaskWrapper):
     values: str
     variable: str
 
-    def __init__(self, grizzly: 'GrizzlyContext', name: str, values: str, variable: str, scenario: Optional['GrizzlyContextScenario'] = None) -> None:
-        super().__init__(scenario)
+    def __init__(self, grizzly: 'GrizzlyContext', name: str, values: str, variable: str) -> None:
+        super().__init__()
 
         self.name = name
         self.values = values
@@ -100,15 +100,15 @@ class LoopTask(GrizzlyTaskWrapper):
 
                 parent.user.environment.events.request.fire(
                     request_type='LOOP',
-                    name=f'{self.scenario.identifier} {self.name} ({task_count})',
+                    name=f'{parent.user._scenario.identifier} {self.name} ({task_count})',
                     response_time=response_time,
                     response_length=response_length,
                     context=parent.user._context,
                     exception=exception,
                 )
 
-                if exception is not None and self.scenario.failure_exception is not None:
-                    raise self.scenario.failure_exception()
+                if exception is not None and parent.user._scenario.failure_exception is not None:
+                    raise parent.user._scenario.failure_exception()
 
         @task.on_start
         def on_start(parent: 'GrizzlyScenario') -> None:

--- a/grizzly/tasks/request.py
+++ b/grizzly/tasks/request.py
@@ -69,7 +69,6 @@ from grizzly.context import GrizzlyContext
 from . import GrizzlyMetaRequestTask, template, grizzlytask  # pylint: disable=unused-import
 
 if TYPE_CHECKING:  # pragma: no cover
-    from grizzly.context import GrizzlyContextScenario
     from grizzly.scenarios import GrizzlyScenario
     from grizzly.users.base.response_handler import ResponseHandlerAction
 
@@ -122,8 +121,8 @@ class RequestTask(GrizzlyMetaRequestTask):
 
     response: RequestTaskResponse
 
-    def __init__(self, method: RequestMethod, name: str, endpoint: str, source: Optional[str] = None, scenario: Optional['GrizzlyContextScenario'] = None) -> None:
-        super().__init__(scenario)
+    def __init__(self, method: RequestMethod, name: str, endpoint: str, source: Optional[str] = None) -> None:
+        super().__init__()
 
         self.method = method
         self.name = name
@@ -183,9 +182,9 @@ class RequestTask(GrizzlyMetaRequestTask):
     def __call__(self) -> grizzlytask:
         @grizzlytask
         def task(parent: 'GrizzlyScenario') -> Any:
-            return parent.user.request(self)
+            return parent.user.request(parent, self)
 
         return task
 
     def execute(self, parent: 'GrizzlyScenario') -> GrizzlyResponse:
-        return parent.user.request(self)
+        return parent.user.request(parent, self)

--- a/grizzly/tasks/set_variable.py
+++ b/grizzly/tasks/set_variable.py
@@ -25,7 +25,6 @@ from grizzly.testdata.variables import AtomicVariable
 from . import GrizzlyTask, template, grizzlytask
 
 if TYPE_CHECKING:  # pragma: no cover
-    from grizzly.context import GrizzlyContextScenario
     from grizzly.scenarios import GrizzlyScenario
 
 
@@ -38,8 +37,8 @@ class SetVariableTask(GrizzlyTask):
     _variable_instance_type: Optional[Type[AtomicVariable]] = None
     _variable_key: str
 
-    def __init__(self, variable: str, value: str, scenario: Optional[GrizzlyContextScenario] = None) -> None:
-        super().__init__(scenario)
+    def __init__(self, variable: str, value: str) -> None:
+        super().__init__()
 
         self.variable = variable
         self.value = value

--- a/grizzly/tasks/task_wait.py
+++ b/grizzly/tasks/task_wait.py
@@ -34,15 +34,14 @@ from . import GrizzlyTask, grizzlytask
 
 if TYPE_CHECKING:  # pragma: no cover
     from grizzly.scenarios import GrizzlyScenario
-    from grizzly.context import GrizzlyContextScenario
 
 
 class TaskWaitTask(GrizzlyTask):
     min_time: float
     max_time: Optional[float]
 
-    def __init__(self, min_time: float, max_time: Optional[float] = None, scenario: Optional['GrizzlyContextScenario'] = None) -> None:
-        super().__init__(scenario)
+    def __init__(self, min_time: float, max_time: Optional[float] = None) -> None:
+        super().__init__()
 
         self.min_time = min_time
         self.max_time = max_time

--- a/grizzly/tasks/timer.py
+++ b/grizzly/tasks/timer.py
@@ -23,7 +23,7 @@ run.
 
 * `name` _str_ - name of the timer
 '''
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 from hashlib import sha1
 from time import perf_counter
 
@@ -31,15 +31,14 @@ from . import GrizzlyTask, grizzlytask
 
 if TYPE_CHECKING:  # pragma: no cover
     from grizzly.scenarios import GrizzlyScenario
-    from grizzly.context import GrizzlyContextScenario
 
 
 class TimerTask(GrizzlyTask):
     name: str
     variable: str
 
-    def __init__(self, name: str, scenario: Optional['GrizzlyContextScenario'] = None) -> None:
-        super().__init__(scenario)
+    def __init__(self, name: str) -> None:
+        super().__init__()
 
         name_hash = sha1(f'timer-{name}'.encode('utf-8')).hexdigest()[:8]
 
@@ -47,10 +46,10 @@ class TimerTask(GrizzlyTask):
         self.variable = f'{name_hash}::{name}'
 
     def __call__(self) -> grizzlytask:
-        name = f'{self.scenario.identifier} {self.name}'
 
         @grizzlytask
         def task(parent: 'GrizzlyScenario') -> Any:
+            name = f'{parent.user._scenario.identifier} {self.name}'
             variable = parent.user._context['variables'].get(self.variable, None)
 
             # start timer

--- a/grizzly/tasks/transformer.py
+++ b/grizzly/tasks/transformer.py
@@ -28,7 +28,7 @@ then have the request type `TRNSF`.
 * `variable` _str_ - name of variable to save value to, must have been intialized
 '''
 from time import perf_counter
-from typing import TYPE_CHECKING, List, Callable, Any, Type, Optional
+from typing import TYPE_CHECKING, List, Callable, Any, Type
 
 from grizzly_extras.transformer import Transformer, transformer, TransformerContentType, TransformerError
 
@@ -37,7 +37,7 @@ from grizzly.exceptions import TransformerLocustError
 from . import GrizzlyTask, template, grizzlytask
 
 if TYPE_CHECKING:  # pragma: no cover
-    from grizzly.context import GrizzlyContextScenario, GrizzlyContext
+    from grizzly.context import GrizzlyContext
     from grizzly.scenarios import GrizzlyScenario
 
 
@@ -58,9 +58,8 @@ class TransformerTask(GrizzlyTask):
         variable: str,
         content: str,
         content_type: TransformerContentType,
-        scenario: Optional['GrizzlyContextScenario'] = None,
     ) -> None:
-        super().__init__(scenario)
+        super().__init__()
 
         self.expression = expression
         self.variable = variable
@@ -113,14 +112,14 @@ class TransformerTask(GrizzlyTask):
                 response_time = int((perf_counter() - start) * 1000)
                 parent.user.environment.events.request.fire(
                     request_type='TRNSF',
-                    name=f'{self.scenario.identifier} Transformer=>{self.variable}',
+                    name=f'{parent.user._scenario.identifier} Transformer=>{self.variable}',
                     response_time=response_time,
                     response_length=response_length,
                     context=parent.user._context,
                     exception=exception,
                 )
 
-                if exception is not None and self.scenario.failure_exception is not None:
-                    raise self.scenario.failure_exception()
+                if exception is not None and parent.user._scenario.failure_exception is not None:
+                    raise parent.user._scenario.failure_exception()
 
         return task

--- a/grizzly/tasks/until.py
+++ b/grizzly/tasks/until.py
@@ -58,7 +58,7 @@ from grizzly.utils import safe_del
 from . import GrizzlyTask, GrizzlyMetaRequestTask, template, grizzlytask
 
 if TYPE_CHECKING:  # pragma: no cover
-    from grizzly.context import GrizzlyContextScenario, GrizzlyContext
+    from grizzly.context import GrizzlyContext
     from grizzly.scenarios import GrizzlyScenario
 
 
@@ -77,8 +77,8 @@ class UntilRequestTask(GrizzlyTask):
     wait: float
     expected_matches: int
 
-    def __init__(self, grizzly: 'GrizzlyContext', request: GrizzlyMetaRequestTask, condition: str, scenario: Optional['GrizzlyContextScenario'] = None) -> None:
-        super().__init__(scenario)
+    def __init__(self, grizzly: 'GrizzlyContext', request: GrizzlyMetaRequestTask, condition: str) -> None:
+        super().__init__()
 
         self.request = request
         self.condition = condition
@@ -122,7 +122,7 @@ class UntilRequestTask(GrizzlyTask):
 
         @grizzlytask
         def task(parent: 'GrizzlyScenario') -> Any:
-            task_name = f'{self.scenario.identifier} {self.request.name}, w={self.wait}s, r={self.retries}, em={self.expected_matches}'
+            task_name = f'{parent.user._scenario.identifier} {self.request.name}, w={self.wait}s, r={self.retries}, em={self.expected_matches}'
             condition_rendered = parent.render(self.condition)
             endpoint_rendered = parent.render(self.request.endpoint)
 
@@ -221,8 +221,8 @@ class UntilRequestTask(GrizzlyTask):
                     exception=exception,
                 )
 
-                if exception is not None and self.scenario.failure_exception is not None:
-                    raise self.scenario.failure_exception()
+                if exception is not None and parent.user._scenario.failure_exception is not None:
+                    raise parent.user._scenario.failure_exception()
 
         @task.on_start
         def on_start(parent: 'GrizzlyScenario') -> None:

--- a/grizzly/tasks/wait.py
+++ b/grizzly/tasks/wait.py
@@ -10,7 +10,7 @@ This task executes a `gevent.sleep` and is used to manually create delays betwee
 
 * `time_expression` _str_ - float as string or a {@pydocfractions of seconds to excplicitly sleep in the scenario
 '''
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from gevent import sleep as gsleep
 
@@ -19,7 +19,6 @@ from grizzly.exceptions import StopUser
 from . import GrizzlyTask, template, grizzlytask
 
 if TYPE_CHECKING:  # pragma: no cover
-    from grizzly.context import GrizzlyContextScenario
     from grizzly.scenarios import GrizzlyScenario
 
 
@@ -27,8 +26,8 @@ if TYPE_CHECKING:  # pragma: no cover
 class WaitTask(GrizzlyTask):
     time_expression: str
 
-    def __init__(self, time_expression: str, scenario: Optional['GrizzlyContextScenario'] = None) -> None:
-        super().__init__(scenario)
+    def __init__(self, time_expression: str) -> None:
+        super().__init__()
 
         self.time_expression = time_expression
 
@@ -47,7 +46,7 @@ class WaitTask(GrizzlyTask):
             except Exception as exception:
                 parent.user.environment.events.request.fire(
                     request_type='WAIT',
-                    name=f'{self.scenario.identifier} WaitTask=>{self.time_expression}',
+                    name=f'{parent.user._scenario.identifier} WaitTask=>{self.time_expression}',
                     response_time=0,
                     response_length=0,
                     context=parent.user._context,

--- a/grizzly/testdata/ast.py
+++ b/grizzly/testdata/ast.py
@@ -5,24 +5,28 @@ from typing import TYPE_CHECKING, Set, Optional, List, Dict, Generator
 from jinja2 import Environment as Jinja2Environment, FileSystemLoader as Jinja2FileSystemLoader
 from jinja2 import nodes as j2
 
-from grizzly.tasks import GrizzlyTask
-
 
 if TYPE_CHECKING:  # pragma: no cover
-    from grizzly.context import GrizzlyContextScenario
+    from grizzly.context import GrizzlyContextScenario, GrizzlyContext
 
 logger = logging.getLogger(__name__)
 
 
-def get_template_variables(tasks: List[GrizzlyTask]) -> Dict[str, Set[str]]:
+def get_template_variables(grizzly: 'GrizzlyContext') -> Dict[str, Set[str]]:
     templates: Dict['GrizzlyContextScenario', Set[str]] = {}
 
-    for task in tasks:
-        if task.scenario not in templates:
-            templates[task.scenario] = set()
+    for scenario in grizzly.scenarios:
+        if scenario not in templates:
+            templates[scenario] = set()
 
-        for template in task.get_templates():
-            templates[task.scenario].add(template)
+        for task in scenario.tasks():
+            for template in task.get_templates():
+                templates[scenario].add(template)
+
+        templates[scenario].update(scenario.orphan_templates)
+
+        if len(templates[scenario]) == 0:
+            del templates[scenario]
 
     return _parse_templates(templates)
 
@@ -48,73 +52,71 @@ def walk_attr(node: j2.Getattr) -> List[str]:
 def _parse_templates(templates: Dict['GrizzlyContextScenario', Set[str]]) -> Dict[str, Set[str]]:
     variables: Dict[str, Set[str]] = {}
 
-    for scenario, scenario_templates in templates.items():
+    def _getattr(node: j2.Node) -> Generator[List[str], None, None]:
+        attributes: Optional[List[str]] = None
+
+        if isinstance(node, j2.Getattr):
+            attributes = walk_attr(node)
+        elif isinstance(node, j2.Getitem):
+            child_node = getattr(node, 'node')
+            child_node_name = getattr(child_node, 'name', None)
+            if child_node_name is not None:
+                attributes = [child_node_name]
+        elif isinstance(node, j2.Name):
+            attributes = [getattr(node, 'name')]
+        elif isinstance(node, (j2.Filter, j2.UnaryExpr,)):
+            child_node = getattr(node, 'node')
+            yield from _getattr(child_node)
+        elif isinstance(node, j2.BinExpr):
+            left_node = getattr(node, 'left')
+            yield from _getattr(left_node)
+            right_node = getattr(node, 'right')
+            yield from _getattr(right_node)
+        elif isinstance(node, j2.CondExpr):
+            test_node = getattr(node, 'test')
+            yield from _getattr(test_node)
+
+            expr_node = getattr(node, 'expr1')
+            yield from _getattr(expr_node)
+
+            expr_node = getattr(node, 'expr2')
+            if expr_node is not None:
+                yield from _getattr(expr_node)
+        elif isinstance(node, j2.Compare):
+            expr = getattr(node, 'expr')
+            yield from _getattr(expr)
+
+            ops = getattr(node, 'ops', [])
+            for op in ops:
+                yield from _getattr(op)
+        elif isinstance(node, j2.Operand):
+            expr = getattr(node, 'expr')
+
+            yield from _getattr(expr)
+        elif isinstance(node, j2.Concat):
+            nodes = getattr(node, 'nodes')
+
+            for node in nodes:
+                yield from _getattr(node)
+        elif isinstance(node, j2.Test):
+            child_node = getattr(node, 'node')
+            yield from _getattr(child_node)
+
+            args = getattr(node, 'args')
+            for arg in args:
+                yield from _getattr(arg)
+        elif isinstance(node, j2.List):
+            for item in getattr(node, 'items', []):
+                yield from _getattr(item)
+
+        if attributes is not None:
+            yield attributes
+
+    for scenario, template_sources in templates.items():
         scenario_name = scenario.class_name
 
         if scenario_name not in variables:
             variables[scenario_name] = set()
-
-        def _getattr(node: j2.Node) -> Generator[List[str], None, None]:
-            attributes: Optional[List[str]] = None
-
-            if isinstance(node, j2.Getattr):
-                attributes = walk_attr(node)
-            elif isinstance(node, j2.Getitem):
-                child_node = getattr(node, 'node')
-                child_node_name = getattr(child_node, 'name', None)
-                if child_node_name is not None:
-                    attributes = [child_node_name]
-            elif isinstance(node, j2.Name):
-                attributes = [getattr(node, 'name')]
-            elif isinstance(node, (j2.Filter, j2.UnaryExpr,)):
-                child_node = getattr(node, 'node')
-                yield from _getattr(child_node)
-            elif isinstance(node, j2.BinExpr):
-                left_node = getattr(node, 'left')
-                yield from _getattr(left_node)
-                right_node = getattr(node, 'right')
-                yield from _getattr(right_node)
-            elif isinstance(node, j2.CondExpr):
-                test_node = getattr(node, 'test')
-                yield from _getattr(test_node)
-
-                expr_node = getattr(node, 'expr1')
-                yield from _getattr(expr_node)
-
-                expr_node = getattr(node, 'expr2')
-                if expr_node is not None:
-                    yield from _getattr(expr_node)
-            elif isinstance(node, j2.Compare):
-                expr = getattr(node, 'expr')
-                yield from _getattr(expr)
-
-                ops = getattr(node, 'ops', [])
-                for op in ops:
-                    yield from _getattr(op)
-            elif isinstance(node, j2.Operand):
-                expr = getattr(node, 'expr')
-
-                yield from _getattr(expr)
-            elif isinstance(node, j2.Concat):
-                nodes = getattr(node, 'nodes')
-
-                for node in nodes:
-                    yield from _getattr(node)
-            elif isinstance(node, j2.Test):
-                child_node = getattr(node, 'node')
-                yield from _getattr(child_node)
-
-                args = getattr(node, 'args')
-                for arg in args:
-                    yield from _getattr(arg)
-            elif isinstance(node, j2.List):
-                for item in getattr(node, 'items', []):
-                    yield from _getattr(item)
-
-            if attributes is not None:
-                yield attributes
-
-        template_sources = list(scenario_templates) + scenario.orphan_templates
 
         # can raise TemplateError which should be handled else where
         for template in template_sources:

--- a/grizzly/testdata/utils.py
+++ b/grizzly/testdata/utils.py
@@ -13,7 +13,6 @@ from jinja2.filters import FILTERS
 from grizzly.types import RequestType, TestdataType, GrizzlyVariableType
 from grizzly.types.locust import StopUser, MessageHandler
 from grizzly.testdata.ast import get_template_variables
-from grizzly.tasks import GrizzlyTask
 from grizzly.utils import merge_dicts
 
 from . import GrizzlyVariables
@@ -26,9 +25,9 @@ if TYPE_CHECKING:  # pragma: no cover
 logger = logging.getLogger(__name__)
 
 
-def initialize_testdata(grizzly: 'GrizzlyContext', tasks: List[GrizzlyTask]) -> Tuple[TestdataType, Set[str], Dict[str, MessageHandler]]:
+def initialize_testdata(grizzly: 'GrizzlyContext') -> Tuple[TestdataType, Set[str], Dict[str, MessageHandler]]:
     testdata: TestdataType = {}
-    template_variables = get_template_variables(tasks)
+    template_variables = get_template_variables(grizzly)
 
     found_variables = set()
     for variable in itertools.chain(*template_variables.values()):

--- a/grizzly/users/base/__init__.py
+++ b/grizzly/users/base/__init__.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:  # pragma: no cover
     from grizzly.types import GrizzlyResponse
     from grizzly.tasks import RequestTask
+    from grizzly.scenarios import GrizzlyScenario
 
 
 class FileRequests:
@@ -17,7 +18,7 @@ class HttpRequests:
 
 class AsyncRequests:
     @abstractmethod
-    def async_request(self, request: 'RequestTask') -> 'GrizzlyResponse':
+    def async_request(self, parent: 'GrizzlyScenario', request: 'RequestTask') -> 'GrizzlyResponse':
         raise NotImplementedError(f'{self.__class__.__name__} has not implemented async_request')  # pragma: no cover
 
 

--- a/grizzly/users/base/grizzly_user.py
+++ b/grizzly/users/base/grizzly_user.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Dict, Tuple, Optional, Set, cast
 from logging import Logger
 from abc import abstractmethod
 from json import dumps as jsondumps, loads as jsonloads
-from dataclasses import replace as dataclass_copy
+from copy import copy
 
 from locust.user.users import User
 from locust.user.task import LOCUST_STATE_RUNNING
@@ -52,7 +52,7 @@ class GrizzlyUser(User):
         self.logger = logging.getLogger(f'{self.__class__.__name__}/{id(self)}')
         self._scenario_state = None
         self.abort = False
-        self._scenario = dataclass_copy(self.__scenario__)
+        self._scenario = copy(self.__scenario__)
         # these are not copied, and we can share reference
         self._scenario._tasks = self.__scenario__._tasks
 

--- a/grizzly/users/base/grizzly_user.py
+++ b/grizzly/users/base/grizzly_user.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Dict, Tuple, Optional, Set, cast
 from logging import Logger
 from abc import abstractmethod
 from json import dumps as jsondumps, loads as jsonloads
+from dataclasses import replace as dataclass_copy
 
 from locust.user.users import User
 from locust.user.task import LOCUST_STATE_RUNNING
@@ -20,16 +21,18 @@ from . import FileRequests
 
 if TYPE_CHECKING:  # pragma: no cover
     from grizzly.context import GrizzlyContextScenario
+    from grizzly.scenarios import GrizzlyScenario
 
 
 class GrizzlyUser(User):
     __dependencies__: Set[str] = set()
+    __scenario__: 'GrizzlyContextScenario'  # reference to grizzly scenario this user is part of
 
     _context_root: str
     _context: Dict[str, Any] = {
         'variables': {},
     }
-    _scenario: 'GrizzlyContextScenario'
+    _scenario: 'GrizzlyContextScenario'  # copy of scenario for this user instance
 
     _scenario_state: Optional[ScenarioState]
 
@@ -49,6 +52,9 @@ class GrizzlyUser(User):
         self.logger = logging.getLogger(f'{self.__class__.__name__}/{id(self)}')
         self._scenario_state = None
         self.abort = False
+        self._scenario = dataclass_copy(self.__scenario__)
+        # these are not copied, and we can share reference
+        self._scenario._tasks = self.__scenario__._tasks
 
         environment.events.quitting.add_listener(self.on_quitting)
 
@@ -80,17 +86,17 @@ class GrizzlyUser(User):
             return cast(bool, super().stop(force=force))
 
     @abstractmethod
-    def request(self, request: RequestTask) -> GrizzlyResponse:
+    def request(self, parent: 'GrizzlyScenario', request: RequestTask) -> GrizzlyResponse:
         raise NotImplementedError(f'{self.__class__.__name__} has not implemented request')  # pragma: no cover
 
     def render(self, request: RequestTask) -> Tuple[str, str, Optional[str], Optional[Dict[str, str]], Optional[Dict[str, str]]]:
-        scenario_name = f'{request.scenario.identifier} {request.name}'
+        scenario_name = f'{self._scenario.identifier} {request.name}'
 
         try:
             j2env = self.grizzly.state.jinja2
             payload: Optional[str] = None
             name = j2env.from_string(request.name).render(**self.context_variables)
-            scenario_name = f'{request.scenario.identifier} {name}'
+            scenario_name = f'{self._scenario.identifier} {name}'
             endpoint = j2env.from_string(request.endpoint).render(**self.context_variables)
             arguments: Optional[Dict[str, str]] = None
             metadata: Optional[Dict[str, str]] = None

--- a/grizzly/users/base/request_logger.py
+++ b/grizzly/users/base/request_logger.py
@@ -4,7 +4,7 @@ import unicodedata
 import re
 import traceback
 
-from typing import Dict, Any, Tuple, Optional, Union, cast
+from typing import Dict, Any, Tuple, Optional, Union, cast, TYPE_CHECKING
 from datetime import datetime, timedelta
 from urllib.parse import urlparse, urlunparse
 
@@ -19,6 +19,9 @@ from grizzly.utils import merge_dicts
 
 from .response_event import ResponseEvent
 from .grizzly_user import GrizzlyUser
+
+if TYPE_CHECKING:  # pragma: no cover
+    from grizzly.scenarios import GrizzlyScenario
 
 
 LOG_FILE_TEMPLATE = '''
@@ -150,8 +153,8 @@ class RequestLogger(ResponseEvent, GrizzlyUser):
             },
         }
 
-    def request(self, request: RequestTask) -> GrizzlyResponse:
-        raise NotImplementedError(f'{self.__class__.__name__} has not implemented request')  # pragma: no cover
+    def request(self, parent: 'GrizzlyScenario', request: RequestTask) -> GrizzlyResponse:  # pragma: no cover
+        return None, None
 
     def request_logger(
         self,

--- a/grizzly/users/base/response_handler.py
+++ b/grizzly/users/base/response_handler.py
@@ -101,7 +101,10 @@ class ResponseHandlerAction(ABC):
                 if self.as_json:
                     match = jsondumps([match])
             else:
-                match = jsondumps(matches)
+                if self.as_json:
+                    match = jsondumps(matches)
+                else:
+                    match = '\n'.join(matches)
 
         return match, interpolated_expression, interpolated_match_with
 

--- a/grizzly/users/blobstorage.py
+++ b/grizzly/users/blobstorage.py
@@ -29,7 +29,7 @@ Then send request "test/blob.file" to endpoint "azure-blobstorage-container-name
 '''
 import os
 
-from typing import Dict, Any, Tuple, Optional
+from typing import Dict, Any, Tuple, Optional, TYPE_CHECKING
 from urllib.parse import urlparse, parse_qs
 from time import perf_counter as time
 
@@ -41,6 +41,10 @@ from grizzly.tasks import RequestTask
 from grizzly.utils import merge_dicts
 
 from .base import GrizzlyUser
+
+
+if TYPE_CHECKING:  # pragma: no cover
+    from grizzly.scenarios import GrizzlyScenario
 
 
 class BlobStorageUser(GrizzlyUser):
@@ -83,10 +87,10 @@ class BlobStorageUser(GrizzlyUser):
         self.client.close()
         super().on_stop()
 
-    def request(self, request: RequestTask) -> GrizzlyResponse:
+    def request(self, parent: 'GrizzlyScenario', request: RequestTask) -> GrizzlyResponse:
         request_name, endpoint, payload, _, _ = self.render(request)
 
-        name = f'{request.scenario.identifier} {request_name}'
+        name = f'{self._scenario.identifier} {request_name}'
 
         exception: Optional[Exception] = None
         start_time = time()
@@ -115,7 +119,7 @@ class BlobStorageUser(GrizzlyUser):
             if exception is not None:
                 if isinstance(exception, NotImplementedError):
                     raise StopUser()
-                elif request.scenario.failure_exception is not None:
-                    raise request.scenario.failure_exception()
+                elif self._scenario.failure_exception is not None:
+                    raise self._scenario.failure_exception()
 
             return {}, payload

--- a/grizzly/users/dummy.py
+++ b/grizzly/users/dummy.py
@@ -14,7 +14,7 @@ Example of how to use it in a scenario:
 Given a user of type "Dummy" load testing "/dev/null"
 ```
 '''
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Tuple, TYPE_CHECKING
 
 from grizzly.types import GrizzlyResponse
 from grizzly.types.locust import Environment
@@ -23,9 +23,13 @@ from grizzly.tasks import RequestTask
 from .base import GrizzlyUser
 
 
+if TYPE_CHECKING:  # pragma: no cover
+    from grizzly.scenarios import GrizzlyScenario
+
+
 class DummyUser(GrizzlyUser):
     def __init__(self, environment: Environment, *args: Tuple[Any], **kwargs: Dict[str, Any]) -> None:
         super().__init__(environment, *args, **kwargs)
 
-    def request(self, request: RequestTask) -> GrizzlyResponse:
+    def request(self, parent: 'GrizzlyScenario', request: RequestTask) -> GrizzlyResponse:
         return None, None

--- a/grizzly/utils.py
+++ b/grizzly/utils.py
@@ -107,8 +107,8 @@ def create_user_class_type(scenario: 'GrizzlyContextScenario', global_context: O
     return type(user_class_name, (base_user_class_type, ), {
         '__module__': base_user_class_type.__module__,
         '__dependencies__': base_user_class_type.__dependencies__,
+        '__scenario__': scenario,
         '_context': context,
-        '_scenario': scenario,
         **distribution,
     })
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,9 +64,9 @@ def _behave_fixture(locust_fixture: LocustFixture) -> Generator[BehaveFixture, N
         yield fixture
 
 
-@pytest.mark.usefixtures('tmp_path_factory')
-def _request_task(tmp_path_factory: TempPathFactory) -> Generator[RequestTaskFixture, None, None]:
-    with RequestTaskFixture(tmp_path_factory) as fixture:
+@pytest.mark.usefixtures('tmp_path_factory', 'behave_fixture')
+def _request_task(tmp_path_factory: TempPathFactory, behave_fixture: BehaveFixture) -> Generator[RequestTaskFixture, None, None]:
+    with RequestTaskFixture(tmp_path_factory, behave_fixture) as fixture:
         yield fixture
 
 

--- a/tests/e2e/steps/scenario/test_user.py
+++ b/tests/e2e/steps/scenario/test_user.py
@@ -9,14 +9,14 @@ from grizzly.types.behave import Context
 from tests.fixtures import End2EndFixture
 
 
-@pytest.mark.parametrize('user_type,host', [
-    ('RestApi', 'https://localhost/api',),
-    ('MessageQueueUser', 'mq://mqm:secret@localhost/?QueueManager=QMGR01&Channel=Channel01',),
-    ('ServiceBus', 'sb://localhost/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc123def456ghi789=',),
-    ('BlobStorageUser', 'DefaultEndpointsProtocol=https;EndpointSuffix=localhost;AccountName=examplestorage;AccountKey=xxxyyyyzzz==',),
-    ('Sftp', 'sftp://localhost',),
+@pytest.mark.parametrize('user_type,host,expected_rc', [
+    ('RestApi', 'https://localhost/api', 0,),
+    ('MessageQueueUser', 'mq://localhost/?QueueManager=QMGR01&Channel=Channel01', 1,),
+    ('ServiceBus', 'sb://localhost/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc123def456ghi789=', 0,),
+    ('BlobStorageUser', 'DefaultEndpointsProtocol=https;EndpointSuffix=localhost;AccountName=examplestorage;AccountKey=xxxyyyyzzz==', 0,),
+    ('Sftp', 'sftp://localhost', 1,),
 ])
-def test_e2e_step_user_type_with_weight(e2e_fixture: End2EndFixture, user_type: str, host: str) -> None:
+def test_e2e_step_user_type_with_weight(e2e_fixture: End2EndFixture, user_type: str, host: str, expected_rc: int) -> None:
     def validate_user_type(context: Context) -> None:
         grizzly = cast(GrizzlyContext, context.grizzly)
         data = list(context.table)[0].as_dict()
@@ -24,13 +24,14 @@ def test_e2e_step_user_type_with_weight(e2e_fixture: End2EndFixture, user_type: 
         expected_weight = int(data['weight'])
         expected_user_type = data['user_type']
         expected_host = data['host']
+        actual_host = grizzly.scenario.context.get('host', None)
 
         if not expected_user_type.endswith('User'):
             expected_user_type += 'User'
 
         assert grizzly.scenario.user.class_name == expected_user_type
         assert grizzly.scenario.user.weight == expected_weight
-        assert grizzly.scenario.context.get('host', None) == expected_host
+        assert actual_host == expected_host, f'{actual_host} != {expected_host}'
 
     if 'messagequeue' in user_type.lower() and not e2e_fixture.has_pymqi():
         pytest.skip('pymqi not installed')
@@ -58,20 +59,17 @@ def test_e2e_step_user_type_with_weight(e2e_fixture: End2EndFixture, user_type: 
 
     rc, _ = e2e_fixture.execute(feature_file)
 
-    if user_type == 'Sftp':
-        assert rc == 1
-    else:
-        assert rc == 0
+    assert rc == expected_rc
 
 
-@pytest.mark.parametrize('user_type,host', [
-    ('RestApi', 'https://localhost/api',),
-    ('MessageQueueUser', 'mq://mqm:secret@localhost/?QueueManager=QMGR01&Channel=Channel01',),
-    ('ServiceBus', 'sb://localhost/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc123def456ghi789=',),
-    ('BlobStorageUser', 'DefaultEndpointsProtocol=https;EndpointSuffix=localhost;AccountName=examplestorage;AccountKey=xxxyyyyzzz==',),
-    ('Sftp', 'sftp://localhost',),
+@pytest.mark.parametrize('user_type,host,expected_rc', [
+    ('RestApi', 'https://localhost/api', 0,),
+    ('MessageQueueUser', 'mq://localhost/?QueueManager=QMGR01&Channel=Channel01', 1,),
+    ('ServiceBus', 'sb://localhost/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc123def456ghi789=', 0,),
+    ('BlobStorageUser', 'DefaultEndpointsProtocol=https;EndpointSuffix=localhost;AccountName=examplestorage;AccountKey=xxxyyyyzzz==', 0,),
+    ('Sftp', 'sftp://localhost', 1,),
 ])
-def test_e2e_step_user_type(e2e_fixture: End2EndFixture, user_type: str, host: str) -> None:
+def test_e2e_step_user_type(e2e_fixture: End2EndFixture, user_type: str, host: str, expected_rc: int) -> None:
     def validate_user_type(context: Context) -> None:
         grizzly = cast(GrizzlyContext, context.grizzly)
         data = list(context.table)[0].as_dict()
@@ -109,7 +107,4 @@ def test_e2e_step_user_type(e2e_fixture: End2EndFixture, user_type: str, host: s
 
     rc, _ = e2e_fixture.execute(feature_file)
 
-    if user_type == 'Sftp':
-        assert rc == 1
-    else:
-        assert rc == 0
+    assert rc == expected_rc

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -773,7 +773,7 @@ def step_start_webserver(context: Context, port: int) -> None:
 
         # create grizzly project
         rc, output = run_command(
-            ['grizzly-cli', 'init', '--yes', project_name],
+            ['grizzly-cli', 'init', '--with-mq', '--yes', project_name],
             cwd=str(test_context),
             env=self._env,
         )

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -41,7 +41,7 @@ from grizzly.types import GrizzlyResponseContextManager, RequestMethod
 from grizzly.types.behave import Context as BehaveContext, Scenario, Step, Feature
 from grizzly.tasks import RequestTask
 from grizzly.testdata.variables import destroy_variables
-from grizzly.context import GrizzlyContext, GrizzlyContextScenario
+from grizzly.context import GrizzlyContext
 from grizzly.types.locust import Environment, LocustRunner
 
 from .helpers import TestUser, TestScenario, RequestSilentFailureEvent
@@ -85,7 +85,7 @@ class LocustFixture:
     _test_context_root: str
     _tmp_path_factory: TempPathFactory
 
-    env: Environment
+    environment: Environment
     runner: LocustRunner
 
     def __init__(self, tmp_path_factory: TempPathFactory) -> None:
@@ -97,8 +97,8 @@ class LocustFixture:
         self._test_context_root = path.dirname(test_context)
 
         environ['GRIZZLY_CONTEXT_ROOT'] = self._test_context_root
-        self.env = Environment()
-        self.runner = self.env.create_local_runner()
+        self.environment = Environment()
+        self.runner = self.environment.create_local_runner()
 
         return self
 
@@ -228,11 +228,11 @@ class ParamikoFixture:
 
 
 class BehaveFixture:
-    _locust_fixture: LocustFixture
+    locust: LocustFixture
     context: BehaveContext
 
     def __init__(self, locust_fixture: LocustFixture) -> None:
-        self._locust_fixture = locust_fixture
+        self.locust = locust_fixture
 
     @property
     def grizzly(self) -> GrizzlyContext:
@@ -257,7 +257,7 @@ class BehaveFixture:
         context.scenario.background = Background(filename=None, line=None, keyword='', steps=[context.step], name='')
         context._runner.step_registry = step_registry
         grizzly = GrizzlyContext()
-        grizzly.state.locust = self._locust_fixture.runner
+        grizzly.state.locust = self.locust.runner
         setattr(context, 'grizzly', grizzly)
 
         self.context = context
@@ -296,9 +296,11 @@ class RequestTaskFixture:
     relative_path: str
     request: RequestTask
     test_context: Path
+    behave_fixture: BehaveFixture
 
-    def __init__(self, tmp_path_factory: TempPathFactory) -> None:
+    def __init__(self, tmp_path_factory: TempPathFactory, behave_fixture: BehaveFixture) -> None:
         self._tmp_path_factory = tmp_path_factory
+        self.behave_fixture = behave_fixture
 
     def __enter__(self) -> 'RequestTaskFixture':
         self.test_context = self._tmp_path_factory.mktemp('example_payload') / 'requests'
@@ -310,13 +312,6 @@ class RequestTaskFixture:
 
         request = RequestTask(RequestMethod.POST, endpoint='/api/test', name='request_task')
         request.source = REQUEST_TASK_TEMPLATE_CONTENTS
-        request.scenario = GrizzlyContextScenario(1)
-        request.scenario.name = 'test-scenario'
-        request.scenario.user.class_name = 'TestUser'
-        request.scenario.context['host'] = 'http://example.com'
-        request.scenario.behave = None
-
-        request.scenario.tasks.add(request)
 
         self.context_root = request_path
         self.request = request
@@ -338,12 +333,11 @@ class RequestTaskFixture:
 class GrizzlyFixture:
     request_task: RequestTaskFixture
     grizzly: GrizzlyContext
-    behave: BehaveContext
-    locust_env: Environment
+    behave: BehaveFixture
 
     def __init__(self, request_task: RequestTaskFixture, behave_fixture: BehaveFixture) -> None:
         self.request_task = request_task
-        self.behave = behave_fixture.context
+        self.behave = behave_fixture
 
     @property
     def test_context(self) -> Path:
@@ -352,7 +346,11 @@ class GrizzlyFixture:
     def __enter__(self) -> 'GrizzlyFixture':
         environ['GRIZZLY_CONTEXT_ROOT'] = path.abspath(path.join(self.request_task.context_root, '..'))
         self.grizzly = GrizzlyContext()
-        self.grizzly.scenarios.append(self.request_task.request.scenario)
+        self.grizzly.scenarios.clear()
+        self.grizzly.scenarios.create(self.behave.create_scenario('test scenario'))
+        self.grizzly.scenario.user.class_name = 'TestUser'
+        self.grizzly.scenario.context['host'] = 'http://example.com'
+        self.grizzly.scenario.tasks.add(self.request_task.request)
 
         return self
 
@@ -362,35 +360,36 @@ class GrizzlyFixture:
         user_type: Optional[Type['GrizzlyUser']] = None,
         scenario_type: Optional[Type['GrizzlyScenario']] = None,
         no_tasks: Optional[bool] = False,
-    ) -> Tuple[Environment, 'GrizzlyUser', Optional['GrizzlyScenario']]:
+    ) -> 'GrizzlyScenario':
         if user_type is None:
             user_type = TestUser
 
         if scenario_type is None:
             scenario_type = TestScenario
 
-        self.locust_env = Environment(
+        self.behave.locust.environment = Environment(
             host=host,
             user_classes=[user_type],
         )
 
-        self.request_task.request.scenario.description = self.request_task.request.scenario.name
+        self.grizzly.scenario.user.class_name = user_type.__name__
+        self.grizzly.scenario.context['host'] = host
         self.request_task.request.name = scenario_type.__name__
 
+        user_type.__scenario__ = self.grizzly.scenario
         user_type.host = host
-        user_type._scenario = self.request_task.request.scenario
-        user = user_type(self.locust_env)
+        user = user_type(self.behave.locust.environment)
 
         if not no_tasks:
             user_type.tasks = [scenario_type]
-            scenario = scenario_type(parent=user)
         else:
             user_type.tasks = []
-            scenario = None
 
-        self.grizzly.state.locust = self.locust_env.create_local_runner()
+        scenario = scenario_type(parent=user)
 
-        return self.locust_env, user, scenario
+        self.grizzly.state.locust = self.behave.locust.environment.create_local_runner()
+
+        return scenario
 
     def __exit__(
         self,
@@ -773,7 +772,7 @@ def step_start_webserver(context: Context, port: int) -> None:
 
         # create grizzly project
         rc, output = run_command(
-            ['grizzly-cli', 'init', '--with-mq', '--yes', project_name],
+            ['grizzly-cli', 'init', '--yes', project_name],
             cwd=str(test_context),
             env=self._env,
         )

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -836,6 +836,7 @@ def step_start_webserver(context: Context, port: int) -> None:
             grizzly_package = '.'
             if self.has_pymqi():
                 grizzly_package = f'{grizzly_package}[mq]'
+                self._env.update({'LD_LIBRARY_PATH': environ.get('LD_LIBRARY_PATH', '')})
 
             rc, output = run_command(
                 ['python3', '-m', 'pip', 'install', grizzly_package],

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from locust import task
 from locust.event import EventHook
 
-from grizzly.context import GrizzlyContextScenario
 from grizzly.users.base import GrizzlyUser
 from grizzly.types.locust import Message, Environment
 from grizzly.types import GrizzlyResponse, RequestMethod
@@ -60,7 +59,7 @@ class TestUser(GrizzlyUser):
     def config_property(self, value: Optional[str]) -> None:
         self._config_property = value
 
-    def request(self, request: RequestTask) -> GrizzlyResponse:
+    def request(self, parent: GrizzlyScenario, request: RequestTask) -> GrizzlyResponse:
         raise RequestCalled(request)
 
 
@@ -70,6 +69,7 @@ class TestScenario(GrizzlyScenario):
     @task
     def task(self) -> None:
         self.user.request(
+            self,
             RequestTask(RequestMethod.POST, name='test', endpoint='payload.j2.json')
         )
 
@@ -82,8 +82,8 @@ class TestTask(GrizzlyTask):
     call_count: int
     task_call_count: int
 
-    def __init__(self, name: Optional[str] = None, scenario: Optional[GrizzlyContextScenario] = None) -> None:
-        super().__init__(scenario)
+    def __init__(self, name: Optional[str] = None) -> None:
+        super().__init__()
         self.name = name
         self.call_count = 0
         self.task_call_count = 0

--- a/tests/unit/test_grizzly/listeners/test___init__.py
+++ b/tests/unit/test_grizzly/listeners/test___init__.py
@@ -87,7 +87,7 @@ def test_init_master(listener_test_mocker: None, caplog: LogCaptureFixture, griz
     try:
         grizzly_fixture()
         grizzly = grizzly_fixture.grizzly
-        runner = MasterRunner(grizzly_fixture.locust_env, '0.0.0.0', 5555)
+        runner = MasterRunner(grizzly_fixture.behave.locust.environment, '0.0.0.0', 5555)
         grizzly.state.locust = runner
 
         init_function = init(grizzly, {})
@@ -139,7 +139,7 @@ def test_init_worker(listener_test_mocker: None, grizzly_fixture: GrizzlyFixture
         init_function = init(grizzly)
         assert callable(init_function)
 
-        runner = WorkerRunner(grizzly_fixture.locust_env, 'localhost', 5555)
+        runner = WorkerRunner(grizzly_fixture.behave.locust.environment, 'localhost', 5555)
 
         grizzly.state.locust = runner
 
@@ -181,7 +181,7 @@ def test_init_local(listener_test_mocker: None, grizzly_fixture: GrizzlyFixture)
 
     try:
         grizzly = grizzly_fixture.grizzly
-        runner = LocalRunner(grizzly_fixture.locust_env)
+        runner = LocalRunner(grizzly_fixture.behave.locust.environment)
         grizzly.state.locust = runner
 
         init_function = init(grizzly, {})
@@ -248,7 +248,7 @@ def test_init_statistics_listener(mocker: MockerFixture, locust_fixture: LocustF
     try:
         grizzly = GrizzlyContext()
 
-        environment = locust_fixture.env
+        environment = locust_fixture.environment
 
         environment.events.quitting._handlers = []
         environment.events.spawning_complete._handlers = []
@@ -289,7 +289,7 @@ def test_locust_test_start(listener_test_mocker: None, grizzly_fixture: GrizzlyF
         scenario = Scenario(filename=None, line=None, keyword='', name='Test Scenario')
         grizzly.scenarios.create(scenario)
         grizzly.scenario.iterations = -1
-        runner = MasterRunner(grizzly_fixture.locust_env, '0.0.0.0', 5555)
+        runner = MasterRunner(grizzly_fixture.behave.locust.environment, '0.0.0.0', 5555)
         grizzly.state.locust = runner
 
         locust_test_start(grizzly)(grizzly.state.locust.environment)
@@ -343,7 +343,7 @@ def test_quitting(mocker: MockerFixture, listener_test_mocker: None, grizzly_fix
 
     try:
         grizzly = grizzly_fixture.grizzly
-        runner = MasterRunner(grizzly_fixture.locust_env, '0.0.0.0', 5555)
+        runner = MasterRunner(grizzly_fixture.behave.locust.environment, '0.0.0.0', 5555)
         grizzly.state.locust = runner
 
         init_testdata = _init_testdata_producer(grizzly, '5557', {})
@@ -480,7 +480,7 @@ def test_validate_result(mocker: MockerFixture, listener_test_mocker: None, capl
 
 
 def test_grizzly_worker_quit_non_worker(locust_fixture: LocustFixture, caplog: LogCaptureFixture) -> None:
-    environment = locust_fixture.env
+    environment = locust_fixture.environment
     environment.runner = LocalRunner(environment=environment)
 
     with caplog.at_level(logging.DEBUG):
@@ -494,7 +494,7 @@ def test_grizzly_worker_quit_non_worker(locust_fixture: LocustFixture, caplog: L
 
 
 def test_grizzly_worker_quit_worker(listener_test_mocker: None, locust_fixture: LocustFixture, caplog: LogCaptureFixture, mocker: MockerFixture) -> None:
-    environment = locust_fixture.env
+    environment = locust_fixture.environment
     environment.runner = WorkerRunner(environment=environment, master_host='localhost', master_port=1337)
 
     runner_stop_mock = mocker.patch.object(environment.runner, 'stop', autospec=True)

--- a/tests/unit/test_grizzly/listeners/test_appinsights.py
+++ b/tests/unit/test_grizzly/listeners/test_appinsights.py
@@ -42,33 +42,33 @@ class TestAppInsightsListener:
         patch_azureloghandler()
 
         # fire_deprecated_request_handlers is already an internal event handler for the request event
-        assert len(locust_fixture.env.events.request._handlers) == 1
+        assert len(locust_fixture.environment.events.request._handlers) == 1
 
         with pytest.raises(AssertionError) as ae:
-            ApplicationInsightsListener(locust_fixture.env, '?')
+            ApplicationInsightsListener(locust_fixture.environment, '?')
         assert 'IngestionEndpoint was neither set as the hostname or in the query string' in str(ae)
 
         with pytest.raises(AssertionError) as ae:
-            ApplicationInsightsListener(locust_fixture.env, '?IngestionEndpoint=insights.test.com')
+            ApplicationInsightsListener(locust_fixture.environment, '?IngestionEndpoint=insights.test.com')
         assert 'InstrumentationKey not found in' in str(ae)
 
         try:
-            listener = ApplicationInsightsListener(locust_fixture.env, '?IngestionEndpoint=insights.test.com&InstrumentationKey=asdfasdfasdfasdf')
+            listener = ApplicationInsightsListener(locust_fixture.environment, '?IngestionEndpoint=insights.test.com&InstrumentationKey=asdfasdfasdfasdf')
 
-            assert len(locust_fixture.env.events.request._handlers) == 2
+            assert len(locust_fixture.environment.events.request._handlers) == 2
             assert listener.testplan == 'appinsightstestplan'
         finally:
             # remove ApplicationInsightsListener
-            locust_fixture.env.events.request._handlers.pop()
+            locust_fixture.environment.events.request._handlers.pop()
 
         try:
-            listener = ApplicationInsightsListener(locust_fixture.env, 'https://insights.test.com?InstrumentationKey=asdfasdfasdfasdf&Testplan=test___init__')
+            listener = ApplicationInsightsListener(locust_fixture.environment, 'https://insights.test.com?InstrumentationKey=asdfasdfasdfasdf&Testplan=test___init__')
 
-            assert len(locust_fixture.env.events.request._handlers) == 2
+            assert len(locust_fixture.environment.events.request._handlers) == 2
             assert listener.testplan == 'test___init__'
         finally:
             # remove ApplicationInsightsListener
-            locust_fixture.env.events.request._handlers.pop()
+            locust_fixture.environment.events.request._handlers.pop()
 
     @pytest.mark.usefixtures('patch_azureloghandler')
     def test_request(self, locust_fixture: LocustFixture, patch_azureloghandler: Callable[[], None], mocker: MockerFixture, caplog: LogCaptureFixture) -> None:
@@ -101,7 +101,7 @@ class TestAppInsightsListener:
         )
 
         try:
-            listener = ApplicationInsightsListener(locust_fixture.env, 'https://insights.test.com?InstrumentationKey=asdfasdfasdfasdf')
+            listener = ApplicationInsightsListener(locust_fixture.environment, 'https://insights.test.com?InstrumentationKey=asdfasdfasdfasdf')
             listener.request('GET', '/api/v1/test', 133.7, 200, None)
 
             mocker.patch(
@@ -118,13 +118,13 @@ class TestAppInsightsListener:
             assert 'failed to write metric for "GET /api/v2/test' in caplog.text
             caplog.clear()
         finally:
-            locust_fixture.env.events.request._handlers.pop()
+            locust_fixture.environment.events.request._handlers.pop()
 
     @pytest.mark.usefixtures('patch_azureloghandler')
     def test__create_custom_dimensions_dict(self, locust_fixture: LocustFixture, patch_azureloghandler: Callable[[], None]) -> None:
         patch_azureloghandler()
         try:
-            listener = ApplicationInsightsListener(locust_fixture.env, 'https://insights.test.com?InstrumentationKey=asdfasdfasdfasdf')
+            listener = ApplicationInsightsListener(locust_fixture.environment, 'https://insights.test.com?InstrumentationKey=asdfasdfasdfasdf')
 
             expected_keys = [
                 'thread_count', 'target_user_count', 'spawn_rate', 'method', 'result', 'response_time', 'response_length', 'endpoint', 'testplan', 'exception'
@@ -145,13 +145,13 @@ class TestAppInsightsListener:
             assert custom_dimensions.get('endpoint', None) == '/api/v1/test'
             assert custom_dimensions.get('testplan', None) == 'appinsightstestplan'
         finally:
-            locust_fixture.env.events.request._handlers.pop()
+            locust_fixture.environment.events.request._handlers.pop()
 
     @pytest.mark.usefixtures('patch_azureloghandler')
     def test__safe_return_runner_values(self, locust_fixture: LocustFixture, patch_azureloghandler: Callable[[], None]) -> None:
         patch_azureloghandler()
         try:
-            listener = ApplicationInsightsListener(locust_fixture.env, 'https://insights.test.com?InstrumentationKey=asdfasdfasdfasdf')
+            listener = ApplicationInsightsListener(locust_fixture.environment, 'https://insights.test.com?InstrumentationKey=asdfasdfasdfasdf')
 
             expected_keys = ['thread_count', 'target_user_count', 'spawn_rate']
 
@@ -167,15 +167,15 @@ class TestAppInsightsListener:
             assert runner_values.get('target_user_count', None) == '0'
             assert runner_values.get('spawn_rate', None) == ''
 
-            locust_fixture.env.runner = None
-            locust_fixture.env.runner = locust_fixture.env.create_local_runner()
+            locust_fixture.environment.runner = None
+            locust_fixture.environment.runner = locust_fixture.environment.create_local_runner()
 
             runner_values = listener._safe_return_runner_values()
             assert runner_values.get('thread_count', None) == '0'
             assert runner_values.get('target_user_count', None) == '0'
             assert runner_values.get('spawn_rate', None) == ''
 
-            listener.environment.runner = locust_fixture.env.runner = None
+            listener.environment.runner = locust_fixture.environment.runner = None
 
             assert listener._safe_return_runner_values() == {
                 'thread_count': '',
@@ -183,4 +183,4 @@ class TestAppInsightsListener:
                 'spawn_rate': '',
             }
         finally:
-            locust_fixture.env.events.request._handlers.pop()
+            locust_fixture.environment.events.request._handlers.pop()

--- a/tests/unit/test_grizzly/listeners/test_influxdb.py
+++ b/tests/unit/test_grizzly/listeners/test_influxdb.py
@@ -173,47 +173,47 @@ class TestInfluxDbListener:
     @pytest.mark.usefixtures('patch_influxdblistener')
     def test___init__(self, locust_fixture: LocustFixture, patch_influxdblistener: Callable[[], None]) -> None:
         with pytest.raises(AssertionError) as ae:
-            InfluxDbListener(locust_fixture.env, '')
+            InfluxDbListener(locust_fixture.environment, '')
         assert 'hostname not found in' in str(ae)
 
         with pytest.raises(AssertionError) as ae:
-            InfluxDbListener(locust_fixture.env, 'https://influx.test.com')
+            InfluxDbListener(locust_fixture.environment, 'https://influx.test.com')
         assert 'database was not found in' in str(ae)
 
         with pytest.raises(AssertionError) as ae:
-            InfluxDbListener(locust_fixture.env, 'https://influx.test.com/testdb')
+            InfluxDbListener(locust_fixture.environment, 'https://influx.test.com/testdb')
         assert 'Testplan not found in' in str(ae)
 
         patch_influxdblistener()
 
-        assert len(locust_fixture.env.events.request._handlers) == 1  # interally added handler for deprecated request events
+        assert len(locust_fixture.environment.events.request._handlers) == 1  # interally added handler for deprecated request events
 
-        listener = InfluxDbListener(locust_fixture.env, 'https://influx.test.com/testdb?Testplan=unittest-plan')
+        listener = InfluxDbListener(locust_fixture.environment, 'https://influx.test.com/testdb?Testplan=unittest-plan')
 
-        assert len(locust_fixture.env.events.request._handlers) == 2
+        assert len(locust_fixture.environment.events.request._handlers) == 2
         assert listener.influx_port == 8086
         assert listener._testplan == 'unittest-plan'
         assert listener._target_environment is None
         assert listener._hostname == socket.gethostname()
-        assert listener.environment is locust_fixture.env
+        assert listener.environment is locust_fixture.environment
         assert listener._username == os.getenv('USER', 'unknown')
         assert listener._events == []
         assert not listener._finished
         assert listener._profile_name == ''
         assert listener._description == ''
 
-        locust_fixture.env.events.request._handlers.pop()
+        locust_fixture.environment.events.request._handlers.pop()
 
         listener = InfluxDbListener(
-            locust_fixture.env,
+            locust_fixture.environment,
             'https://influx.test.com:1337/testdb?Testplan=unittest-plan&TargetEnvironment=local&ProfileName=unittest-profile&Description=unittesting',
         )
-        assert len(locust_fixture.env.events.request._handlers) == 2
+        assert len(locust_fixture.environment.events.request._handlers) == 2
         assert listener.influx_port == 1337
         assert listener._testplan == 'unittest-plan'
         assert listener._target_environment == 'local'
         assert listener._hostname == socket.gethostname()
-        assert listener.environment is locust_fixture.env
+        assert listener.environment is locust_fixture.environment
         assert listener._username == os.getenv('USER', 'unknown')
         assert listener._events == []
         assert not listener._finished
@@ -237,7 +237,7 @@ class TestInfluxDbListener:
         )
 
         listener = InfluxDbListener(
-            locust_fixture.env,
+            locust_fixture.environment,
             'https://influx.test.com:1337/testdb?Testplan=unittest-plan&TargetEnvironment=local&ProfileName=unittest-profile&Description=unittesting',
         )
 
@@ -275,7 +275,7 @@ class TestInfluxDbListener:
         patch_influxdblistener()
 
         listener = InfluxDbListener(
-            locust_fixture.env,
+            locust_fixture.environment,
             'https://influx.test.com:1337/testdb?Testplan=unittest-plan&TargetEnvironment=local&ProfileName=unittest-profile&Description=unittesting',
         )
 
@@ -340,7 +340,7 @@ class TestInfluxDbListener:
         datetime_mock.now.return_value = expected_datetime
 
         listener = InfluxDbListener(
-            grizzly_fixture.locust_env,
+            grizzly_fixture.behave.locust.environment,
             'https://influx.test.com:1337/testdb?Testplan=unittest-plan&TargetEnvironment=local&ProfileName=unittest-profile&Description=unittesting',
         )
 
@@ -408,7 +408,7 @@ class TestInfluxDbListener:
                     'result': 'Failure',
                     'testplan': 'unittest-plan',
                     'hostname': get_hostname(),
-                    'scenario': '001 test-scenario',
+                    'scenario': '001 test scenario',
                     'TEST1': 'unittest-1',
                     'TEST2': 'unittest-2',
                 }
@@ -442,7 +442,7 @@ class TestInfluxDbListener:
             return logger_call
 
         listener = InfluxDbListener(
-            locust_fixture.env,
+            locust_fixture.environment,
             'https://influx.example.com:1337/testdb?Testplan=unittest-plan&TargetEnvironment=local&ProfileName=unittest-profile&Description=unittesting',
         )
 
@@ -466,7 +466,7 @@ class TestInfluxDbListener:
         self, locust_fixture: LocustFixture, mocker: MockerFixture, caplog: LogCaptureFixture,
     ) -> None:
         listener = InfluxDbListener(
-            locust_fixture.env,
+            locust_fixture.environment,
             'https://influx.example.com:1337/testdb?Testplan=unittest-plan&TargetEnvironment=local&ProfileName=unittest-profile&Description=unittesting',
         )
         mocker.patch.object(listener, '_create_metrics', side_effect=[Exception])
@@ -481,7 +481,7 @@ class TestInfluxDbListener:
         patch_influxdblistener()
 
         listener = InfluxDbListener(
-            locust_fixture.env,
+            locust_fixture.environment,
             'https://influx.example.com:1337/testdb?Testplan=unittest-plan&TargetEnvironment=local&ProfileName=unittest-profile&Description=unittesting',
         )
         expected_keys = ['response_time', 'response_length']

--- a/tests/unit/test_grizzly/scenarios/test_iterator.py
+++ b/tests/unit/test_grizzly/scenarios/test_iterator.py
@@ -33,15 +33,15 @@ if TYPE_CHECKING:
 class TestIterationScenario:
     def test_initialize(self, grizzly_fixture: GrizzlyFixture) -> None:
         reload(iterator)
-        _, _, scenario = grizzly_fixture(scenario_type=iterator.IteratorScenario)
-        assert isinstance(scenario, iterator.IteratorScenario)
-        assert issubclass(scenario.__class__, SequentialTaskSet)
-        assert scenario.pace_time is None
+        parent = grizzly_fixture(scenario_type=iterator.IteratorScenario)
+        assert isinstance(parent, iterator.IteratorScenario)
+        assert issubclass(parent.__class__, SequentialTaskSet)
+        assert parent.pace_time is None
 
     def test_render(self, grizzly_fixture: GrizzlyFixture) -> None:
-        _, _, scenario = grizzly_fixture(scenario_type=iterator.IteratorScenario)
+        parent = grizzly_fixture(scenario_type=iterator.IteratorScenario)
 
-        assert isinstance(scenario, iterator.IteratorScenario)
+        assert isinstance(parent, iterator.IteratorScenario)
 
         @templatingfilter
         def sarcasm(value: str) -> str:
@@ -54,24 +54,24 @@ class TestIterationScenario:
 
             return ''.join(sarcastic_value)
 
-        scenario.user._context['variables'].update({'are': 'foo'})
-        assert scenario.render('how {{ are }} we {{ doing | sarcasm }} today', variables={'doing': 'bar'}) == 'how foo we BaR today'
+        parent.user._context['variables'].update({'are': 'foo'})
+        assert parent.render('how {{ are }} we {{ doing | sarcasm }} today', variables={'doing': 'bar'}) == 'how foo we BaR today'
 
     def test_populate(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
         reload(iterator)
-        _, user, scenario = grizzly_fixture(scenario_type=iterator.IteratorScenario)
+        parent = grizzly_fixture(scenario_type=iterator.IteratorScenario)
         request = grizzly_fixture.request_task.request
         request.endpoint = '/api/v1/test'
         try:
             iterator.IteratorScenario.populate(request)
-            assert isinstance(scenario, iterator.IteratorScenario)
-            assert len(scenario.tasks) == 3
+            assert isinstance(parent, iterator.IteratorScenario)
+            assert len(parent.tasks) == 3
 
-            task_method = scenario.tasks[-2]
+            task_method = parent.tasks[-2]
 
             assert callable(task_method)
             with pytest.raises(RequestCalled) as e:
-                task_method(scenario)
+                task_method(parent)
             assert e.value.endpoint == '/api/v1/test' and e.value.request is request
 
             def generate_mocked_wait(sleep_time: float) -> None:
@@ -85,38 +85,38 @@ class TestIterationScenario:
 
             generate_mocked_wait(1.5)
             iterator.IteratorScenario.populate(WaitTask(time_expression='1.5'))
-            assert len(scenario.tasks) == 4
+            assert len(parent.tasks) == 4
 
-            task_method = scenario.tasks[-2]
+            task_method = parent.tasks[-2]
             assert callable(task_method)
-            task_method(scenario)
+            task_method(parent)
 
             iterator.IteratorScenario.populate(LogMessageTask(message='hello {{ world }}'))
-            assert len(scenario.tasks) == 5
+            assert len(parent.tasks) == 5
 
-            logger_spy = mocker.spy(scenario.logger, 'info')
+            logger_spy = mocker.spy(parent.logger, 'info')
 
-            task_method = scenario.tasks[-2]
+            task_method = parent.tasks[-2]
             assert callable(task_method)
-            task_method(scenario)
+            task_method(parent)
 
             assert logger_spy.call_count == 1
             args, _ = logger_spy.call_args_list[0]
             assert args[0] == 'hello '
 
-            user.set_context_variable('world', 'world!')
+            parent.user.set_context_variable('world', 'world!')
 
-            task_method(scenario)
+            task_method(parent)
 
             assert logger_spy.call_count == 2
             args, _ = logger_spy.call_args_list[1]
             assert args[0] == 'hello world!'
 
-            first_task = scenario.tasks[0]
+            first_task = parent.tasks[0]
             assert isinstance(first_task, FunctionType)
             assert first_task.__name__ == 'iterator'
 
-            last_task = scenario.tasks[-1]
+            last_task = parent.tasks[-1]
             assert isinstance(last_task, FunctionType)
             assert last_task.__name__ == 'pace'
         finally:
@@ -126,7 +126,7 @@ class TestIterationScenario:
         reload(iterator)
 
         try:
-            _, _, scenario = grizzly_fixture(scenario_type=iterator.IteratorScenario)
+            parent = grizzly_fixture(scenario_type=iterator.IteratorScenario)
 
             def TestdataConsumer__init__(self: 'TestdataConsumer', scenario: 'GrizzlyScenario', address: str, identifier: str) -> None:
                 pass
@@ -144,19 +144,19 @@ class TestIterationScenario:
                 TestdataConsumer_on_stop,
             )
 
-            assert scenario is not None
+            assert parent is not None
 
-            mocker.patch.object(scenario, 'prefetch', return_value=None)
+            mocker.patch.object(parent, 'prefetch', return_value=None)
 
             with pytest.raises(StopUser):
-                scenario.on_start()
+                parent.on_start()
 
             environ['TESTDATA_PRODUCER_ADDRESS'] = 'localhost:5555'
 
-            scenario.on_start()
+            parent.on_start()
 
             with pytest.raises(StopUser):
-                scenario.on_stop()
+                parent.on_stop()
         finally:
             try:
                 del environ['TESTDATA_PRODUCER_ADDRESS']
@@ -165,26 +165,26 @@ class TestIterationScenario:
 
     def test_prefetch(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
         reload(iterator)
-        _, _, scenario = grizzly_fixture(scenario_type=iterator.IteratorScenario)
+        parent = grizzly_fixture(scenario_type=iterator.IteratorScenario)
 
-        assert isinstance(scenario, iterator.IteratorScenario)
+        assert isinstance(parent, iterator.IteratorScenario)
 
-        iterator_mock = mocker.patch.object(scenario, 'iterator', return_value=None)
+        iterator_mock = mocker.patch.object(parent, 'iterator', return_value=None)
 
-        scenario.prefetch()
+        parent.prefetch()
 
         iterator_mock.assert_called_once_with(prefetch=True)
 
     def test_iterator(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
         reload(iterator)
-        _, user, scenario = grizzly_fixture(scenario_type=iterator.IteratorScenario)
+        parent = grizzly_fixture(scenario_type=iterator.IteratorScenario)
 
         grizzly = grizzly_fixture.grizzly
 
-        assert isinstance(scenario, iterator.IteratorScenario)
-        assert not getattr(scenario, '_prefetch', True)
+        assert isinstance(parent, iterator.IteratorScenario)
+        assert not getattr(parent, '_prefetch', True)
 
-        scenario.consumer = TestdataConsumer(scenario, identifier='test')
+        parent.consumer = TestdataConsumer(parent, identifier='test')
 
         def mock_request(data: Optional[Dict[str, Any]]) -> None:
             def request(self: 'TestdataConsumer', scenario: str) -> Optional[Dict[str, Any]]:
@@ -204,16 +204,16 @@ class TestIterationScenario:
         mock_request(None)
 
         with pytest.raises(StopScenario):
-            scenario.iterator()
+            parent.iterator()
 
-        assert user.context_variables == {}
+        assert parent.user.context_variables == {}
 
         mock_request({})
 
         with pytest.raises(StopScenario):
-            scenario.iterator()
+            parent.iterator()
 
-        assert user.context_variables == {}
+        assert parent.user.context_variables == {}
 
         mock_request({
             'variables': {
@@ -225,12 +225,12 @@ class TestIterationScenario:
             },
         })
 
-        scenario.iterator(prefetch=True)
+        parent.iterator(prefetch=True)
 
-        assert user.context_variables['AtomicIntegerIncrementer'].messageID == 1337
-        assert user.context_variables['AtomicCsvReader'].test.header1 == 'value1'
-        assert user.context_variables['AtomicCsvReader'].test.header2 == 'value2'
-        assert getattr(scenario, '_prefetch', False)
+        assert parent.user.context_variables['AtomicIntegerIncrementer'].messageID == 1337
+        assert parent.user.context_variables['AtomicCsvReader'].test.header1 == 'value1'
+        assert parent.user.context_variables['AtomicCsvReader'].test.header2 == 'value2'
+        assert getattr(parent, '_prefetch', False)
 
         mock_request({
             'variables': {
@@ -242,34 +242,34 @@ class TestIterationScenario:
             },
         })
 
-        scenario.iterator()
+        parent.iterator()
 
-        assert user.context_variables['AtomicIntegerIncrementer'].messageID == 1337
-        assert user.context_variables['AtomicCsvReader'].test.header1 == 'value1'
-        assert user.context_variables['AtomicCsvReader'].test.header2 == 'value2'
-        assert not getattr(scenario, '_prefetch', True)
+        assert parent.user.context_variables['AtomicIntegerIncrementer'].messageID == 1337
+        assert parent.user.context_variables['AtomicCsvReader'].test.header1 == 'value1'
+        assert parent.user.context_variables['AtomicCsvReader'].test.header2 == 'value2'
+        assert not getattr(parent, '_prefetch', True)
 
-        scenario.iterator()
+        parent.iterator()
 
-        assert user.context_variables['AtomicIntegerIncrementer'].messageID == 1338
-        assert user.context_variables['AtomicCsvReader'].test.header1 == 'value3'
-        assert user.context_variables['AtomicCsvReader'].test.header2 == 'value4'
-        assert not getattr(scenario, '_prefetch', True)
+        assert parent.user.context_variables['AtomicIntegerIncrementer'].messageID == 1338
+        assert parent.user.context_variables['AtomicCsvReader'].test.header1 == 'value3'
+        assert parent.user.context_variables['AtomicCsvReader'].test.header2 == 'value4'
+        assert not getattr(parent, '_prefetch', True)
 
     def test_pace(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
         reload(iterator)
-        _, _, scenario = grizzly_fixture(scenario_type=iterator.IteratorScenario)
+        parent = grizzly_fixture(scenario_type=iterator.IteratorScenario)
 
-        assert isinstance(scenario, iterator.IteratorScenario)
+        assert isinstance(parent, iterator.IteratorScenario)
 
         perf_counter_spy = mocker.patch('grizzly.scenarios.iterator.perf_counter', return_value=1000)
-        request_spy = mocker.spy(scenario.user.environment.events.request, 'fire')
+        request_spy = mocker.spy(parent.user.environment.events.request, 'fire')
         gsleep_spy = mocker.patch('grizzly.scenarios.iterator.gsleep', return_value=None)
 
         # return directly, we don't have a pace
-        assert getattr(scenario, 'pace_time', '') is None
+        assert getattr(parent, 'pace_time', '') is None
 
-        scenario.pace()
+        parent.pace()
 
         assert perf_counter_spy.call_count == 0
         assert request_spy.call_count == 0
@@ -280,16 +280,16 @@ class TestIterationScenario:
         gsleep_spy.reset_mock()
 
         # invalid float for pace_time
-        scenario.pace_time = 'asdf'
+        parent.pace_time = 'asdf'
         with pytest.raises(StopUser):
-            scenario.pace()
+            parent.pace()
 
         assert perf_counter_spy.call_count == 2
         assert request_spy.call_count == 1
         assert gsleep_spy.call_count == 0
         _, kwargs = request_spy.call_args_list[-1]
         assert kwargs.get('request_type', None) == 'PACE'
-        assert kwargs.get('name', None) == scenario.user._scenario.locust_name
+        assert kwargs.get('name', None) == parent.user._scenario.locust_name
         assert kwargs.get('response_time', None) == 0
         assert kwargs.get('response_length', None) == 0
         exception = kwargs.get('exception', None)
@@ -301,11 +301,11 @@ class TestIterationScenario:
         gsleep_spy.reset_mock()
 
         # iteration time < specified pace
-        scenario.start = 12.26
-        scenario.pace_time = '3000'
+        parent.start = 12.26
+        parent.pace_time = '3000'
         perf_counter_spy = mocker.patch('grizzly.scenarios.iterator.perf_counter', side_effect=[13.37, 14.48])
 
-        scenario.pace()
+        parent.pace()
 
         assert perf_counter_spy.call_count == 2
         assert request_spy.call_count == 1
@@ -313,7 +313,7 @@ class TestIterationScenario:
 
         _, kwargs = request_spy.call_args_list[-1]
         assert kwargs.get('request_type', None) == 'PACE'
-        assert kwargs.get('name', None) == scenario.user._scenario.locust_name
+        assert kwargs.get('name', None) == parent.user._scenario.locust_name
         assert kwargs.get('response_time', None) == 1110
         assert kwargs.get('response_length', None) == 1
         assert kwargs.get('exception', RuntimeError) is None
@@ -327,10 +327,10 @@ class TestIterationScenario:
         gsleep_spy.reset_mock()
 
         # iteration time > specified pace
-        scenario.pace_time = '500'
+        parent.pace_time = '500'
         perf_counter_spy = mocker.patch('grizzly.scenarios.iterator.perf_counter', side_effect=[13.37, 14.48])
 
-        scenario.pace()
+        parent.pace()
 
         assert perf_counter_spy.call_count == 2
         assert request_spy.call_count == 1
@@ -338,7 +338,7 @@ class TestIterationScenario:
 
         _, kwargs = request_spy.call_args_list[-1]
         assert kwargs.get('request_type', None) == 'PACE'
-        assert kwargs.get('name', None) == scenario.user._scenario.locust_name
+        assert kwargs.get('name', None) == parent.user._scenario.locust_name
         assert kwargs.get('response_time', None) == 1110
         assert kwargs.get('response_length', None) == 0
         exception = kwargs.get('exception', None)
@@ -350,18 +350,18 @@ class TestIterationScenario:
         gsleep_spy.reset_mock()
 
         # templating, no value
-        scenario.pace_time = '{{ foobar }}'
+        parent.pace_time = '{{ foobar }}'
         perf_counter_spy = mocker.patch('grizzly.scenarios.iterator.perf_counter', side_effect=[13.37, 14.48])
 
         with pytest.raises(StopUser):
-            scenario.pace()
+            parent.pace()
 
         assert perf_counter_spy.call_count == 2
         assert request_spy.call_count == 1
         assert gsleep_spy.call_count == 0
         _, kwargs = request_spy.call_args_list[-1]
         assert kwargs.get('request_type', None) == 'PACE'
-        assert kwargs.get('name', None) == scenario.user._scenario.locust_name
+        assert kwargs.get('name', None) == parent.user._scenario.locust_name
         assert kwargs.get('response_time', None) == 1110
         assert kwargs.get('response_length', None) == 0
         exception = kwargs.get('exception', None)
@@ -373,12 +373,12 @@ class TestIterationScenario:
         gsleep_spy.reset_mock()
 
         # iteration time < specified pace, variable
-        scenario.user._context['variables'].update({'pace': '3000'})
-        scenario.start = 12.26
-        scenario.pace_time = '{{ pace }}'
+        parent.user._context['variables'].update({'pace': '3000'})
+        parent.start = 12.26
+        parent.pace_time = '{{ pace }}'
         perf_counter_spy = mocker.patch('grizzly.scenarios.iterator.perf_counter', side_effect=[13.37, 14.48])
 
-        scenario.pace()
+        parent.pace()
 
         assert perf_counter_spy.call_count == 2
         assert request_spy.call_count == 1
@@ -386,7 +386,7 @@ class TestIterationScenario:
 
         _, kwargs = request_spy.call_args_list[-1]
         assert kwargs.get('request_type', None) == 'PACE'
-        assert kwargs.get('name', None) == scenario.user._scenario.locust_name
+        assert kwargs.get('name', None) == parent.user._scenario.locust_name
         assert kwargs.get('response_time', None) == 1110
         assert kwargs.get('response_length', None) == 1
         assert kwargs.get('exception', RuntimeError) is None
@@ -400,11 +400,11 @@ class TestIterationScenario:
         gsleep_spy.reset_mock()
 
         # iteration time > specified pace, templating
-        scenario.user._context['variables'].update({'pace': '500'})
-        scenario.pace_time = '{{ pace }}'
+        parent.user._context['variables'].update({'pace': '500'})
+        parent.pace_time = '{{ pace }}'
         perf_counter_spy = mocker.patch('grizzly.scenarios.iterator.perf_counter', side_effect=[13.37, 14.48])
 
-        scenario.pace()
+        parent.pace()
 
         assert perf_counter_spy.call_count == 2
         assert request_spy.call_count == 1
@@ -412,7 +412,7 @@ class TestIterationScenario:
 
         _, kwargs = request_spy.call_args_list[-1]
         assert kwargs.get('request_type', None) == 'PACE'
-        assert kwargs.get('name', None) == scenario.user._scenario.locust_name
+        assert kwargs.get('name', None) == parent.user._scenario.locust_name
         assert kwargs.get('response_time', None) == 1110
         assert kwargs.get('response_length', None) == 0
         exception = kwargs.get('exception', None)
@@ -425,101 +425,101 @@ class TestIterationScenario:
 
     def test_iteration_stop(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
         reload(iterator)
-        _, _, scenario = grizzly_fixture(scenario_type=iterator.IteratorScenario)
-        assert isinstance(scenario, iterator.IteratorScenario)
+        parent = grizzly_fixture(scenario_type=iterator.IteratorScenario)
+        assert isinstance(parent, iterator.IteratorScenario)
 
-        stats_log_mock = mocker.patch.object(scenario.stats, 'log', return_value=None)
-        stats_log_error_mock = mocker.patch.object(scenario.stats, 'log_error', return_value=None)
+        stats_log_mock = mocker.patch.object(parent.stats, 'log', return_value=None)
+        stats_log_error_mock = mocker.patch.object(parent.stats, 'log_error', return_value=None)
 
         mocker.patch('grizzly.scenarios.iterator.perf_counter', return_value=11.0)
 
-        scenario.start = None
+        parent.start = None
 
-        scenario.iteration_stop(has_error=True)
+        parent.iteration_stop(has_error=True)
 
         assert stats_log_mock.call_count == 0
 
         assert stats_log_error_mock.call_count == 0
 
-        scenario.start = 1.0
+        parent.start = 1.0
 
-        scenario.iteration_stop(has_error=True)
+        parent.iteration_stop(has_error=True)
 
         assert stats_log_mock.call_count == 1
         args, _ = stats_log_mock.call_args_list[-1]
         assert len(args) == 2
         assert args[0] == 10000
-        assert args[1] == (scenario._task_index % scenario.task_count) + 1
+        assert args[1] == (parent._task_index % parent.task_count) + 1
 
         assert stats_log_error_mock.call_count == 1
         args, _ = stats_log_error_mock.call_args_list[-1]
         assert len(args) == 1
         assert args[0] is None
 
-        scenario.iteration_stop(has_error=False)
+        parent.iteration_stop(has_error=False)
 
         assert stats_log_mock.call_count == 2
         args, _ = stats_log_mock.call_args_list[-1]
         assert len(args) == 2
         assert args[0] == 10000
-        assert args[1] == (scenario._task_index % scenario.task_count) + 1
+        assert args[1] == (parent._task_index % parent.task_count) + 1
 
         assert stats_log_error_mock.call_count == 1
 
     def test_wait(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture, caplog: LogCaptureFixture) -> None:
         reload(iterator)
-        _, _, scenario = grizzly_fixture(scenario_type=iterator.IteratorScenario)
+        parent = grizzly_fixture(scenario_type=iterator.IteratorScenario)
 
-        assert isinstance(scenario, iterator.IteratorScenario)
+        assert isinstance(parent, iterator.IteratorScenario)
 
         wait_mocked = mocker.patch('grizzly.scenarios.iterator.GrizzlyScenario.wait', return_value=None)
-        sleep_mocked = mocker.patch.object(scenario, '_sleep', return_value=None)
+        sleep_mocked = mocker.patch.object(parent, '_sleep', return_value=None)
 
-        scenario.user._scenario_state = ScenarioState.STOPPING
-        scenario.user._state = LOCUST_STATE_STOPPING
-        scenario.task_count = 10
-        scenario.current_task_index = 3
+        parent.user._scenario_state = ScenarioState.STOPPING
+        parent.user._state = LOCUST_STATE_STOPPING
+        parent.task_count = 10
+        parent.current_task_index = 3
 
         with caplog.at_level(logging.DEBUG):
-            scenario.wait()
+            parent.wait()
 
         assert wait_mocked.call_count == 0
         assert sleep_mocked.call_count == 1
-        assert scenario.user._state == LOCUST_STATE_RUNNING
+        assert parent.user._state == LOCUST_STATE_RUNNING
         assert len(caplog.messages) == 1
         assert caplog.messages[-1] == 'not finished with scenario, currently at task 4 of 10, let me be!'
         caplog.clear()
 
-        scenario.current_task_index = 9
+        parent.current_task_index = 9
 
         with caplog.at_level(logging.DEBUG):
-            scenario.wait()
+            parent.wait()
 
         assert wait_mocked.call_count == 1
-        assert scenario.user._state == LOCUST_STATE_STOPPING
-        assert scenario.user.scenario_state == ScenarioState.STOPPED
+        assert parent.user._state == LOCUST_STATE_STOPPING
+        assert parent.user.scenario_state == ScenarioState.STOPPED
 
         assert len(caplog.messages) == 2
         assert caplog.messages[-2] == "okay, I'm done with my running tasks now"
         assert caplog.messages[-1] == "scenario state=ScenarioState.STOPPING -> ScenarioState.STOPPED"
         caplog.clear()
 
-        scenario.user._scenario_state = ScenarioState.STOPPED
+        parent.user._scenario_state = ScenarioState.STOPPED
 
         with caplog.at_level(logging.DEBUG):
-            scenario.wait()
+            parent.wait()
 
         assert wait_mocked.call_count == 2
         assert len(caplog.messages) == 0
 
     def test_run(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture, caplog: LogCaptureFixture) -> None:
         reload(iterator)
-        _, user, scenario = grizzly_fixture(scenario_type=iterator.IteratorScenario)
+        parent = grizzly_fixture(scenario_type=iterator.IteratorScenario)
 
-        assert isinstance(scenario, iterator.IteratorScenario)
+        assert isinstance(parent, iterator.IteratorScenario)
 
         # always assume that spawning is complete in unit test
-        scenario.grizzly.state.spawning_complete = True
+        parent.grizzly.state.spawning_complete = True
 
         side_effects: List[Optional[InterruptTaskSet]] = [
             InterruptTaskSet(reschedule=False),
@@ -527,49 +527,49 @@ class TestIterationScenario:
         ]
         side_effects.extend([None] * 10)
 
-        on_stop = mocker.patch.object(scenario, 'on_stop', autospec=True)
+        on_stop = mocker.patch.object(parent, 'on_stop', autospec=True)
         on_start = mocker.patch.object(
-            scenario,
+            parent,
             'on_start',
             side_effect=side_effects,
         )
 
-        mocker.patch.object(scenario, 'tasks', [f'task-{index}' for index in range(0, 10)])
-        scenario.task_count = len(scenario.tasks)
+        mocker.patch.object(parent, 'tasks', [f'task-{index}' for index in range(0, 10)])
+        parent.task_count = len(parent.tasks)
 
-        schedule_task = mocker.patch.object(scenario, 'schedule_task', autospec=True)
-        get_next_task = mocker.patch.object(scenario, 'get_next_task', autospec=True)
-        wait = mocker.patch.object(scenario, 'wait', autospec=True)
-        user_error = mocker.spy(scenario.user.environment.events.user_error, 'fire')
+        schedule_task = mocker.patch.object(parent, 'schedule_task', autospec=True)
+        get_next_task = mocker.patch.object(parent, 'get_next_task', autospec=True)
+        wait = mocker.patch.object(parent, 'wait', autospec=True)
+        user_error = mocker.spy(parent.user.environment.events.user_error, 'fire')
 
         with pytest.raises(RescheduleTask):
-            scenario.run()
+            parent.run()
 
         assert on_start.call_count == 1
 
         with pytest.raises(RescheduleTaskImmediately):
-            scenario.run()
+            parent.run()
 
         assert on_start.call_count == 2
 
-        user._state = LOCUST_STATE_STOPPING
+        parent.user._state = LOCUST_STATE_STOPPING
 
         with pytest.raises(StopUser):
-            scenario.run()
+            parent.run()
 
-        user._state = LOCUST_STATE_RUNNING
+        parent.user._state = LOCUST_STATE_RUNNING
 
         assert on_start.call_count == 3
         assert get_next_task.call_count == 1
         assert schedule_task.call_count == 1
 
-        user.environment.catch_exceptions = False
+        parent.user.environment.catch_exceptions = False
 
-        get_next_task = mocker.patch.object(scenario, 'get_next_task', side_effect=[None, RuntimeError])
-        execute_next_task = mocker.patch.object(scenario, 'execute_next_task', side_effect=[RescheduleTaskImmediately])
+        get_next_task = mocker.patch.object(parent, 'get_next_task', side_effect=[None, RuntimeError])
+        execute_next_task = mocker.patch.object(parent, 'execute_next_task', side_effect=[RescheduleTaskImmediately])
 
         with pytest.raises(RuntimeError):
-            scenario.run()
+            parent.run()
 
         assert on_start.call_count == 4
         assert get_next_task.call_count == 2
@@ -578,15 +578,15 @@ class TestIterationScenario:
         assert wait.call_count == 0
         assert user_error.call_count == 1
         _, kwargs = user_error.call_args_list[-1]
-        assert kwargs.get('user_instance', None) is user
+        assert kwargs.get('user_instance', None) is parent.user
         assert isinstance(kwargs.get('exception', None), RuntimeError)
         assert kwargs.get('tb', None) is not None
 
-        get_next_task = mocker.patch.object(scenario, 'get_next_task', side_effect=[None, RuntimeError])
-        execute_next_task = mocker.patch.object(scenario, 'execute_next_task', side_effect=[RescheduleTask])
+        get_next_task = mocker.patch.object(parent, 'get_next_task', side_effect=[None, RuntimeError])
+        execute_next_task = mocker.patch.object(parent, 'execute_next_task', side_effect=[RescheduleTask])
 
         with pytest.raises(RuntimeError):
-            scenario.run()
+            parent.run()
 
         assert on_start.call_count == 5
         assert get_next_task.call_count == 2
@@ -595,15 +595,15 @@ class TestIterationScenario:
         assert wait.call_count == 1
         assert user_error.call_count == 2
         _, kwargs = user_error.call_args_list[-1]
-        assert kwargs.get('user_instance', None) is user
+        assert kwargs.get('user_instance', None) is parent.user
         assert isinstance(kwargs.get('exception', None), RuntimeError)
         assert kwargs.get('tb', None) is not None
 
-        get_next_task = mocker.patch.object(scenario, 'get_next_task', side_effect=[None, RuntimeError])
-        execute_next_task = mocker.patch.object(scenario, 'execute_next_task')
+        get_next_task = mocker.patch.object(parent, 'get_next_task', side_effect=[None, RuntimeError])
+        execute_next_task = mocker.patch.object(parent, 'execute_next_task')
 
         with pytest.raises(RuntimeError):
-            scenario.run()
+            parent.run()
 
         assert on_start.call_count == 6
         assert get_next_task.call_count == 2
@@ -612,7 +612,7 @@ class TestIterationScenario:
         assert wait.call_count == 2
         assert user_error.call_count == 3
         _, kwargs = user_error.call_args_list[-1]
-        assert kwargs.get('user_instance', None) is user
+        assert kwargs.get('user_instance', None) is parent.user
         assert isinstance(kwargs.get('exception', None), RuntimeError)
         assert kwargs.get('tb', None) is not None
 
@@ -620,11 +620,11 @@ class TestIterationScenario:
         wait.reset_mock()
         schedule_task.reset_mock()
 
-        get_next_task = mocker.patch.object(scenario, 'get_next_task', side_effect=[InterruptTaskSet(reschedule=False), InterruptTaskSet(reschedule=True)])
-        execute_next_task = mocker.patch.object(scenario, 'execute_next_task')
+        get_next_task = mocker.patch.object(parent, 'get_next_task', side_effect=[InterruptTaskSet(reschedule=False), InterruptTaskSet(reschedule=True)])
+        execute_next_task = mocker.patch.object(parent, 'execute_next_task')
 
         with pytest.raises(RescheduleTask):
-            scenario.run()
+            parent.run()
 
         assert on_start.call_count == 7
         assert on_stop.call_count == 1
@@ -635,7 +635,7 @@ class TestIterationScenario:
         assert user_error.call_count == 3
 
         with pytest.raises(RescheduleTaskImmediately):
-            scenario.run()
+            parent.run()
 
         assert on_start.call_count == 8
         assert on_stop.call_count == 2
@@ -645,14 +645,14 @@ class TestIterationScenario:
         assert wait.call_count == 0
         assert user_error.call_count == 3
 
-        scenario._task_index = 10
-        get_next_task = mocker.patch.object(scenario, 'get_next_task', side_effect=[None, RuntimeError])
-        execute_next_task = mocker.patch.object(scenario, 'execute_next_task', side_effect=[RestartScenario])
+        parent._task_index = 10
+        get_next_task = mocker.patch.object(parent, 'get_next_task', side_effect=[None, RuntimeError])
+        execute_next_task = mocker.patch.object(parent, 'execute_next_task', side_effect=[RestartScenario])
 
         with pytest.raises(RuntimeError):
-            scenario.run()
+            parent.run()
 
-        assert scenario._task_index == 20
+        assert parent._task_index == 20
         assert on_start.call_count == 9
         assert on_stop.call_count == 2
         assert get_next_task.call_count == 2
@@ -663,13 +663,13 @@ class TestIterationScenario:
 
         user_error.reset_mock()
         wait.reset_mock()
-        scenario.user.environment.catch_exceptions = True
+        parent.user.environment.catch_exceptions = True
 
-        get_next_task = mocker.patch.object(scenario, 'get_next_task', side_effect=[RuntimeError, StopUser])
+        get_next_task = mocker.patch.object(parent, 'get_next_task', side_effect=[RuntimeError, StopUser])
 
         with caplog.at_level(logging.ERROR):
             with pytest.raises(StopUser):
-                scenario.run()
+                parent.run()
 
         assert wait.call_count == 1
         assert get_next_task.call_count == 2
@@ -677,7 +677,7 @@ class TestIterationScenario:
         assert execute_next_task.call_count == 1
         assert user_error.call_count == 1
         _, kwargs = user_error.call_args_list[-1]
-        assert kwargs.get('user_instance', None) is user
+        assert kwargs.get('user_instance', None) is parent.user
         assert isinstance(kwargs.get('exception', None), RuntimeError)
         assert kwargs.get('tb', None) is not None
         assert 'ERROR' in caplog.text and 'IteratorScenario' in caplog.text
@@ -687,7 +687,7 @@ class TestIterationScenario:
         on_start.side_effect = [StopScenario]
 
         with pytest.raises(StopUser):
-            scenario.run()
+            parent.run()
 
         on_stop.reset_mock()
 
@@ -700,7 +700,7 @@ class TestIterationScenario:
 
         with caplog.at_level(logging.ERROR):
             with pytest.raises(RescheduleTask):
-                scenario.run()
+                parent.run()
 
         on_stop.assert_called_once_with()
         assert caplog.messages == ['on_stop failed']
@@ -709,13 +709,13 @@ class TestIterationScenario:
         on_stop.reset_mock()
 
         # problems in on_stop, in handling of StopScenario
-        scenario.user._scenario_state = ScenarioState.RUNNING
+        parent.user._scenario_state = ScenarioState.RUNNING
         on_stop.side_effect = [RuntimeError]
         get_next_task.side_effect = [StopScenario]
 
         with caplog.at_level(logging.ERROR):
             with pytest.raises(StopUser):
-                scenario.run()
+                parent.run()
 
         on_stop.assert_called_once_with()
         assert caplog.messages == ['on_stop failed']
@@ -737,7 +737,7 @@ class TestIterationScenario:
 
                 return task
 
-        _, user, _ = grizzly_fixture()
+        parent = grizzly_fixture()
 
         mocker.patch('grizzly.scenarios.iterator.gsleep', return_value=None)
 
@@ -745,21 +745,18 @@ class TestIterationScenario:
         try:
             for i in range(1, 6):
                 name = f'test-task-{i}'
-                user.logger.debug(f'populating with {name}')
-                user._scenario.tasks.behave_steps.update({i + 1: name})
+                parent.user._scenario.tasks.behave_steps.update({i + 1: name})
                 iterator.IteratorScenario.populate(TestTask(name=name))
 
             iterator.IteratorScenario.populate(TestErrorTask(name='test-error-task-1'))
-            user.logger.debug('populating with test-error-task-1')
-            user._scenario.tasks.behave_steps.update({7: 'test-error-task-1'})
+            parent.user._scenario.tasks.behave_steps.update({7: 'test-error-task-1'})
 
             for i in range(6, 11):
                 name = f'test-task-{i}'
-                user.logger.debug(f'populating with {name}')
-                user._scenario.tasks.behave_steps.update({i + 2: name})
+                parent.user._scenario.tasks.behave_steps.update({i + 2: name})
                 iterator.IteratorScenario.populate(TestTask(name=name))
 
-            scenario = iterator.IteratorScenario(user)
+            scenario = iterator.IteratorScenario(parent.user)
             scenario.pace_time = '10000'
             mocker.patch.object(scenario, 'prefetch', return_value=None)
 
@@ -799,7 +796,9 @@ class TestIterationScenario:
                 'test-task-5 executed',
                 'executing task 7 of 13: test-error-task-1',
                 'test-error-task-1 executed',
+                'task 7 of 13: test-error-task-1, failed: RestartScenario',
                 'restarting scenario at task 7 of 13',
+                '0 tasks in queue',
                 'executing task 1 of 13: iterator',  # IteratorScenario.iterator()
                 'executing task 2 of 13: test-task-1',
                 'test-task-1 executed',
@@ -855,7 +854,7 @@ class TestIterationScenario:
     def test_on_start(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
         reload(iterator)
 
-        _, user, _ = grizzly_fixture()
+        parent = grizzly_fixture()
 
         class TestOnStartTask(TestTask):
             def __call__(self) -> grizzlytask:
@@ -873,7 +872,7 @@ class TestIterationScenario:
         iterator.IteratorScenario.populate(TestOnStartTask(name='test-on-task-2'))
 
         try:
-            scenario = iterator.IteratorScenario(user)
+            scenario = iterator.IteratorScenario(parent.user)
 
             testdata_consumer_mock = mocker.patch('grizzly.scenarios.TestdataConsumer.__init__', return_value=None)
             prefetch_mock = mocker.patch.object(scenario, 'prefetch', return_value=None)
@@ -919,7 +918,7 @@ class TestIterationScenario:
     def test_on_stop(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
         reload(iterator)
 
-        _, user, _ = grizzly_fixture()
+        parent = grizzly_fixture()
 
         class TestOnStopTask(TestTask):
             def __call__(self) -> grizzlytask:
@@ -937,7 +936,7 @@ class TestIterationScenario:
         iterator.IteratorScenario.populate(TestOnStopTask(name='test-on-task-2'))
 
         try:
-            scenario = iterator.IteratorScenario(user)
+            scenario = iterator.IteratorScenario(parent.user)
 
             testdata_consumer_mock = mocker.MagicMock()
             scenario.consumer = testdata_consumer_mock

--- a/tests/unit/test_grizzly/scenarios/test_iterator.py
+++ b/tests/unit/test_grizzly/scenarios/test_iterator.py
@@ -518,6 +518,9 @@ class TestIterationScenario:
 
         assert isinstance(scenario, iterator.IteratorScenario)
 
+        # always assume that spawning is complete in unit test
+        scenario.grizzly.state.spawning_complete = True
+
         side_effects: List[Optional[InterruptTaskSet]] = [
             InterruptTaskSet(reschedule=False),
             InterruptTaskSet(reschedule=True),

--- a/tests/unit/test_grizzly/steps/background/test_setup.py
+++ b/tests/unit/test_grizzly/steps/background/test_setup.py
@@ -111,6 +111,7 @@ def test_step_setup_save_statistics(behave_fixture: BehaveFixture) -> None:
 def test_step_setup_stop_user_on_failure(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     assert not behave.config.stop
     assert grizzly.scenario.failure_exception is None
@@ -124,6 +125,7 @@ def test_step_setup_stop_user_on_failure(behave_fixture: BehaveFixture) -> None:
 def test_step_setup_restart_scenario_on_failure(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     assert not behave.config.stop
     assert grizzly.scenario.failure_exception is None

--- a/tests/unit/test_grizzly/steps/background/test_shapes.py
+++ b/tests/unit/test_grizzly/steps/background/test_shapes.py
@@ -28,6 +28,7 @@ def test_step_shapes_user_count(behave_fixture: BehaveFixture) -> None:
 
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
     assert grizzly.setup.user_count == 0
 
     step_impl(behave, '10', grammar='user')
@@ -72,6 +73,7 @@ def test_step_shapes_spawn_rate(behave_fixture: BehaveFixture) -> None:
 
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
     assert grizzly.setup.spawn_rate is None
 
     # spawn_rate must be <= user_count

--- a/tests/unit/test_grizzly/steps/scenario/test_response.py
+++ b/tests/unit/test_grizzly/steps/scenario/test_response.py
@@ -107,7 +107,7 @@ def test_step_response_save_matches_metadata(grizzly_fixture: GrizzlyFixture) ->
 
 
 def test_step_response_save_matches_payload(grizzly_fixture: GrizzlyFixture) -> None:
-    behave = grizzly_fixture.behave
+    behave = grizzly_fixture.behave.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
     request = cast(RequestTask, grizzly.scenario.tasks()[0])
 
@@ -139,7 +139,7 @@ def test_step_response_save_matches_payload(grizzly_fixture: GrizzlyFixture) -> 
 
 
 def test_step_response_save_metadata(grizzly_fixture: GrizzlyFixture) -> None:
-    behave = grizzly_fixture.behave
+    behave = grizzly_fixture.behave.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
     request = cast(RequestTask, grizzly.scenario.tasks()[0])
 
@@ -171,7 +171,7 @@ def test_step_response_save_metadata(grizzly_fixture: GrizzlyFixture) -> None:
 
 
 def test_step_response_save_payload(grizzly_fixture: GrizzlyFixture) -> None:
-    behave = grizzly_fixture.behave
+    behave = grizzly_fixture.behave.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
     request = cast(RequestTask, grizzly.scenario.tasks()[0])
 
@@ -203,7 +203,7 @@ def test_step_response_save_payload(grizzly_fixture: GrizzlyFixture) -> None:
 
 
 def test_step_response_validate_metadata(grizzly_fixture: GrizzlyFixture) -> None:
-    behave = grizzly_fixture.behave
+    behave = grizzly_fixture.behave.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
     request = cast(RequestTask, grizzly.scenario.tasks()[0])
 
@@ -226,7 +226,7 @@ def test_step_response_validate_metadata(grizzly_fixture: GrizzlyFixture) -> Non
 
 
 def test_step_response_validate_payload(grizzly_fixture: GrizzlyFixture) -> None:
-    behave = grizzly_fixture.behave
+    behave = grizzly_fixture.behave.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
     request = cast(RequestTask, grizzly.scenario.tasks()[0])
 
@@ -248,6 +248,7 @@ def test_step_response_validate_payload(grizzly_fixture: GrizzlyFixture) -> None
 def test_step_response_allow_status_codes(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
     with pytest.raises(AssertionError) as ve:
         step_response_allow_status_codes(behave, '-200')
     assert 'there are no requests in the scenario' in str(ve)
@@ -277,6 +278,7 @@ def test_step_response_allow_status_codes(behave_fixture: BehaveFixture) -> None
 def test_step_response_allow_status_codes_table(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     with pytest.raises(AssertionError) as ae:
         step_response_allow_status_codes_table(behave)
@@ -309,7 +311,6 @@ def test_step_response_allow_status_codes_table(behave_fixture: BehaveFixture) -
     assert 'data table does not have column "status"' in str(ae)
 
     request = RequestTask(RequestMethod.GET, name='no-code', endpoint='/api/test')
-    request.scenario = grizzly.scenario
     grizzly.scenario.tasks().insert(0, request)
 
     rows = []
@@ -342,7 +343,6 @@ def test_step_response_allow_status_codes_table(behave_fixture: BehaveFixture) -
     request = RequestTask(RequestMethod.GET, name='test-get', endpoint='/api/test')
     grizzly.scenario.tasks.add(request)
     request = RequestTask(RequestMethod.GET, name='no-code', endpoint='/api/test')
-    request.scenario = grizzly.scenario
     grizzly.scenario.tasks().insert(0, request)
 
     step_response_allow_status_codes_table(behave)
@@ -354,6 +354,7 @@ def test_step_response_allow_status_codes_table(behave_fixture: BehaveFixture) -
 def test_step_response_content_type(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     with pytest.raises(AssertionError) as ae:
         step_response_content_type(behave, TransformerContentType.JSON)

--- a/tests/unit/test_grizzly/steps/scenario/test_results.py
+++ b/tests/unit/test_grizzly/steps/scenario/test_results.py
@@ -9,6 +9,7 @@ from tests.fixtures import BehaveFixture
 def test_step_results_fail_ratio(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     assert grizzly.scenario.validation.fail_ratio is None
     assert not grizzly.scenario.should_validate()
@@ -22,6 +23,7 @@ def test_step_results_fail_ratio(behave_fixture: BehaveFixture) -> None:
 def test_step_results_avg_response_time(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     assert grizzly.scenario.validation.avg_response_time is None
     assert not grizzly.scenario.should_validate()
@@ -35,6 +37,7 @@ def test_step_results_avg_response_time(behave_fixture: BehaveFixture) -> None:
 def test_step_results_response_time_percentile(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     assert grizzly.scenario.validation.response_time_percentile is None
     assert not grizzly.scenario.should_validate()

--- a/tests/unit/test_grizzly/steps/scenario/test_setup.py
+++ b/tests/unit/test_grizzly/steps/scenario/test_setup.py
@@ -34,6 +34,7 @@ def test_parse_iteration_gramatical_number() -> None:
 def test_step_setup_set_context_variable(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     step_setup_set_context_variable(behave, 'token.url', 'test')
     assert grizzly.scenario.context == {
@@ -197,6 +198,7 @@ def test_step_setup_set_context_variable(behave_fixture: BehaveFixture) -> None:
 def test_step_setup_iterations(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     assert grizzly.scenario.iterations == 1
 
@@ -246,6 +248,7 @@ def test_step_setup_iterations(behave_fixture: BehaveFixture) -> None:
 def test_step_setup_pace(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     assert getattr(grizzly.scenario, 'pace', '') is None
 
@@ -302,6 +305,8 @@ def test_step_setup_set_variable_alias(behave_fixture: BehaveFixture, mocker: Mo
 def test_step_setup_log_all_requests(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
+
     assert 'log_all_requests' not in grizzly.scenario.context
 
     step_setup_log_all_requests(behave)
@@ -312,6 +317,7 @@ def test_step_setup_log_all_requests(behave_fixture: BehaveFixture) -> None:
 def test_step_setup_metadata(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     assert grizzly.scenario.context.get('metadata', None) is None
 

--- a/tests/unit/test_grizzly/steps/scenario/test_tasks.py
+++ b/tests/unit/test_grizzly/steps/scenario/test_tasks.py
@@ -61,6 +61,7 @@ def test_parse_direction() -> None:
 def test_step_task_request_with_name_endpoint_until(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     assert len(grizzly.scenario.tasks()) == 0
 
@@ -116,6 +117,9 @@ def test_step_task_request_with_name_endpoint_until(behave_fixture: BehaveFixtur
 @pytest.mark.parametrize('method', RequestDirection.TO.methods)
 def test_step_task_request_file_with_name_endpoint(behave_fixture: BehaveFixture, method: RequestMethod) -> None:
     behave = behave_fixture.context
+    grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
+
     step_task_request_file_with_name_endpoint(behave, method, '{}', 'the_name', 'the_container')
 
 
@@ -130,6 +134,9 @@ def test_step_task_request_file_with_name_endpoint_wrong_direction(behave_fixtur
 @pytest.mark.parametrize('method', RequestDirection.TO.methods)
 def test_step_task_request_file_with_name(behave_fixture: BehaveFixture, method: RequestMethod) -> None:
     behave = behave_fixture.context
+    grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
+
     with pytest.raises(ValueError):
         step_task_request_file_with_name(behave, method, '{}', f'{method.name}-test')
 
@@ -149,6 +156,8 @@ def test_step_task_request_file_with_name_wrong_direction(behave_fixture: Behave
 @pytest.mark.parametrize('method', RequestDirection.TO.methods)
 def test_step_task_request_text_with_name_endpoint_to(behave_fixture: BehaveFixture, method: RequestMethod) -> None:
     behave = behave_fixture.context
+    grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
     behave.text = '{}'
 
     step_task_request_text_with_name_endpoint(behave, method, 'test-name', RequestDirection.TO, '/api/test')
@@ -175,6 +184,8 @@ def test_step_task_request_text_with_name_endpoint_from(behave_fixture: BehaveFi
 @pytest.mark.parametrize('method', RequestDirection.FROM.methods)
 def test_step_task_request_text_with_name_endpoint_no_text(behave_fixture: BehaveFixture, method: RequestMethod) -> None:
     behave = behave_fixture.context
+    grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
     behave.text = None
 
     step_task_request_text_with_name_endpoint(behave, method, 'test-name', RequestDirection.FROM, '/api/test')
@@ -193,6 +204,9 @@ def test_step_task_request_text_with_name_endpoint_no_direction(behave_fixture: 
 
 def test_step_task_request_text_with_name(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
+    grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
+
     behave.text = '{}'
 
     with pytest.raises(ValueError):
@@ -214,6 +228,7 @@ def test_step_task_request_text_with_name(behave_fixture: BehaveFixture) -> None
 def test_step_task_wait_seconds(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     with pytest.raises(AssertionError) as ae:
         step_task_wait_seconds(behave, '-1.0')
@@ -241,6 +256,7 @@ def test_step_task_wait_seconds(behave_fixture: BehaveFixture) -> None:
 def test_step_task_log_message(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     step_task_log_message(behave, 'hello {{ world }}')
 
@@ -252,6 +268,7 @@ def test_step_task_log_message(behave_fixture: BehaveFixture) -> None:
 def test_step_task_transform_json(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     with pytest.raises(ValueError) as ve:
         step_task_transform(
@@ -317,6 +334,7 @@ def test_step_task_transform_json(behave_fixture: BehaveFixture) -> None:
 def test_step_task_transform_xml(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     with pytest.raises(ValueError) as ve:
         step_task_transform(
@@ -382,6 +400,7 @@ def test_step_task_transform_xml(behave_fixture: BehaveFixture) -> None:
 def test_step_task_client_get_endpoint_payload_metadata(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     with pytest.raises(AssertionError) as ae:
         step_task_client_get_endpoint_payload_metadata(behave, 'obscure.example.com', 'step-name', 'test', 'metadata')
@@ -434,6 +453,7 @@ def test_step_task_client_get_endpoint_payload_metadata(behave_fixture: BehaveFi
 def test_step_task_client_get_endpoint_payload(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     with pytest.raises(AssertionError) as ae:
         step_task_client_get_endpoint_payload(behave, 'obscure.example.com', 'step-name', 'test')
@@ -475,6 +495,7 @@ def test_step_task_client_get_endpoint_payload(behave_fixture: BehaveFixture) ->
 def test_step_task_client_get_endpoint_until(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     with pytest.raises(AssertionError) as ae:
         step_task_client_get_endpoint_until(behave, 'api.example.io/api/test', 'step-name', '$.`this`[?status=true]')
@@ -497,7 +518,6 @@ def test_step_task_client_get_endpoint_until(behave_fixture: BehaveFixture) -> N
     assert len(grizzly.scenario.tasks()) == 1
     task = grizzly.scenario.tasks()[-1]
     assert isinstance(task, UntilRequestTask)
-    assert task.scenario is task.request.scenario
     assert isinstance(task.request, HttpClientTask)
     assert task.request.content_type == TransformerContentType.JSON
     assert task.request.endpoint == 'https://api.example.io/api/test'
@@ -509,7 +529,6 @@ def test_step_task_client_get_endpoint_until(behave_fixture: BehaveFixture) -> N
     assert len(grizzly.scenario.tasks()) == 2
     task = grizzly.scenario.tasks()[-1]
     assert isinstance(task, UntilRequestTask)
-    assert task.scenario is task.request.scenario
     assert isinstance(task.request, HttpClientTask)
     assert task.request.content_type == TransformerContentType.JSON
     assert task.request.endpoint == 'https://api.example.com/api/test'
@@ -523,6 +542,7 @@ def test_step_task_client_get_endpoint_until(behave_fixture: BehaveFixture) -> N
 def test_step_task_date(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     with pytest.raises(AssertionError) as ae:
         step_task_date(behave, '{{ datetime.now() }} | offset=1D', 'date_variable')
@@ -547,6 +567,7 @@ def test_step_task_date(behave_fixture: BehaveFixture) -> None:
 def test_step_task_client_put_endpoint_file_destination(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     behave.text = 'hello'
 
@@ -584,6 +605,7 @@ def test_step_task_client_put_endpoint_file_destination(behave_fixture: BehaveFi
 def test_step_task_client_put_endpoint_file(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     behave.text = 'hello'
 
@@ -620,6 +642,7 @@ def test_step_task_client_put_endpoint_file(behave_fixture: BehaveFixture) -> No
 def test_step_task_async_group_start(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = behave_fixture.grizzly
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     assert getattr(grizzly.scenario.tasks.tmp, 'async_group', '') is None
 
@@ -636,6 +659,7 @@ def test_step_task_async_group_start(behave_fixture: BehaveFixture) -> None:
 def test_step_task_async_group_end(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = behave_fixture.grizzly
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     assert len(grizzly.scenario.tasks()) == 0
     assert getattr(grizzly.scenario.tasks.tmp, 'async_group', '') is None
@@ -663,6 +687,7 @@ def test_step_task_async_group_end(behave_fixture: BehaveFixture) -> None:
 def test_step_task_timer_start_and_stop(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = behave_fixture.grizzly
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     assert grizzly.scenario.tasks.tmp.timers == {}
 
@@ -693,6 +718,7 @@ def test_step_task_timer_start_and_stop(behave_fixture: BehaveFixture) -> None:
 def test_step_task_request_wait_between(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = behave_fixture.grizzly
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     assert len(grizzly.scenario.tasks()) == 0
 
@@ -716,6 +742,7 @@ def test_step_task_request_wait_between(behave_fixture: BehaveFixture) -> None:
 def test_step_task_wait_constant(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = behave_fixture.grizzly
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     assert len(grizzly.scenario.tasks()) == 0
 
@@ -731,6 +758,7 @@ def test_step_task_wait_constant(behave_fixture: BehaveFixture) -> None:
 def test_step_task_conditional_if(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = behave_fixture.grizzly
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     assert getattr(grizzly.scenario.tasks.tmp, 'conditional', '') is None
 
@@ -760,6 +788,7 @@ def test_step_task_conditional_if(behave_fixture: BehaveFixture) -> None:
 def test_step_task_conditional_else(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = behave_fixture.grizzly
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     assert getattr(grizzly.scenario.tasks.tmp, 'conditional', '') is None
 
@@ -787,6 +816,7 @@ def test_step_task_conditional_else(behave_fixture: BehaveFixture) -> None:
 def test_step_task_conditional_end(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = behave_fixture.grizzly
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     assert getattr(grizzly.scenario.tasks.tmp, 'conditional', '') is None
 
@@ -813,6 +843,7 @@ def test_step_task_conditional_end(behave_fixture: BehaveFixture) -> None:
 def test_step_task_loop(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = behave_fixture.grizzly
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     assert getattr(grizzly.scenario.tasks.tmp, 'loop', '') is None
 

--- a/tests/unit/test_grizzly/steps/scenario/test_user.py
+++ b/tests/unit/test_grizzly/steps/scenario/test_user.py
@@ -12,6 +12,7 @@ from tests.fixtures import BehaveFixture
 def test_step_user_type(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     assert hasattr(grizzly.scenario, 'user')
     assert not hasattr(grizzly.scenario.user, 'class_name')
@@ -53,6 +54,7 @@ def test_step_user_type(behave_fixture: BehaveFixture) -> None:
 def test_step_user_type_with_weight(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     assert hasattr(grizzly.scenario, 'user')
     assert not hasattr(grizzly.scenario.user, 'class_name')

--- a/tests/unit/test_grizzly/steps/test__helpers.py
+++ b/tests/unit/test_grizzly/steps/test__helpers.py
@@ -49,8 +49,9 @@ def test_add_request_task_response_status_codes() -> None:
 
 @pytest.mark.parametrize('as_async', [False, True])
 def test_add_request_task(grizzly_fixture: GrizzlyFixture, tmp_path_factory: TempPathFactory, as_async: bool) -> None:
-    behave = grizzly_fixture.behave
+    behave = grizzly_fixture.behave.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test scenario'))
     grizzly.scenario.context['host'] = 'http://test'
 
     if as_async:
@@ -258,19 +259,20 @@ def test_add_request_task(grizzly_fixture: GrizzlyFixture, tmp_path_factory: Tem
 
 @pytest.mark.parametrize('as_async', [False, True])
 def test_add_save_handler(behave_fixture: BehaveFixture, locust_fixture: LocustFixture, as_async: bool) -> None:
+    behave = behave_fixture.context
+    grizzly = cast(GrizzlyContext, behave.grizzly)
+    scenario = GrizzlyContextScenario(index=2, behave=behave_fixture.create_scenario('test scenario'))
+    grizzly.scenarios.append(scenario)
+
+    TestUser.__scenario__ = scenario
     TestUser.host = 'https://example.io'
-    user = TestUser(locust_fixture.env)
-    scenario = GrizzlyContextScenario(index=2)
-    scenario.name = 'test scenario'
-    user._scenario = scenario
+    user = TestUser(locust_fixture.environment)
+
     response = Response()
     response._content = '{}'.encode('utf-8')
     response.status_code = 200
     response_context_manager = ResponseContextManager(response, None, None)
     response_context_manager._entered = True
-
-    behave = behave_fixture.context
-    grizzly = cast(GrizzlyContext, behave.grizzly)
 
     if as_async:
         grizzly.scenario.tasks.tmp.async_group = AsyncRequestGroupTask(name='async-test-2')
@@ -396,19 +398,20 @@ def test_add_save_handler(behave_fixture: BehaveFixture, locust_fixture: LocustF
 
 @pytest.mark.parametrize('as_async', [False, True])
 def test_add_validation_handler(behave_fixture: BehaveFixture, locust_fixture: LocustFixture, as_async: bool) -> None:
+    behave = behave_fixture.context
+    grizzly = cast(GrizzlyContext, behave.grizzly)
+    scenario = GrizzlyContextScenario(index=1, behave=behave_fixture.create_scenario('test scenario'))
+    grizzly.scenarios.append(scenario)
+
+    TestUser.__scenario__ = scenario
     TestUser.host = 'http://example.io'
-    user = TestUser(locust_fixture.env)
-    scenario = GrizzlyContextScenario(index=1)
-    scenario.name = 'test scenario'
-    user._scenario = scenario
+    user = TestUser(locust_fixture.environment)
+
     response = Response()
     response._content = '{}'.encode('utf-8')
     response.status_code = 200
     response_context_manager = ResponseContextManager(response, None, None)
     response_context_manager._entered = True
-
-    behave = behave_fixture.context
-    grizzly = cast(GrizzlyContext, behave.grizzly)
 
     if as_async:
         grizzly.scenario.tasks.tmp.async_group = AsyncRequestGroupTask(name='test-async-3')

--- a/tests/unit/test_grizzly/steps/test_setup.py
+++ b/tests/unit/test_grizzly/steps/test_setup.py
@@ -47,6 +47,7 @@ def test_step_setup_variable_value_ask(behave_fixture: BehaveFixture) -> None:
 def test_step_setup_variable_value(behave_fixture: BehaveFixture, mocker: MockerFixture) -> None:
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     assert 'test' not in grizzly.state.variables
 

--- a/tests/unit/test_grizzly/tasks/clients/test___init__.py
+++ b/tests/unit/test_grizzly/tasks/clients/test___init__.py
@@ -1,0 +1,65 @@
+import logging
+
+import pytest
+
+from _pytest.logging import LogCaptureFixture
+
+from grizzly.scenarios import GrizzlyScenario, IteratorScenario
+from grizzly.tasks.clients import ClientTask, client
+from grizzly.types import GrizzlyResponse, RequestDirection
+from grizzly.exceptions import StopUser, RestartScenario
+
+from tests.fixtures import GrizzlyFixture, MockerFixture
+
+
+def test_task_failing(grizzly_fixture: GrizzlyFixture, mocker: MockerFixture, caplog: LogCaptureFixture) -> None:
+
+    @client('test')
+    class TestTask(ClientTask):
+        def get(self, parent: GrizzlyScenario) -> GrizzlyResponse:
+            with self.action(parent):
+                raise RuntimeError('failed get')
+
+        def put(self, parent: GrizzlyScenario) -> GrizzlyResponse:
+            return None, 'put'
+
+    _, _, scenario = grizzly_fixture(scenario_type=IteratorScenario)
+
+    assert isinstance(scenario, IteratorScenario)
+
+    task_factory = TestTask(RequestDirection.FROM, 'test://foo.bar', 'dummy-stuff')
+
+    task = task_factory()
+
+    scenario.user._scenario.failure_exception = StopUser
+
+    with pytest.raises(StopUser):
+        task(scenario)
+
+    scenario.user._scenario.failure_exception = RestartScenario
+
+    with pytest.raises(RestartScenario):
+        task(scenario)
+
+    scenario.user._scenario.failure_exception = None
+
+    task(scenario)
+
+    log_error_mock = mocker.patch.object(scenario.stats, 'log_error')
+    mocker.patch.object(scenario, 'on_start', return_value=None)
+    mocker.patch.object(scenario, 'wait', side_effect=[NotImplementedError, NotImplementedError])
+    scenario.user.environment.catch_exceptions = True
+    scenario.user._scenario.failure_exception = RestartScenario
+
+    scenario.tasks.clear()
+    scenario._task_queue.clear()
+    scenario._task_queue.append(task)
+    scenario.task_count = 1
+
+    with pytest.raises(NotImplementedError):
+        with caplog.at_level(logging.INFO):
+            scenario.run()
+
+    log_error_mock.assert_called_once_with(None)
+
+    assert 'restarting scenario' in '\n'.join(caplog.messages)

--- a/tests/unit/test_grizzly/tasks/clients/test___init__.py
+++ b/tests/unit/test_grizzly/tasks/clients/test___init__.py
@@ -23,42 +23,42 @@ def test_task_failing(grizzly_fixture: GrizzlyFixture, mocker: MockerFixture, ca
         def put(self, parent: GrizzlyScenario) -> GrizzlyResponse:
             return None, 'put'
 
-    _, _, scenario = grizzly_fixture(scenario_type=IteratorScenario)
+    parent = grizzly_fixture(scenario_type=IteratorScenario)
 
-    assert isinstance(scenario, IteratorScenario)
+    assert isinstance(parent, IteratorScenario)
 
     task_factory = TestTask(RequestDirection.FROM, 'test://foo.bar', 'dummy-stuff')
 
     task = task_factory()
 
-    scenario.user._scenario.failure_exception = StopUser
+    parent.user._scenario.failure_exception = StopUser
 
     with pytest.raises(StopUser):
-        task(scenario)
+        task(parent)
 
-    scenario.user._scenario.failure_exception = RestartScenario
+    parent.user._scenario.failure_exception = RestartScenario
 
     with pytest.raises(RestartScenario):
-        task(scenario)
+        task(parent)
 
-    scenario.user._scenario.failure_exception = None
+    parent.user._scenario.failure_exception = None
 
-    task(scenario)
+    task(parent)
 
-    log_error_mock = mocker.patch.object(scenario.stats, 'log_error')
-    mocker.patch.object(scenario, 'on_start', return_value=None)
-    mocker.patch.object(scenario, 'wait', side_effect=[NotImplementedError, NotImplementedError])
-    scenario.user.environment.catch_exceptions = True
-    scenario.user._scenario.failure_exception = RestartScenario
+    log_error_mock = mocker.patch.object(parent.stats, 'log_error')
+    mocker.patch.object(parent, 'on_start', return_value=None)
+    mocker.patch.object(parent, 'wait', side_effect=[NotImplementedError, NotImplementedError])
+    parent.user.environment.catch_exceptions = True
+    parent.user._scenario.failure_exception = RestartScenario
 
-    scenario.tasks.clear()
-    scenario._task_queue.clear()
-    scenario._task_queue.append(task)
-    scenario.task_count = 1
+    parent.tasks.clear()
+    parent._task_queue.clear()
+    parent._task_queue.append(task)
+    parent.task_count = 1
 
     with pytest.raises(NotImplementedError):
         with caplog.at_level(logging.INFO):
-            scenario.run()
+            parent.run()
 
     log_error_mock.assert_called_once_with(None)
 

--- a/tests/unit/test_grizzly/tasks/clients/test_blobstorage.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_blobstorage.py
@@ -129,11 +129,10 @@ class TestBlobStorageClientTask:
         )
         task = task_factory()
 
-        _, _, scenario = grizzly_fixture()
-        assert scenario is not None
+        parent = grizzly_fixture()
 
         with pytest.raises(NotImplementedError) as nie:
-            task(scenario)
+            task(parent)
         assert 'BlobStorageClientTask has not implemented GET' in str(nie.value)
 
     def test_put(self, behave_fixture: BehaveFixture, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture, tmp_path_factory: TempPathFactory) -> None:
@@ -175,24 +174,23 @@ class TestBlobStorageClientTask:
 
             task = task_factory()
 
-            _, _, scenario = grizzly_fixture()
-            assert scenario is not None
+            parent = grizzly_fixture()
 
-            request_fire_spy = mocker.spy(scenario.user.environment.events.request, 'fire')
+            request_fire_spy = mocker.spy(parent.user.environment.events.request, 'fire')
 
-            scenario.user._context['variables'].update(grizzly.state.variables)
+            parent.user._context['variables'].update(grizzly.state.variables)
 
-            task(scenario)
+            task(parent)
 
             assert upload_blob_mock.call_count == 0
 
             assert request_fire_spy.call_count == 1
             _, kwargs = request_fire_spy.call_args_list[-1]
             assert kwargs.get('request_type', None) == 'CLTSK'
-            assert kwargs.get('name', None) == f'{scenario.user._scenario.identifier} BlobStorage->my-container'
+            assert kwargs.get('name', None) == f'{parent.user._scenario.identifier} BlobStorage->my-container'
             assert kwargs.get('response_time', None) >= 0.0
             assert kwargs.get('response_length') == 0
-            assert kwargs.get('context', None) is scenario.user._context
+            assert kwargs.get('context', None) is parent.user._context
             exception = kwargs.get('exception', '')
             assert isinstance(exception, FileNotFoundError)
             assert str(exception) == 'source.json'
@@ -214,7 +212,7 @@ class TestBlobStorageClientTask:
 
             task = task_factory()
 
-            task(scenario)
+            task(parent)
 
             assert upload_blob_mock.call_count == 1
 
@@ -233,16 +231,16 @@ class TestBlobStorageClientTask:
             assert request_fire_spy.call_count == 2
             _, kwargs = request_fire_spy.call_args_list[-1]
             assert kwargs.get('request_type', None) == 'CLTSK'
-            assert kwargs.get('name', None) == f'{scenario.user._scenario.identifier} test-bss-request'
+            assert kwargs.get('name', None) == f'{parent.user._scenario.identifier} test-bss-request'
             assert kwargs.get('response_time', None) >= 0.0
             assert kwargs.get('response_length') == len('this is my hello world test!')
-            assert kwargs.get('context', None) is scenario.user._context
+            assert kwargs.get('context', None) is parent.user._context
             assert kwargs.get('exception', '') is None
 
             task_factory.destination = None
             task_factory.overwrite = True
 
-            task(scenario)
+            task(parent)
 
             assert upload_blob_mock.call_count == 2
 
@@ -258,10 +256,10 @@ class TestBlobStorageClientTask:
             assert request_fire_spy.call_count == 3
             _, kwargs = request_fire_spy.call_args_list[-1]
             assert kwargs.get('request_type', None) == 'CLTSK'
-            assert kwargs.get('name', None) == f'{scenario.user._scenario.identifier} test-bss-request'
+            assert kwargs.get('name', None) == f'{parent.user._scenario.identifier} test-bss-request'
             assert kwargs.get('response_time', None) >= 0.0
             assert kwargs.get('response_length') == len('this is my hello world test!')
-            assert kwargs.get('context', None) is scenario.user._context
+            assert kwargs.get('context', None) is parent.user._context
             assert kwargs.get('exception', '') is None
         finally:
             try:

--- a/tests/unit/test_grizzly/tasks/test_date.py
+++ b/tests/unit/test_grizzly/tasks/test_date.py
@@ -37,73 +37,73 @@ class TestDateTask:
         ])
 
     def test___call__(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
-        behave = grizzly_fixture.behave
+        behave = grizzly_fixture.behave.context
         grizzly = cast(GrizzlyContext, behave.grizzly)
         grizzly.state.variables.update({'date_variable': 'none'})
 
-        _, _, scenario = grizzly_fixture()
+        parent = grizzly_fixture()
 
-        assert scenario is not None
+        assert parent is not None
 
         task_factory = DateTask('date_variable', '2022-01-17 10:37:01 | offset=-1D')
         task = task_factory()
-        task(scenario)
+        task(parent)
 
-        assert scenario.user._context['variables']['date_variable'] == '2022-01-16 10:37:01'
+        assert parent.user._context['variables']['date_variable'] == '2022-01-16 10:37:01'
 
         task_factory = DateTask('date_variable', '2022-01-17 10:37:01 | offset=-22Y-1D, timezone=UTC')
         task = task_factory()
-        task(scenario)
+        task(parent)
 
-        assert scenario.user._context['variables']['date_variable'] == '2000-01-16 09:37:01'
+        assert parent.user._context['variables']['date_variable'] == '2000-01-16 09:37:01'
 
         task_factory = DateTask('date_variable', '2022-01-17 10:37:01 | offset=-22Y-16D-37m59s, timezone=UTC, format="%d/%m %y %H.%M.%S"')
         task = task_factory()
-        task(scenario)
+        task(parent)
 
-        assert scenario.user._context['variables']['date_variable'] == '01/01 00 09.01.00'
+        assert parent.user._context['variables']['date_variable'] == '01/01 00 09.01.00'
 
         expected = datetime.now().strftime('%d/%m -%y')
         task_factory = DateTask('date_variable', '{{ datetime.now() }} | format="%d/%m -%y"')
         task = task_factory()
-        task(scenario)
+        task(parent)
 
-        assert scenario.user._context['variables']['date_variable'] == expected
+        assert parent.user._context['variables']['date_variable'] == expected
 
-        scenario.user._context['variables']['date_value'] = '2022-01-17T10:48:37.000'
+        parent.user._context['variables']['date_value'] = '2022-01-17T10:48:37.000'
         task_factory = DateTask('date_variable', '{{ date_value }} | timezone=UTC, offset=-22Y2M3D, format="%d/%m %y %H:%M:%S"')
         task = task_factory()
-        task(scenario)
+        task(parent)
 
-        assert scenario.user._context['variables']['date_variable'] == '20/03 00 09:48:37'
+        assert parent.user._context['variables']['date_variable'] == '20/03 00 09:48:37'
 
         task_factory.arguments['offset'] = 'asdf'
 
         with pytest.raises(ValueError) as ve:
-            task(scenario)
+            task(parent)
         assert 'invalid time span format' in str(ve)
 
         task_factory.arguments.update({'offset': None, 'timezone': 'DisneyWorld/Ankeborg'})
 
         with pytest.raises(ValueError) as ve:
-            task(scenario)
+            task(parent)
         assert '"DisneyWorld/Ankeborg" is not a valid time zone' in str(ve)
 
         task_factory = DateTask('date_variable', 'asdf | timezone=UTC, offset=-22Y2M3D, format="%-d/%-m %y %H:%M:%S"')
         task = task_factory()
 
         with pytest.raises(ValueError) as ve:
-            task(scenario)
+            task(parent)
         assert '"asdf" is not a valid datetime string' in str(ve)
 
         task_factory = DateTask('date_variable', '{{ datetime.now().strftime("%Y") }} | timezone=UTC, format=%Y')
         task = task_factory()
 
-        task(scenario)
+        task(parent)
 
-        assert scenario.user._context['variables']['date_variable'] == datetime.now().strftime('%Y')
+        assert parent.user._context['variables']['date_variable'] == datetime.now().strftime('%Y')
 
-        scenario.user._context['variables'].update({
+        parent.user._context['variables'].update({
             'to_year': '2022',
             'to_month': '01',
             'to_day': '18',
@@ -112,9 +112,9 @@ class TestDateTask:
         task_factory = DateTask('date_variable', '{{ to_year }}-{{ to_month }}-{{ to_day }} | format="%Y", offset=-1D')
         task = task_factory()
 
-        task(scenario)
+        task(parent)
 
-        assert scenario.user._context['variables']['date_variable'] == '2022'
+        assert parent.user._context['variables']['date_variable'] == '2022'
 
         expected_datetime = dateparser('2022-05-19 07:20:00.123456+0200')
 
@@ -127,30 +127,30 @@ class TestDateTask:
         task_factory = DateTask('date_variable', '{{ datetime.now() }} | format="ISO-8601:DateTime"')
         task = task_factory()
 
-        task(scenario)
+        task(parent)
 
-        assert scenario.user._context['variables']['date_variable'] == '2022-05-19T07:20:00+02:00'
+        assert parent.user._context['variables']['date_variable'] == '2022-05-19T07:20:00+02:00'
 
         task_factory = DateTask('date_variable', '{{ datetime.now() }} | format="ISO-8601:DateTime:ms"')
         task = task_factory()
 
-        task(scenario)
+        task(parent)
 
-        assert scenario.user._context['variables']['date_variable'] == '2022-05-19T07:20:00.123456+02:00'
+        assert parent.user._context['variables']['date_variable'] == '2022-05-19T07:20:00.123456+02:00'
 
         task_factory = DateTask('date_variable', '{{ datetime.now() }} | format="ISO-8601:Time"')
         task = task_factory()
 
-        task(scenario)
+        task(parent)
 
         expected = expected_datetime.replace(microsecond=0).isoformat()
         _, expected = expected.split('T', 1)
 
-        assert scenario.user._context['variables']['date_variable'] == '07:20:00+02:00'
+        assert parent.user._context['variables']['date_variable'] == '07:20:00+02:00'
 
         task_factory = DateTask('date_variable', '{{ datetime.now() }} | format="ISO-8601:Time:ms"')
         task = task_factory()
 
-        task(scenario)
+        task(parent)
 
-        assert scenario.user._context['variables']['date_variable'] == '07:20:00.123456+02:00'
+        assert parent.user._context['variables']['date_variable'] == '07:20:00.123456+02:00'

--- a/tests/unit/test_grizzly/tasks/test_log_message.py
+++ b/tests/unit/test_grizzly/tasks/test_log_message.py
@@ -17,12 +17,10 @@ class TestLogMessageTask:
 
         assert callable(task)
 
-        _, _, scenario = grizzly_fixture()
-
-        assert scenario is not None
+        parent = grizzly_fixture()
 
         with caplog.at_level(logging.INFO):
-            task(scenario)
+            task(parent)
         assert 'hello world!' in caplog.text
         caplog.clear()
 
@@ -33,9 +31,9 @@ class TestLogMessageTask:
 
         assert callable(task)
 
-        scenario.user._context['variables']['variable'] = 'hello world!'
+        parent.user._context['variables']['variable'] = 'hello world!'
 
         with caplog.at_level(logging.INFO):
-            task(scenario)
+            task(parent)
         assert 'variable=hello world!' in caplog.text
         caplog.clear()

--- a/tests/unit/test_grizzly/tasks/test_request.py
+++ b/tests/unit/test_grizzly/tasks/test_request.py
@@ -85,18 +85,19 @@ class TestRequestTask:
         task = task_factory()
         assert callable(task)
 
-        _, _, scenario = grizzly_fixture()
+        parent = grizzly_fixture()
 
-        assert scenario is not None
+        mocker.patch.object(parent.user, 'request', autospec=True)
+        request_spy = mocker.spy(parent.user, 'request')
 
-        mocker.patch.object(scenario.user, 'request', autospec=True)
-        request_spy = mocker.spy(scenario.user, 'request')
-
-        task(scenario)
+        task(parent)
 
         assert request_spy.call_count == 1
-        args, _ = request_spy.call_args_list[0]
-        assert args[0] is task_factory
+        args, kwargs = request_spy.call_args_list[0]
+        assert args[0] is parent
+        assert args[1] is task_factory
+        assert len(args) == 2
+        assert kwargs == {}
 
         # automagically create template if not set
         task_factory.source = 'hello {{ world }}'

--- a/tests/unit/test_grizzly/tasks/test_task_wait.py
+++ b/tests/unit/test_grizzly/tasks/test_task_wait.py
@@ -19,25 +19,23 @@ class TestTaskWaitTask:
         assert task_factory.max_time == 13.0
 
     def test___call__(self, grizzly_fixture: GrizzlyFixture) -> None:
-        _, _, scenario = grizzly_fixture()
-
-        assert scenario is not None
+        parent = grizzly_fixture()
 
         # force the scenario user to not have a wait_time method
-        scenario.user.wait_time = None
+        parent.user.wait_time = None
 
         with pytest.raises(MissingWaitTimeError):
-            scenario.wait_time()
+            parent.wait_time()
 
         task = TaskWaitTask(1.0, 12.0)()
 
-        task(scenario)
+        task(parent)
 
-        wait_time = scenario.wait_time()
+        wait_time = parent.wait_time()
         assert wait_time >= 1.0 and wait_time <= 12.0
 
         task = TaskWaitTask(13.0)()
 
-        task(scenario)
+        task(parent)
 
-        assert scenario.wait_time() == 13.0
+        assert parent.wait_time() == 13.0

--- a/tests/unit/test_grizzly/tasks/test_transformer.py
+++ b/tests/unit/test_grizzly/tasks/test_transformer.py
@@ -15,18 +15,13 @@ class TestTransformerTask:
     def test(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
         grizzly = grizzly_fixture.grizzly
 
-        _, _, scenario = grizzly_fixture()
+        parent = grizzly_fixture()
 
-        assert scenario is not None
-
-        scenario_context = grizzly_fixture.request_task.request.scenario
-
-        fire_spy = mocker.spy(scenario.user.environment.events.request, 'fire')
+        fire_spy = mocker.spy(parent.user.environment.events.request, 'fire')
 
         with pytest.raises(ValueError) as ve:
             TransformerTask(
                 grizzly, variable='test_variable', expression='$.', content_type=TransformerContentType.JSON, content='',
-                scenario=scenario_context,
             )
         assert 'test_variable has not been initialized' in str(ve)
 
@@ -38,7 +33,6 @@ class TestTransformerTask:
         with pytest.raises(ValueError) as ve:
             TransformerTask(
                 grizzly, variable='test_variable', expression='$.', content_type=TransformerContentType.JSON, content='',
-                scenario=scenario_context,
             )
         assert 'could not find a transformer for JSON' in str(ve)
 
@@ -47,13 +41,11 @@ class TestTransformerTask:
         with pytest.raises(ValueError) as ve:
             TransformerTask(
                 grizzly, variable='test_variable', expression='$.', content_type=TransformerContentType.JSON, content='',
-                scenario=scenario_context,
             )
         assert '$. is not a valid expression for JSON' in str(ve)
 
         task_factory = TransformerTask(
             grizzly, variable='test_variable', expression='$.result.value', content_type=TransformerContentType.JSON, content='',
-            scenario=scenario_context,
         )
 
         assert task_factory.__template_attributes__ == {'content'}
@@ -62,16 +54,16 @@ class TestTransformerTask:
 
         assert callable(task)
 
-        task(scenario)
+        task(parent)
 
         assert fire_spy.call_count == 1
         _, kwargs = fire_spy.call_args_list[-1]
 
         assert kwargs.get('request_type', None) == 'TRNSF'
-        assert kwargs.get('name', None) == f'{scenario.user._scenario.identifier} Transformer=>test_variable'
+        assert kwargs.get('name', None) == f'{parent.user._scenario.identifier} Transformer=>test_variable'
         assert kwargs.get('response_time', None) >= 0.0
         assert kwargs.get('response_length', None) == 0
-        assert kwargs.get('context', None) == scenario.user._context
+        assert kwargs.get('context', None) == parent.user._context
         exception = kwargs.get('exception', None)
         assert isinstance(exception, TransformerLocustError)
         assert str(exception) == 'failed to transform JSON'
@@ -86,18 +78,17 @@ class TestTransformerTask:
                     'value': 'hello world!',
                 },
             }),
-            scenario=scenario_context,
         )
 
         task = task_factory()
 
         assert callable(task)
 
-        assert scenario.user._context['variables'].get('test_variable', None) is None
+        assert parent.user._context['variables'].get('test_variable', None) is None
 
-        task(scenario)
+        task(parent)
 
-        assert scenario.user._context['variables'].get('test_variable', None) == 'hello world!'
+        assert parent.user._context['variables'].get('test_variable', None) == 'hello world!'
 
         grizzly.state.variables.update({'payload_url': 'none'})
         content = jsondumps({
@@ -119,18 +110,17 @@ class TestTransformerTask:
             expression='$.payloads[0].url',
             content_type=TransformerContentType.JSON,
             content=content,
-            scenario=scenario_context,
         )
 
         task = task_factory()
 
         assert callable(task)
 
-        task(scenario)
+        task(parent)
 
-        assert scenario.user._context['variables'].get('payload_url', None) == 'https://mystorageaccount.blob.core.windows.net/mycontainer/myfile'
+        assert parent.user._context['variables'].get('payload_url', None) == 'https://mystorageaccount.blob.core.windows.net/mycontainer/myfile'
 
-        scenario.user._context['variables'].update({
+        parent.user._context['variables'].update({
             'payload_url': None,
             'payload': content,
         })
@@ -141,16 +131,15 @@ class TestTransformerTask:
             expression='$.payloads[0].url',
             content_type=TransformerContentType.JSON,
             content='{{ payload }}',
-            scenario=scenario_context,
         )
 
         task = task_factory()
 
         assert callable(task)
 
-        task(scenario)
+        task(parent)
 
-        assert scenario.user._context['variables'].get('payload_url', None) == 'https://mystorageaccount.blob.core.windows.net/mycontainer/myfile'
+        assert parent.user._context['variables'].get('payload_url', None) == 'https://mystorageaccount.blob.core.windows.net/mycontainer/myfile'
 
         assert fire_spy.call_count == 1
 
@@ -164,26 +153,25 @@ class TestTransformerTask:
                     'value': 'hello world!',
                 },
             }),
-            scenario=scenario_context,
         )
         task = task_factory()
-        scenario_context.failure_exception = RestartScenario
+        parent.user._scenario.failure_exception = RestartScenario
         with pytest.raises(RestartScenario):
-            task(scenario)
+            task(parent)
 
         assert fire_spy.call_count == 2
         _, kwargs = fire_spy.call_args_list[-1]
 
         assert kwargs.get('request_type', None) == 'TRNSF'
-        assert kwargs.get('name', None) == f'{scenario.user._scenario.identifier} Transformer=>test_variable'
+        assert kwargs.get('name', None) == f'{parent.user._scenario.identifier} Transformer=>test_variable'
         assert kwargs.get('response_time', None) >= 0.0
         assert kwargs.get('response_length', None) == 37
-        assert kwargs.get('context', None) == scenario.user._context
+        assert kwargs.get('context', None) == parent.user._context
         exception = kwargs.get('exception', None)
         assert isinstance(exception, RuntimeError)
         assert str(exception) == '"$.result.name" returned 0 matches'
 
-        scenario_context.failure_exception = None
+        parent.user._scenario.failure_exception = None
 
         task_factory = TransformerTask(
             grizzly,
@@ -197,12 +185,11 @@ class TestTransformerTask:
                     {'value': 'hello world!'},
                 ],
             }),
-            scenario=scenario_context,
         )
         task = task_factory()
-        task(scenario)
+        task(parent)
 
-        assert scenario.user._context['variables']['test_variable'] == '''{"value": "hello world!"}
+        assert parent.user._context['variables']['test_variable'] == '''{"value": "hello world!"}
 {"value": "hello world!"}
 {"value": "hello world!"}'''
 
@@ -214,12 +201,11 @@ class TestTransformerTask:
             content=jsondumps({
                 'success': True,
             }),
-            scenario=scenario_context,
         )
         task = task_factory()
-        task(scenario)
+        task(parent)
 
-        assert scenario.user._context['variables']['test_variable'] == 'True'
+        assert parent.user._context['variables']['test_variable'] == 'True'
 
         task_factory = TransformerTask(
             grizzly,
@@ -238,16 +224,15 @@ class TestTransformerTask:
     <foo:singer id="12">Ray Charles</foo:singer>
   </foo:singers>
 </root>''',
-            scenario=scenario_context,
         )
 
         task = task_factory()
 
         assert callable(task)
 
-        task(scenario)
+        task(parent)
 
-        assert scenario.user._context['variables']['test_variable'] == '<actor id="9">Michael Caine</actor>'
+        assert parent.user._context['variables']['test_variable'] == '<actor id="9">Michael Caine</actor>'
 
         grizzly.state.variables['child_elem'] = 'none'
 
@@ -268,15 +253,14 @@ class TestTransformerTask:
     <foo:singer id="12">Ray Charles</foo:singer>
   </foo:singers>
 </root>''',
-            scenario=scenario_context,
         )
 
         task = task_factory()
 
         assert callable(task)
 
-        task(scenario)
+        task(parent)
 
-        assert scenario.user._context['variables']['child_elem'] == '''<actor id="7">Christian Bale</actor>
+        assert parent.user._context['variables']['child_elem'] == '''<actor id="7">Christian Bale</actor>
 <actor id="8">Liam Neeson</actor>
 <actor id="9">Michael Caine</actor>'''

--- a/tests/unit/test_grizzly/tasks/test_until.py
+++ b/tests/unit/test_grizzly/tasks/test_until.py
@@ -70,12 +70,9 @@ class TestUntilRequestTask:
         meta_args: Tuple[Any, ...],
         meta_kwargs: Dict[str, Any],
     ) -> None:
-        _, _, scenario = grizzly_fixture()
-        assert scenario is not None
+        parent = grizzly_fixture()
 
         meta_request_task = meta_request_task_type(*meta_args, **meta_kwargs)
-
-        meta_request_task.scenario = grizzly_fixture.request_task.request.scenario
 
         grizzly = grizzly_fixture.grizzly
 
@@ -114,23 +111,23 @@ class TestUntilRequestTask:
         )
 
         fire_spy = mocker.patch.object(
-            scenario.user.environment.events.request,
+            parent.user.environment.events.request,
             'fire',
         )
 
         gsleep_spy = mocker.patch('grizzly.tasks.until.gsleep', autospec=True)
 
-        task_factory = UntilRequestTask(grizzly, meta_request_task, '/status[text()="ready"]', scenario=meta_request_task.scenario)
+        task_factory = UntilRequestTask(grizzly, meta_request_task, '/status[text()="ready"]')
         task = task_factory()
 
         with pytest.raises(RuntimeError) as re:
-            task(scenario)
+            task(parent)
         assert '/status[text()="ready"] is not a valid expression for JSON' in str(re)
 
         jsontransformer_orig = transformer.available[TransformerContentType.JSON]
         del transformer.available[TransformerContentType.JSON]
 
-        task_factory = UntilRequestTask(grizzly, meta_request_task, '$.`this`[?status="ready"] | wait=100, retries=10', scenario=meta_request_task.scenario)
+        task_factory = UntilRequestTask(grizzly, meta_request_task, '$.`this`[?status="ready"] | wait=100, retries=10')
 
         with pytest.raises(TypeError) as te:
             task_factory()
@@ -138,11 +135,11 @@ class TestUntilRequestTask:
 
         transformer.available[TransformerContentType.JSON] = jsontransformer_orig
 
-        task_factory = UntilRequestTask(grizzly, meta_request_task, "$.`this`[?status='ready'] | wait=100, retries=10", scenario=meta_request_task.scenario)
+        task_factory = UntilRequestTask(grizzly, meta_request_task, "$.`this`[?status='ready'] | wait=100, retries=10")
         task = task_factory()
 
         with caplog.at_level(ERROR):
-            task(scenario)
+            task(parent)
 
         assert len(caplog.messages) == 0
         assert time_spy.call_count == 2
@@ -158,20 +155,20 @@ class TestUntilRequestTask:
         _, kwargs = fire_spy.call_args_list[-1]
 
         assert kwargs.get('request_type', None) == 'UNTL'
-        assert kwargs.get('name', None) == f'{task_factory.scenario.identifier} test-request, w=100.0s, r=10, em=1'
+        assert kwargs.get('name', None) == f'{parent.user._scenario.identifier} test-request, w=100.0s, r=10, em=1'
         assert kwargs.get('response_time', None) == 153500
         assert kwargs.get('response_length', None) == 103
         assert kwargs.get('context', None) == {'variables': {}}
         assert kwargs.get('exception', '') is None
 
         # -->
-        scenario.grizzly.state.variables['wait'] = 100.0
-        scenario.grizzly.state.variables['retries'] = 10
-        task_factory = UntilRequestTask(grizzly, meta_request_task, "$.`this`[?status='ready'] | wait='{{ wait }}', retries='{{ retries }}'", scenario=meta_request_task.scenario)
+        parent.grizzly.state.variables['wait'] = 100.0
+        parent.grizzly.state.variables['retries'] = 10
+        task_factory = UntilRequestTask(grizzly, meta_request_task, "$.`this`[?status='ready'] | wait='{{ wait }}', retries='{{ retries }}'")
         task = task_factory()
 
         with caplog.at_level(ERROR):
-            task(scenario)
+            task(parent)
 
         assert len(caplog.messages) == 0
         assert time_spy.call_count == 4
@@ -187,7 +184,7 @@ class TestUntilRequestTask:
         _, kwargs = fire_spy.call_args_list[-1]
 
         assert kwargs.get('request_type', None) == 'UNTL'
-        assert kwargs.get('name', None) == f'{task_factory.scenario.identifier} test-request, w=100.0s, r=10, em=1'
+        assert kwargs.get('name', None) == f'{parent.user._scenario.identifier} test-request, w=100.0s, r=10, em=1'
         assert kwargs.get('response_time', None) == 12250
         assert kwargs.get('response_length', None) == 33
         assert kwargs.get('context', None) == {'variables': {}}
@@ -203,19 +200,19 @@ class TestUntilRequestTask:
             ],
         )
 
-        meta_request_task.scenario.failure_exception = StopUser
-        task_factory = UntilRequestTask(grizzly, meta_request_task, '$.`this`[?status="ready"] | wait=10, retries=2', scenario=meta_request_task.scenario)
+        parent.user._scenario.failure_exception = StopUser
+        task_factory = UntilRequestTask(grizzly, meta_request_task, '$.`this`[?status="ready"] | wait=10, retries=2')
         task = task_factory()
 
         with pytest.raises(StopUser):
             with caplog.at_level(ERROR):
-                task(scenario)
+                task(parent)
 
         assert fire_spy.call_count == 3
         _, kwargs = fire_spy.call_args_list[-1]
 
         assert kwargs.get('request_type', None) == 'UNTL'
-        assert kwargs.get('name', None) == f'{task_factory.scenario.identifier} test-request, w=10.0s, r=2, em=1'
+        assert kwargs.get('name', None) == f'{parent.user._scenario.identifier} test-request, w=10.0s, r=2, em=1'
         assert kwargs.get('response_time', None) == 12250
         assert kwargs.get('response_length', None) == 70
         assert kwargs.get('context', None) == {'variables': {}}
@@ -226,7 +223,7 @@ class TestUntilRequestTask:
 
         assert len(caplog.messages) == 1
         assert caplog.messages[-1] == (
-            f'{task_factory.scenario.identifier} test-request, w=10.0s, r=2, em=1: endpoint={meta_request_task.endpoint}, number_of_matches=0, '
+            f'{parent.user._scenario.identifier} test-request, w=10.0s, r=2, em=1: endpoint={meta_request_task.endpoint}, number_of_matches=0, '
             f'condition=$.`this`[?status="ready"], retry=2, response_time=12250 payload=\n{jsondumps({"response": {"status": "working"}}, indent=2)}'
         )
 
@@ -242,16 +239,16 @@ class TestUntilRequestTask:
             ],
         )
 
-        meta_request_task.scenario.failure_exception = RestartScenario
+        parent.user._scenario.failure_exception = RestartScenario
         with pytest.raises(RestartScenario):
             with caplog.at_level(ERROR):
-                task(scenario)
+                task(parent)
 
         assert fire_spy.call_count == 4
         _, kwargs = fire_spy.call_args_list[-1]
 
         assert kwargs.get('request_type', None) == 'UNTL'
-        assert kwargs.get('name', None) == f'{task_factory.scenario.identifier} test-request, w=10.0s, r=2, em=1'
+        assert kwargs.get('name', None) == f'{parent.user._scenario.identifier} test-request, w=10.0s, r=2, em=1'
         assert kwargs.get('response_time', None) == 1500
         assert kwargs.get('response_length', None) == 35
         assert kwargs.get('context', None) == {'variables': {}}
@@ -262,7 +259,7 @@ class TestUntilRequestTask:
 
         assert len(caplog.messages) == 1
         assert caplog.messages[-1] == (
-            f'{task_factory.scenario.identifier} test-request, w=10.0s, r=2, em=1: retry=0, endpoint={meta_request_task.endpoint}, exception=foo bar'
+            f'{parent.user._scenario.identifier} test-request, w=10.0s, r=2, em=1: retry=0, endpoint={meta_request_task.endpoint}, exception=foo bar'
         )
 
         caplog.clear()
@@ -278,15 +275,15 @@ class TestUntilRequestTask:
             ],
         )
 
-        task_factory = UntilRequestTask(grizzly, meta_request_task, '$.`this`[?status="ready"] | wait=4, retries=4', scenario=meta_request_task.scenario)
+        task_factory = UntilRequestTask(grizzly, meta_request_task, '$.`this`[?status="ready"] | wait=4, retries=4')
         task = task_factory()
 
         with caplog.at_level(ERROR):
-            task(scenario)
+            task(parent)
 
         assert len(caplog.messages) == 1
         assert caplog.messages[-1] == (
-            f'{task_factory.scenario.identifier} test-request, w=4.0s, r=4, em=1: retry=1, endpoint={meta_request_task.endpoint}, exception=foo bar'
+            f'{parent.user._scenario.identifier} test-request, w=4.0s, r=4, em=1: retry=1, endpoint={meta_request_task.endpoint}, exception=foo bar'
         )
 
         caplog.clear()
@@ -295,7 +292,7 @@ class TestUntilRequestTask:
         _, kwargs = fire_spy.call_args_list[-1]
 
         assert kwargs.get('request_type', None) == 'UNTL'
-        assert kwargs.get('name', None) == f'{task_factory.scenario.identifier} test-request, w=4.0s, r=4, em=1'
+        assert kwargs.get('name', None) == f'{parent.user._scenario.identifier} test-request, w=4.0s, r=4, em=1'
         assert kwargs.get('response_time', None) == 800
         assert kwargs.get('response_length', None) == 103
         assert kwargs.get('context', None) == {'variables': {}}
@@ -329,7 +326,7 @@ class TestUntilRequestTask:
             return_value=(None, jsondumps(return_value_object), ),
         )
 
-        task_factory = UntilRequestTask(grizzly, meta_request_task, '$.list[?(@.count > 19)] | wait=4, expected_matches=3, retries=4', scenario=meta_request_task.scenario)
+        task_factory = UntilRequestTask(grizzly, meta_request_task, '$.list[?(@.count > 19)] | wait=4, expected_matches=3, retries=4')
         assert task_factory.expected_matches == 3
         assert task_factory.wait == 4
         assert task_factory.retries == 4
@@ -337,20 +334,20 @@ class TestUntilRequestTask:
         task = task_factory()
 
         with caplog.at_level(ERROR):
-            task(scenario)
+            task(parent)
 
         assert len(caplog.messages) == 0
         assert fire_spy.call_count == 6
         _, kwargs = fire_spy.call_args_list[-1]
 
         assert kwargs.get('request_type', None) == 'UNTL'
-        assert kwargs.get('name', None) == f'{task_factory.scenario.identifier} test-request, w=4.0s, r=4, em=3'
+        assert kwargs.get('name', None) == f'{parent.user._scenario.identifier} test-request, w=4.0s, r=4, em=3'
         assert kwargs.get('response_time', None) == 800
         assert kwargs.get('response_length', None) == 213
         assert kwargs.get('context', None) == {'variables': {}}
         assert kwargs.get('exception', '') is None
 
-        task_factory = UntilRequestTask(grizzly, meta_request_task, '$.list[?(@.count > 19)] | wait=4, expected_matches=4, retries=4', scenario=meta_request_task.scenario)
+        task_factory = UntilRequestTask(grizzly, meta_request_task, '$.list[?(@.count > 19)] | wait=4, expected_matches=4, retries=4')
         assert task_factory.expected_matches == 4
         assert task_factory.wait == 4
         assert task_factory.retries == 4
@@ -358,11 +355,11 @@ class TestUntilRequestTask:
         task = task_factory()
         with pytest.raises(RestartScenario):
             with caplog.at_level(ERROR):
-                task(scenario)
+                task(parent)
 
         assert len(caplog.messages) == 1
         assert caplog.messages[-1] == (
-            f'{task_factory.scenario.identifier} test-request, w=4.0s, r=4, em=4: endpoint={meta_request_task.endpoint}, number_of_matches=3, '
+            f'{parent.user._scenario.identifier} test-request, w=4.0s, r=4, em=4: endpoint={meta_request_task.endpoint}, number_of_matches=3, '
             f'condition=$.list[?(@.count > 19)], retry=4, response_time=555 payload=\n{jsondumps(return_value_object, indent=2)}'
         )
 
@@ -372,7 +369,7 @@ class TestUntilRequestTask:
         _, kwargs = fire_spy.call_args_list[-1]
 
         assert kwargs.get('request_type', None) == 'UNTL'
-        assert kwargs.get('name', None) == f'{task_factory.scenario.identifier} test-request, w=4.0s, r=4, em=4'
+        assert kwargs.get('name', None) == f'{parent.user._scenario.identifier} test-request, w=4.0s, r=4, em=4'
         assert kwargs.get('response_time', None) == 555
         assert kwargs.get('response_length', None) == 852
         assert kwargs.get('context', None) == {'variables': {}}
@@ -380,51 +377,51 @@ class TestUntilRequestTask:
         assert isinstance(exception, RuntimeError)
         assert str(exception) == 'found 3 matching values for $.list[?(@.count > 19)] in payload'
 
-        task_factory = UntilRequestTask(grizzly, meta_request_task, '$.list[?(@.count == 18)] | wait=4, expected_matches=2, retries=4', scenario=meta_request_task.scenario)
+        task_factory = UntilRequestTask(grizzly, meta_request_task, '$.list[?(@.count == 18)] | wait=4, expected_matches=2, retries=4')
         assert task_factory.expected_matches == 2
         assert task_factory.wait == 4
         assert task_factory.retries == 4
 
         task = task_factory()
-        task(scenario)
+        task(parent)
 
         assert fire_spy.call_count == 8
         _, kwargs = fire_spy.call_args_list[-1]
 
         assert kwargs.get('request_type', None) == 'UNTL'
-        assert kwargs.get('name', None) == f'{task_factory.scenario.identifier} test-request, w=4.0s, r=4, em=2'
+        assert kwargs.get('name', None) == f'{parent.user._scenario.identifier} test-request, w=4.0s, r=4, em=2'
         assert kwargs.get('response_time', None) == 666
         assert kwargs.get('response_length', None) == 213
         assert kwargs.get('context', None) == {'variables': {}}
         assert kwargs.get('exception', '') is None
 
-        task_factory = UntilRequestTask(grizzly, meta_request_task, '$.list[?(@.count == 18)] | wait=4, expected_matches=1, retries=1', scenario=meta_request_task.scenario)
+        task_factory = UntilRequestTask(grizzly, meta_request_task, '$.list[?(@.count == 18)] | wait=4, expected_matches=1, retries=1')
         task = task_factory()
         request_spy.return_value = ({}, None,)
-        meta_request_task.scenario.failure_exception = None
+        parent.user._scenario.failure_exception = None
 
-        task(scenario)
+        task(parent)
 
         assert fire_spy.call_count == 9
         _, kwargs = fire_spy.call_args_list[-1]
 
         assert kwargs.get('request_type', None) == 'UNTL'
-        assert kwargs.get('name', None) == f'{task_factory.scenario.identifier} test-request, w=4.0s, r=1, em=1'
+        assert kwargs.get('name', None) == f'{parent.user._scenario.identifier} test-request, w=4.0s, r=1, em=1'
         assert kwargs.get('response_time', None) == 666
         assert kwargs.get('response_length', None) == 0
         assert kwargs.get('context', None) == {'variables': {}}
         assert isinstance(kwargs.get('exception', ''), TransformerError)
 
-        mocker.patch.object(scenario.logger, 'error', side_effect=[RuntimeError, None])
+        mocker.patch.object(parent.logger, 'error', side_effect=[RuntimeError, None])
         request_spy.return_value = ({}, None,)
 
-        task(scenario)
+        task(parent)
 
         assert fire_spy.call_count == 10
         _, kwargs = fire_spy.call_args_list[-1]
 
         assert kwargs.get('request_type', None) == 'UNTL'
-        assert kwargs.get('name', None) == f'{task_factory.scenario.identifier} test-request, w=4.0s, r=1, em=1'
+        assert kwargs.get('name', None) == f'{parent.user._scenario.identifier} test-request, w=4.0s, r=1, em=1'
         assert kwargs.get('response_time', None) == 111
         assert kwargs.get('response_length', None) == 0
         assert kwargs.get('context', None) == {'variables': {}}
@@ -439,22 +436,20 @@ class TestUntilRequestTask:
         meta_args: Tuple[Any, ...],
         meta_kwargs: Dict[str, Any],
     ) -> None:
-        _, _, scenario = grizzly_fixture()
-        assert scenario is not None
+        parent = grizzly_fixture()
 
         meta_request_task = meta_request_task_type(*meta_args, **meta_kwargs)
 
-        meta_request_task.scenario = grizzly_fixture.request_task.request.scenario
         on_start_spy = mocker.spy(meta_request_task, 'on_start')
 
         grizzly = grizzly_fixture.grizzly
 
-        task_factory = UntilRequestTask(grizzly, meta_request_task, "$.`this`[?status='ready'] | wait=100, retries=10", scenario=meta_request_task.scenario)
+        task_factory = UntilRequestTask(grizzly, meta_request_task, "$.`this`[?status='ready'] | wait=100, retries=10")
         task = task_factory()
 
-        task.on_start(scenario)
+        task.on_start(parent)
 
-        on_start_spy.assert_called_once_with(scenario)
+        on_start_spy.assert_called_once_with(parent)
 
     @pytest.mark.parametrize(*parameterize)
     def test_on_stop(
@@ -465,19 +460,17 @@ class TestUntilRequestTask:
         meta_args: Tuple[Any, ...],
         meta_kwargs: Dict[str, Any],
     ) -> None:
-        _, _, scenario = grizzly_fixture()
-        assert scenario is not None
+        parent = grizzly_fixture()
 
         meta_request_task = meta_request_task_type(*meta_args, **meta_kwargs)
 
-        meta_request_task.scenario = grizzly_fixture.request_task.request.scenario
         on_stop_spy = mocker.spy(meta_request_task, 'on_stop')
 
         grizzly = grizzly_fixture.grizzly
 
-        task_factory = UntilRequestTask(grizzly, meta_request_task, "$.`this`[?status='ready'] | wait=100, retries=10", scenario=meta_request_task.scenario)
+        task_factory = UntilRequestTask(grizzly, meta_request_task, "$.`this`[?status='ready'] | wait=100, retries=10")
         task = task_factory()
 
-        task.on_stop(scenario)
+        task.on_stop(parent)
 
-        on_stop_spy.assert_called_once_with(scenario)
+        on_stop_spy.assert_called_once_with(parent)

--- a/tests/unit/test_grizzly/test_behave.py
+++ b/tests/unit/test_grizzly/test_behave.py
@@ -131,7 +131,7 @@ def test_before_feature(behave_fixture: BehaveFixture, tmp_path_factory: TempPat
 
 
 def test_after_feature(grizzly_fixture: GrizzlyFixture, mocker: MockerFixture, capsys: CaptureFixture) -> None:
-    behave = grizzly_fixture.behave
+    behave = grizzly_fixture.behave.context
     grizzly = grizzly_fixture.grizzly
     feature = Feature(None, None, '', '', scenarios=[behave.scenario])
     behave.scenario.steps = [Step(None, None, '', '', ''), Step(None, None, '', '', '')]
@@ -301,7 +301,7 @@ def test_before_scenario(behave_fixture: BehaveFixture, mocker: MockerFixture) -
 def test_after_scenario(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = behave_fixture.grizzly
-
+    grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
     grizzly.scenario.tasks.tmp.async_group = AsyncRequestGroupTask(name='test-async-1')
 
     with pytest.raises(AssertionError) as ae:
@@ -372,7 +372,7 @@ def test_before_step(behave_fixture: BehaveFixture) -> None:
 
 
 def test_after_step(grizzly_fixture: GrizzlyFixture) -> None:
-    behave = grizzly_fixture.behave
+    behave = grizzly_fixture.behave.context
     grizzly = grizzly_fixture.grizzly
 
     behave.last_task_count = {}

--- a/tests/unit/test_grizzly/test_clients.py
+++ b/tests/unit/test_grizzly/test_clients.py
@@ -12,6 +12,7 @@ from locust.clients import ResponseContextManager
 from locust.event import EventHook
 from paramiko.transport import Transport
 from paramiko.sftp_client import SFTPClient
+from behave.model import Scenario
 
 from grizzly.clients import ResponseEventSession, SftpClientSession
 from grizzly.types import RequestMethod
@@ -60,10 +61,8 @@ class TestResponseEventSession:
 
         session = ResponseEventSession(base_url='', request_event=RequestEvent())
         request = RequestTask(RequestMethod.POST, name='test-request', endpoint='/api/test')
-        scenario = GrizzlyContextScenario(1)
-        scenario.name = 'TestScenario'
+        scenario = GrizzlyContextScenario(1, behave=Scenario('<stdin>', 0, 'Any', 'TestScenario'))
         scenario.context['host'] = 'test'
-        request.scenario = scenario
 
         def handler(expected_request: Optional[RequestTask] = None) -> Callable[
             [str, Union[ResponseContextManager, Tuple[Dict[str, Any], str]], Optional[RequestTask], GrizzlyUser],
@@ -91,7 +90,6 @@ class TestResponseEventSession:
             session.request(method='GET', url='http://example.org', name='test-name', catch_response=False, request=request)
 
         second_request = RequestTask(RequestMethod.GET, name='test-request', endpoint='/api/test')
-        second_request.scenario = scenario
 
         # handler is called, but request is not the same
         session.request(method='GET', url='http://example.org', name='test-name', catch_response=False, request=second_request)

--- a/tests/unit/test_grizzly/testdata/variables/test_csv_writer.py
+++ b/tests/unit/test_grizzly/testdata/variables/test_csv_writer.py
@@ -39,7 +39,7 @@ def test_atomiccsvwriter__base_type__(grizzly_fixture: GrizzlyFixture) -> None:
 
 
 def test_atomiccsvwriter_message_handler(grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
-    env, _, _ = grizzly_fixture()
+    parent = grizzly_fixture()
 
     destination_file = grizzly_fixture.test_context / 'foobar.csv'
 
@@ -53,7 +53,7 @@ def test_atomiccsvwriter_message_handler(grizzly_fixture: GrizzlyFixture, mocker
         }
     }, node_id=None)
 
-    atomiccsvwriter_message_handler(env, message)
+    atomiccsvwriter_message_handler(parent.user.environment, message)
 
     assert destination_file.exists()
     assert destination_file.read_text() == 'foo,bar\nhello,world!\n'
@@ -66,7 +66,7 @@ def test_atomiccsvwriter_message_handler(grizzly_fixture: GrizzlyFixture, mocker
         }
     }, node_id=None)
 
-    atomiccsvwriter_message_handler(env, message)
+    atomiccsvwriter_message_handler(parent.user.environment, message)
 
     assert destination_file.read_text() == 'foo,bar\nhello,world!\nbar,foo\n'
 

--- a/tests/unit/test_grizzly/users/base/test_response_event.py
+++ b/tests/unit/test_grizzly/users/base/test_response_event.py
@@ -21,11 +21,11 @@ class TestResponseEvent:
         assert ResponseEvent.host is None
 
         with pytest.raises(LocustError):
-            ResponseEvent(locust_fixture.env)
+            ResponseEvent(locust_fixture.environment)
 
         ResponseEvent.host = 'http://example.org'
 
-        user = ResponseEvent(locust_fixture.env)
+        user = ResponseEvent(locust_fixture.environment)
         assert getattr(user, 'client', '') is None
         assert len(user.response_event._handlers) == 0
 
@@ -33,7 +33,7 @@ class TestResponseEvent:
             'host': 'https://example.org'
         })
 
-        user = fake_user_type(locust_fixture.env)
+        user = fake_user_type(locust_fixture.environment)
         assert isinstance(user.client, ResponseEventSession)
         assert len(user.response_event._handlers) == 0
 
@@ -42,7 +42,7 @@ class TestResponseEvent:
             pass
 
         ResponseEvent.host = TestUser.host = 'http://example.com'
-        user = ResponseEvent(locust_fixture.env)
+        user = ResponseEvent(locust_fixture.environment)
 
         def handler(name: str, request: Optional[RequestTask], context: Union[ResponseContextManager, Tuple[Dict[str, Any], str]], user: User) -> None:
             raise Called()
@@ -58,5 +58,5 @@ class TestResponseEvent:
                 '',
                 RequestTask(RequestMethod.POST, name='test-request', endpoint='/api/test'),
                 ResponseContextManager(Response(), None, None),
-                TestUser(environment=locust_fixture.env),
+                TestUser(environment=locust_fixture.environment),
             )

--- a/tests/unit/test_grizzly/users/base/test_response_handler.py
+++ b/tests/unit/test_grizzly/users/base/test_response_handler.py
@@ -13,7 +13,6 @@ from requests.models import Response
 from jinja2.filters import FILTERS
 
 from grizzly.clients import ResponseEventSession
-from grizzly.context import GrizzlyContextScenario
 from grizzly.users.base import HttpRequests, ResponseEvent
 from grizzly.users.base.response_handler import ResponseHandler, ValidationHandlerAction, SaveHandlerAction, ResponseHandlerAction
 from grizzly.exceptions import ResponseHandlerError, RestartScenario
@@ -23,7 +22,7 @@ from grizzly.tasks import RequestTask
 from grizzly_extras.transformer import TransformerContentType
 from grizzly.testdata.utils import templatingfilter
 
-from tests.fixtures import LocustFixture, BehaveFixture
+from tests.fixtures import LocustFixture, GrizzlyFixture
 from tests.helpers import TestUser
 
 if TYPE_CHECKING:
@@ -40,10 +39,11 @@ class TestResponseHandlerAction:
         ) -> None:
             super().__call__(input_context, user, response)
 
-    def test___(self, locust_fixture: LocustFixture) -> None:
+    def test___init__(self, grizzly_fixture: GrizzlyFixture) -> None:
         assert issubclass(ResponseHandlerAction, ABC)
+        TestUser.__scenario__ = grizzly_fixture.grizzly.scenario
         TestUser.host = 'http://example.net'
-        user = TestUser(locust_fixture.environment)
+        user = TestUser(grizzly_fixture.behave.locust.environment)
         handler = TestResponseHandlerAction.Dummy('$.', '.*')
         assert handler.expression == '$.'
         assert handler.match_with == '.*'
@@ -53,9 +53,10 @@ class TestResponseHandlerAction:
             handler((TransformerContentType.JSON, None,), user)
         assert str(nie.value) == 'Dummy has not implemented __call__'
 
-    def test_get_matches(self, locust_fixture: LocustFixture) -> None:
+    def test_get_matches(self, grizzly_fixture: GrizzlyFixture) -> None:
+        TestUser.__scenario__ = grizzly_fixture.grizzly.scenario
         TestUser.host = 'http://example.net'
-        user = TestUser(locust_fixture.environment)
+        user = TestUser(grizzly_fixture.behave.locust.environment)
         handler = TestResponseHandlerAction.Dummy('//hello/world', '.*')
 
         with pytest.raises(TypeError) as te:
@@ -65,8 +66,6 @@ class TestResponseHandlerAction:
         with pytest.raises(TypeError) as te:
             handler.get_match((TransformerContentType.JSON, None, ), user)
         assert str(te.value) == '"//hello/world" is not a valid expression for JSON'
-
-        handler = TestResponseHandlerAction.Dummy('$.hello[?world="bar"].foo', '.*', 2)
 
         response = {
             'hello': [{
@@ -80,9 +79,14 @@ class TestResponseHandlerAction:
                 'foo': 2,
             }]
         }
-        print(response)
+
+        handler = TestResponseHandlerAction.Dummy('$.hello[?world="bar"].foo', '.*', 2, as_json=True)
         match, _, _ = handler.get_match((TransformerContentType.JSON, response, ), user)
         assert match == '["1", "2"]'
+
+        handler = TestResponseHandlerAction.Dummy('$.hello[?world="bar"].foo', '.*', 2, as_json=False)
+        match, _, _ = handler.get_match((TransformerContentType.JSON, response, ), user)
+        assert match == '1\n2'
 
 
 class TestValidationHandlerAction:
@@ -95,17 +99,16 @@ class TestValidationHandlerAction:
         assert handler.match_with == 'foo'
         assert handler.expected_matches == 1
 
-    def test___call___true(self, behave_fixture: BehaveFixture) -> None:
-        scenario = GrizzlyContextScenario(index=1, behave=behave_fixture.create_scenario('test-scenario'))
+    def test___call___true(self, grizzly_fixture: GrizzlyFixture) -> None:
+        TestUser.__scenario__ = grizzly_fixture.grizzly.scenario
         TestUser.host = 'http://example.net'
-        user = TestUser(behave_fixture.locust.environment)
-        user._scenario = scenario
+        user = TestUser(grizzly_fixture.behave.locust.environment)
 
         try:
             response = Response()
             response._content = '{}'.encode('utf-8')
             response.status_code = 200
-            response_context_manager = ResponseContextManager(response, behave_fixture.locust.environment.events.request, {})
+            response_context_manager = ResponseContextManager(response, grizzly_fixture.behave.locust.environment.events.request, {})
             response_context_manager._entered = True
 
             handler = ValidationHandlerAction(
@@ -269,17 +272,16 @@ class TestValidationHandlerAction:
                 except:
                     pass
 
-            assert user._context['variables'] is not TestUser(behave_fixture.locust.environment)._context['variables']
+            assert user._context['variables'] is not TestUser(grizzly_fixture.behave.locust.environment)._context['variables']
 
-    def test___call___false(self, behave_fixture: BehaveFixture) -> None:
-        scenario = GrizzlyContextScenario(index=1, behave=behave_fixture.create_scenario('test-scenario'))
+    def test___call___false(self, grizzly_fixture: GrizzlyFixture) -> None:
+        TestUser.__scenario__ = grizzly_fixture.grizzly.scenario
         TestUser.host = 'http://example.io'
-        user = TestUser(behave_fixture.locust.environment)
-        user._scenario = scenario
+        user = TestUser(grizzly_fixture.behave.locust.environment)
         response = Response()
         response._content = '{}'.encode('utf-8')
         response.status_code = 200
-        response_context_manager = ResponseContextManager(response, behave_fixture.locust.environment.events.request, {})
+        response_context_manager = ResponseContextManager(response, grizzly_fixture.behave.locust.environment.events.request, {})
         response_context_manager._entered = True
 
         handler = ValidationHandlerAction(False, expression='$.test.value', match_with='test')
@@ -413,22 +415,22 @@ class TestValidationHandlerAction:
         assert isinstance(getattr(response_context_manager, '_manual_result', None), ResponseHandlerError)
         response_context_manager._manual_result = None
 
-        scenario.failure_exception = None
+        user._scenario.failure_exception = None
 
         with pytest.raises(ResponseHandlerError):
             handler((TransformerContentType.JSON, True), user, None)
 
-        scenario.failure_exception = StopUser
+        user._scenario.failure_exception = StopUser
 
         with pytest.raises(StopUser):
             handler((TransformerContentType.JSON, True), user, None)
 
-        scenario.failure_exception = RestartScenario
+        user._scenario.failure_exception = RestartScenario
 
         with pytest.raises(RestartScenario):
             handler((TransformerContentType.JSON, True), user, None)
 
-        scenario.failure_exception = None
+        user._scenario.failure_exception = None
 
         handler((TransformerContentType.JSON, False), user, response_context_manager)
         assert response_context_manager._manual_result is None
@@ -444,16 +446,15 @@ class TestSaveHandlerAction:
         assert handler.match_with == 'foo'
         assert handler.expected_matches == 1
 
-    def test___call__(self, behave_fixture: BehaveFixture) -> None:
+    def test___call__(self, grizzly_fixture: GrizzlyFixture) -> None:
+        TestUser.__scenario__ = grizzly_fixture.grizzly.scenario
         TestUser.host = 'http://example.com'
-        user = TestUser(behave_fixture.locust.environment)
+        user = TestUser(grizzly_fixture.behave.locust.environment)
         response = Response()
         response._content = '{}'.encode('utf-8')
         response.status_code = 200
-        response_context_manager = ResponseContextManager(response, behave_fixture.locust.environment.events.request, {})
+        response_context_manager = ResponseContextManager(response, grizzly_fixture.behave.locust.environment.events.request, {})
         response_context_manager._entered = True
-        scenario = GrizzlyContextScenario(index=1, behave=behave_fixture.create_scenario('test-scenario'))
-        user._scenario = scenario
 
         assert 'test' not in user.context_variables
 
@@ -496,17 +497,17 @@ class TestSaveHandlerAction:
         assert isinstance(getattr(response_context_manager, '_manual_result', None), ResponseHandlerError)
         assert user.context_variables.get('test', 'test') is None
 
-        scenario.failure_exception = None
+        user._scenario.failure_exception = None
 
         with pytest.raises(StopUser):
             handler((TransformerContentType.JSON, {'test': {'name': 'test'}}), user, None)
 
-        scenario.failure_exception = StopUser
+        user._scenario.failure_exception = StopUser
 
         with pytest.raises(StopUser):
             handler((TransformerContentType.JSON, {'test': {'name': 'test'}}), user, None)
 
-        scenario.failure_exception = RestartScenario
+        user._scenario.failure_exception = RestartScenario
 
         with pytest.raises(RestartScenario):
             handler((TransformerContentType.JSON, {'test': {'name': 'test'}}), user, None)
@@ -694,10 +695,11 @@ class TestResponseHandler:
         assert isinstance(user.response_event, EventHook)
         assert len(user.response_event._handlers) == 1
 
-    def test_response_handler_response_context(self, mocker: MockerFixture, locust_fixture: LocustFixture) -> None:
+    def test_response_handler_response_context(self, mocker: MockerFixture, grizzly_fixture: GrizzlyFixture) -> None:
         ResponseHandler.host = TestUser.host = 'http://example.com'
-        user = ResponseHandler(locust_fixture.environment)
-        test_user = TestUser(locust_fixture.environment)
+        user = ResponseHandler(grizzly_fixture.behave.locust.environment)
+        TestUser.__scenario__ = grizzly_fixture.grizzly.scenario
+        test_user = TestUser(grizzly_fixture.behave.locust.environment)
 
         response = Response()
         response._content = jsondumps({}).encode('utf-8')

--- a/tests/unit/test_grizzly/users/test_blobstorage.py
+++ b/tests/unit/test_grizzly/users/test_blobstorage.py
@@ -1,7 +1,7 @@
 import os
 import json
 
-from typing import Tuple, cast
+from typing import cast
 
 import pytest
 
@@ -9,7 +9,7 @@ from azure.storage.blob._blob_client import BlobClient
 
 from pytest_mock import MockerFixture
 
-from grizzly.types.locust import Environment, StopUser
+from grizzly.types.locust import StopUser
 from grizzly.users.blobstorage import BlobStorageUser
 from grizzly.users.base.grizzly_user import GrizzlyUser
 from grizzly.types import RequestMethod
@@ -17,89 +17,86 @@ from grizzly.context import GrizzlyContextScenario
 from grizzly.tasks import RequestTask
 from grizzly.testdata.utils import transform
 from grizzly.exceptions import RestartScenario
+from grizzly.scenarios import GrizzlyScenario
 
 from tests.fixtures import GrizzlyFixture
 
 
 CONNECTION_STRING = 'DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=my-storage;AccountKey=xxxyyyyzzz=='
 
-BlobStorageScenarioFixture = Tuple[BlobStorageUser, GrizzlyContextScenario, Environment]
-
 
 @pytest.fixture
-def blob_storage_scenario(grizzly_fixture: GrizzlyFixture) -> BlobStorageScenarioFixture:
-    environment, user, task = grizzly_fixture(
+def blob_storage_parent(grizzly_fixture: GrizzlyFixture) -> GrizzlyScenario:
+    parent = grizzly_fixture(
         CONNECTION_STRING,
         BlobStorageUser,
     )
 
     request = grizzly_fixture.request_task.request
-
-    scenario = GrizzlyContextScenario(99)
-    scenario.name = task.__class__.__name__
-    scenario.user.class_name = 'BlobStorageUser'
-    scenario.context['host'] = 'test'
-
     request.method = RequestMethod.SEND
 
+    scenario = GrizzlyContextScenario(99, behave=grizzly_fixture.behave.create_scenario('test scenario'))
+    scenario.user.class_name = 'BlobStorageUser'
+    scenario.context['host'] = 'test'
+    scenario.tasks.clear()
     scenario.tasks.add(request)
 
-    return cast(BlobStorageUser, user), scenario, environment
+    grizzly_fixture.grizzly.scenarios.clear()
+    grizzly_fixture.grizzly.scenarios.append(scenario)
+
+    return parent
 
 
 class TestBlobStorageUser:
-    @pytest.mark.usefixtures('blob_storage_scenario')
-    def test_on_start(self, mocker: MockerFixture, blob_storage_scenario: BlobStorageScenarioFixture) -> None:
-        user, _, _ = blob_storage_scenario
+    @pytest.mark.usefixtures('blob_storage_parent')
+    def test_on_start(self, blob_storage_parent: GrizzlyScenario) -> None:
+        assert not hasattr(blob_storage_parent.user, 'client')
 
-        assert not hasattr(user, 'client')
+        blob_storage_parent.user.on_start()
 
-        user.on_start()
+        assert hasattr(blob_storage_parent.user, 'client')
+        assert blob_storage_parent.user.client.account_name == 'my-storage'
 
-        assert hasattr(user, 'client')
-        assert user.client.account_name == 'my-storage'
+    @pytest.mark.usefixtures('blob_storage_parent')
+    def test_on_stop(self, mocker: MockerFixture, blob_storage_parent: GrizzlyScenario) -> None:
+        assert isinstance(blob_storage_parent.user, BlobStorageUser)
+        blob_storage_parent.user.on_start()
 
-    @pytest.mark.usefixtures('blob_storage_scenario')
-    def test_on_stop(self, mocker: MockerFixture, blob_storage_scenario: BlobStorageScenarioFixture) -> None:
-        user, _, _ = blob_storage_scenario
-        user.on_start()
+        on_stop_spy = mocker.spy(blob_storage_parent.user.client, 'close')
 
-        on_stop_spy = mocker.spy(user.client, 'close')
-
-        user.on_stop()
+        blob_storage_parent.user.on_stop()
 
         assert on_stop_spy.call_count == 1
 
-    @pytest.mark.usefixtures('blob_storage_scenario')
-    def test_create(self, blob_storage_scenario: BlobStorageScenarioFixture) -> None:
-        user, _, environment = blob_storage_scenario
-        user.on_start()
-        assert issubclass(user.__class__, GrizzlyUser)
+    @pytest.mark.usefixtures('blob_storage_parent')
+    def test_create(self, blob_storage_parent: GrizzlyScenario) -> None:
+        assert isinstance(blob_storage_parent.user, BlobStorageUser)
+        assert issubclass(blob_storage_parent.user.__class__, GrizzlyUser)
+        blob_storage_parent.user.on_start()
 
         BlobStorageUser.host = 'DefaultEndpointsProtocol=http;EndpointSuffix=core.windows.net;AccountName=my-storage;AccountKey=xxxyyyyzzz=='
         with pytest.raises(ValueError) as e:
-            user = BlobStorageUser(environment)
+            BlobStorageUser(blob_storage_parent.user.environment)
         assert 'is not supported for BlobStorageUser' in str(e)
 
         BlobStorageUser.host = 'DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net'
         with pytest.raises(ValueError) as e:
-            user = BlobStorageUser(environment)
+            BlobStorageUser(blob_storage_parent.user.environment)
         assert 'needs AccountName and AccountKey in the query string' in str(e)
 
         BlobStorageUser.host = 'DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountKey=xxxyyyyzzz=='
         with pytest.raises(ValueError) as e:
-            user = BlobStorageUser(environment)
+            BlobStorageUser(blob_storage_parent.user.environment)
         assert 'needs AccountName in the query string' in str(e)
 
         BlobStorageUser.host = 'DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=my-storage'
         with pytest.raises(ValueError) as e:
-            user = BlobStorageUser(environment)
+            BlobStorageUser(blob_storage_parent.user.environment)
         assert 'needs AccountKey in the query string' in str(e)
 
-    @pytest.mark.usefixtures('blob_storage_scenario')
-    def test_send(self, blob_storage_scenario: BlobStorageScenarioFixture, mocker: MockerFixture, grizzly_fixture: GrizzlyFixture) -> None:
-        user, scenario, _ = blob_storage_scenario
-        user.on_start()
+    @pytest.mark.usefixtures('blob_storage_parent')
+    def test_send(self, blob_storage_parent: GrizzlyScenario, mocker: MockerFixture, grizzly_fixture: GrizzlyFixture) -> None:
+        blob_storage_parent.user.on_start()
 
         grizzly = grizzly_fixture.grizzly
 
@@ -110,8 +107,8 @@ class TestBlobStorageUser:
                 'messageID': 137,
             }),
         }
-        user.add_context(remote_variables)
-        request = cast(RequestTask, scenario.tasks()[-1])
+        blob_storage_parent.user.add_context(remote_variables)
+        request = cast(RequestTask, blob_storage_parent.user._scenario.tasks()[-1])
         request.endpoint = 'some_container_name'
 
         upload_blob = mocker.patch('azure.storage.blob._blob_service_client.BlobClient.upload_blob', autospec=True)
@@ -127,7 +124,7 @@ class TestBlobStorageUser:
             }
         }
 
-        metadata, payload = user.request(request)
+        metadata, payload = blob_storage_parent.user.request(blob_storage_parent, request)
 
         assert payload is not None
         assert upload_blob.call_count == 1
@@ -141,46 +138,46 @@ class TestBlobStorageUser:
 
         json_payload = json.loads(payload)
         assert json_payload['result']['id'] == 'ID-31337'
-        assert blob_client.container_name == cast(RequestTask, scenario.tasks()[-1]).endpoint
-        assert blob_client.blob_name == os.path.basename(scenario.name)
+        assert blob_client.container_name == cast(RequestTask, blob_storage_parent.user._scenario.tasks()[-1]).endpoint
+        assert blob_client.blob_name == os.path.basename(request.name)
 
-        request = cast(RequestTask, scenario.tasks()[-1])
+        request = cast(RequestTask, blob_storage_parent.user._scenario.tasks()[-1])
 
-        user.request(request)
+        blob_storage_parent.user.request(blob_storage_parent, request)
 
-        request_event = mocker.spy(user.environment.events.request, 'fire')
+        request_event = mocker.spy(blob_storage_parent.user.environment.events.request, 'fire')
 
         request.method = RequestMethod.RECEIVE
         with pytest.raises(StopUser):
-            user.request(request)
+            blob_storage_parent.user.request(blob_storage_parent, request)
 
         assert request_event.call_count == 1
         _, kwargs = request_event.call_args_list[-1]
 
         assert kwargs.get('request_type', None) == 'RECV'
-        assert kwargs.get('name', None) == f'{request.scenario.identifier} {request.scenario.name}'
+        assert kwargs.get('name', None) == f'{blob_storage_parent.user._scenario.identifier} {request.name}'
         assert kwargs.get('response_time', -1) > -1
         assert kwargs.get('response_length', None) == 0
-        assert kwargs.get('context', None) is user._context
+        assert kwargs.get('context', None) is blob_storage_parent.user._context
         exception = kwargs.get('exception', None)
         assert isinstance(exception, NotImplementedError)
         assert 'has not implemented RECEIVE' in str(exception)
 
-        request.scenario.failure_exception = None
+        blob_storage_parent.user._scenario.failure_exception = None
         with pytest.raises(StopUser):
-            user.request(request)
+            blob_storage_parent.user.request(blob_storage_parent, request)
 
-        request.scenario.failure_exception = StopUser
+        blob_storage_parent.user._scenario.failure_exception = StopUser
         with pytest.raises(StopUser):
-            user.request(request)
+            blob_storage_parent.user.request(blob_storage_parent, request)
 
-        request.scenario.failure_exception = RestartScenario
+        blob_storage_parent.user._scenario.failure_exception = RestartScenario
         with pytest.raises(StopUser):
-            user.request(request)
+            blob_storage_parent.user.request(blob_storage_parent, request)
 
         upload_blob = mocker.patch('azure.storage.blob._blob_service_client.BlobClient.upload_blob', side_effect=[RuntimeError('failed to upload blob')])
 
         request.method = RequestMethod.SEND
 
         with pytest.raises(RestartScenario):
-            user.request(request)
+            blob_storage_parent.user.request(blob_storage_parent, request)

--- a/tests/unit/test_grizzly/users/test_dummy.py
+++ b/tests/unit/test_grizzly/users/test_dummy.py
@@ -9,14 +9,18 @@ from tests.fixtures import GrizzlyFixture
 class TestDummyUser:
     def test___init__(self, grizzly_fixture: GrizzlyFixture) -> None:
         grizzly_fixture()
-        environment = grizzly_fixture.locust_env
+        environment = grizzly_fixture.behave.locust.environment
+        DummyUser.__scenario__ = grizzly_fixture.grizzly.scenario
         DummyUser.host = ''
         assert isinstance(DummyUser(environment), GrizzlyUser)
 
     def test_request(self, grizzly_fixture: GrizzlyFixture) -> None:
-        grizzly_fixture()
+        parent = grizzly_fixture()
+        DummyUser.__scenario__ = grizzly_fixture.grizzly.scenario
         DummyUser.host = '/dev/null'
-        user = DummyUser(grizzly_fixture.locust_env)
+        user = DummyUser(grizzly_fixture.behave.locust.environment)
 
         for method in RequestMethod:
-            assert user.request(RequestTask(method, 'dummy', '/api/what/ever')) == (None, None,)
+            assert user.request(parent, RequestTask(method, 'dummy', '/api/what/ever')) == (None, None,)
+
+        assert user._scenario is not DummyUser.__scenario__

--- a/tests/unit/test_grizzly/users/test_messagequeue.py
+++ b/tests/unit/test_grizzly/users/test_messagequeue.py
@@ -24,33 +24,37 @@ from grizzly.testdata import GrizzlyVariables
 from grizzly.testdata.utils import transform
 from grizzly.exceptions import ResponseHandlerError, RestartScenario
 from grizzly.steps._helpers import add_save_handler
+from grizzly.scenarios import IteratorScenario, GrizzlyScenario
 from grizzly_extras.async_message import AsyncMessageResponse
 from grizzly_extras.transformer import TransformerContentType
 
-from tests.fixtures import GrizzlyFixture, LocustFixture, NoopZmqFixture
+from tests.fixtures import GrizzlyFixture, NoopZmqFixture, BehaveFixture
 
 MqScenarioFixture = Tuple[MessageQueueUser, GrizzlyContextScenario, Environment]
 
 
 @pytest.mark.usefixtures('grizzly_fixture')
 @pytest.fixture
-def mq_user(grizzly_fixture: GrizzlyFixture) -> MqScenarioFixture:
-    environment, user, task = grizzly_fixture(
-        'mq://mq.example.com:1337/?QueueManager=QMGR01&Channel=Kanal1', MessageQueueUser)
+def mq_parent(grizzly_fixture: GrizzlyFixture) -> GrizzlyScenario:
+    parent = grizzly_fixture(
+        host='mq://mq.example.com:1337/?QueueManager=QMGR01&Channel=Kanal1',
+        user_type=MessageQueueUser,
+    )
 
     request = grizzly_fixture.request_task.request
 
-    scenario = GrizzlyContextScenario(1)
-    scenario.name = task.__class__.__name__
+    scenario = GrizzlyContextScenario(1, behave=grizzly_fixture.behave.create_scenario(parent.__class__.__name__))
     scenario.user.class_name = 'MessageQueueUser'
     scenario.context['host'] = 'test'
 
     request.method = RequestMethod.SEND
-    request.scenario = scenario
 
     scenario.tasks.add(request)
+    grizzly_fixture.grizzly.scenarios.clear()
+    grizzly_fixture.grizzly.scenarios.append(scenario)
+    parent.user._scenario = scenario
 
-    return cast(MessageQueueUser, user), scenario, environment
+    return parent
 
 
 class TestMessageQueueUserNoPymqi:
@@ -67,7 +71,7 @@ class TestMessageQueueUserNoPymqi:
             [
                 sys.executable,
                 '-c',
-                'import grizzly.users.messagequeue as mq; from grizzly.locust import Environment; print(f"{mq.pymqi.__name__=}"); mq.MessageQueueUser(Environment())'
+                'import grizzly.users.messagequeue as mq; from grizzly.types.locust import Environment; print(f"{mq.pymqi.__name__=}"); mq.MessageQueueUser(Environment())'
             ],
             env=env,
             stdout=subprocess.PIPE,
@@ -94,11 +98,13 @@ class TestMessageQueueUser:
         'channel': '',
     }
 
-    def test_on_start(self, locust_fixture: LocustFixture, mocker: MockerFixture, noop_zmq: NoopZmqFixture) -> None:
+    def test_on_start(self, behave_fixture: BehaveFixture, mocker: MockerFixture, noop_zmq: NoopZmqFixture) -> None:
         noop_zmq('grizzly.users.messagequeue')
 
+        behave_fixture.grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
+        MessageQueueUser.__scenario__ = behave_fixture.grizzly.scenario
         MessageQueueUser.host = 'mq://mq.example.com:1337/?QueueManager=QMGR01&Channel=Kanal1'
-        user = MessageQueueUser(locust_fixture.env)
+        user = MessageQueueUser(behave_fixture.locust.environment)
 
         assert not hasattr(user, 'zmq_client')
 
@@ -131,11 +137,14 @@ class TestMessageQueueUser:
         assert kwargs == {}
         assert args == (user.zmq_url,)
 
-    def test_on_stop(self, locust_fixture: LocustFixture, mocker: MockerFixture, noop_zmq: NoopZmqFixture) -> None:
+    def test_on_stop(self, behave_fixture: BehaveFixture, mocker: MockerFixture, noop_zmq: NoopZmqFixture) -> None:
         noop_zmq('grizzly.users.messagequeue')
 
+        behave_fixture.grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
+
+        MessageQueueUser.__scenario__ = behave_fixture.grizzly.scenario
         MessageQueueUser.host = 'mq://mq.example.com:1337/?QueueManager=QMGR01&Channel=Kanal1'
-        user = MessageQueueUser(locust_fixture.env)
+        user = MessageQueueUser(behave_fixture.locust.environment)
         action_spy = mocker.patch.object(user, 'action_context', return_value=mocker.MagicMock())
 
         user.on_start()
@@ -176,41 +185,44 @@ class TestMessageQueueUser:
         assert len(args) == 1
         assert args[0] == user.zmq_url
 
-    def test_create(self, locust_fixture: LocustFixture) -> None:
+    def test_create(self, behave_fixture: BehaveFixture) -> None:
+        behave_fixture.grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
+        MessageQueueUser.__scenario__ = behave_fixture.grizzly.scenario
+
         try:
             MessageQueueUser.host = 'http://mq.example.com:1337'
             with pytest.raises(ValueError) as e:
-                MessageQueueUser(environment=locust_fixture.env)
+                MessageQueueUser(environment=behave_fixture.locust.environment)
             assert 'is not a supported scheme for MessageQueueUser' in str(e)
 
             MessageQueueUser.host = 'mq://mq.example.com:1337'
             with pytest.raises(ValueError) as e:
-                MessageQueueUser(environment=locust_fixture.env)
+                MessageQueueUser(environment=behave_fixture.locust.environment)
             assert 'needs QueueManager and Channel in the query string' in str(e)
 
             MessageQueueUser.host = 'mq://:1337'
             with pytest.raises(ValueError) as e:
-                MessageQueueUser(environment=locust_fixture.env)
+                MessageQueueUser(environment=behave_fixture.locust.environment)
             assert 'hostname is not specified in' in str(e)
 
             MessageQueueUser.host = 'mq://mq.example.com:1337/?Channel=Kanal1'
             with pytest.raises(ValueError) as e:
-                MessageQueueUser(environment=locust_fixture.env)
+                MessageQueueUser(environment=behave_fixture.locust.environment)
             assert 'needs QueueManager in the query string' in str(e)
 
             MessageQueueUser.host = 'mq://mq.example.com:1337/?QueueManager=QMGR01'
             with pytest.raises(ValueError) as e:
-                MessageQueueUser(environment=locust_fixture.env)
+                MessageQueueUser(environment=behave_fixture.locust.environment)
             assert 'needs Channel in the query string' in str(e)
 
             MessageQueueUser.host = 'mq://username:password@mq.example.com?Channel=Kanal1&QueueManager=QMGR01'
             with pytest.raises(ValueError) as e:
-                MessageQueueUser(environment=locust_fixture.env)
+                MessageQueueUser(environment=behave_fixture.locust.environment)
             assert 'username and password should be set via context' in str(e)
 
             # Test default port and ssl_cipher
             MessageQueueUser.host = 'mq://mq.example.com?Channel=Kanal1&QueueManager=QMGR01'
-            user = MessageQueueUser(environment=locust_fixture.env)
+            user = MessageQueueUser(environment=behave_fixture.locust.environment)
             assert user.am_context.get('connection', None) == 'mq.example.com(1414)'
             assert user.am_context.get('ssl_cipher', None) == 'ECDHE_RSA_AES_256_GCM_SHA384'
 
@@ -223,7 +235,7 @@ class TestMessageQueueUser:
             }
 
             MessageQueueUser.host = 'mq://mq.example.com:1415?Channel=Kanal1&QueueManager=QMGR01'
-            user = MessageQueueUser(environment=locust_fixture.env)
+            user = MessageQueueUser(environment=behave_fixture.locust.environment)
 
             assert user.am_context.get('connection', None) == 'mq.example.com(1415)'
             assert user.am_context.get('queue_manager', None) == 'QMGR01'
@@ -234,31 +246,31 @@ class TestMessageQueueUser:
 
             MessageQueueUser._context['auth']['cert_label'] = None
 
-            user = MessageQueueUser(environment=locust_fixture.env)
+            user = MessageQueueUser(environment=behave_fixture.locust.environment)
 
             assert user.am_context.get('cert_label', None) == 'syrsa'
 
             MessageQueueUser._context['message']['wait'] = 5
 
-            user = MessageQueueUser(environment=locust_fixture.env)
+            user = MessageQueueUser(environment=behave_fixture.locust.environment)
             assert user.am_context.get('message_wait', None) == 5
             assert issubclass(user.__class__, (RequestLogger, ResponseHandler,))
 
             MessageQueueUser._context['message']['header_type'] = 'RFH2'
 
-            user = MessageQueueUser(environment=locust_fixture.env)
+            user = MessageQueueUser(environment=behave_fixture.locust.environment)
             assert user.am_context.get('header_type', None) == 'rfh2'
             assert issubclass(user.__class__, (RequestLogger, ResponseHandler,))
 
             MessageQueueUser._context['message']['header_type'] = 'None'
 
-            user = MessageQueueUser(environment=locust_fixture.env)
+            user = MessageQueueUser(environment=behave_fixture.locust.environment)
             assert user.am_context.get('header_type', None) is None
             assert issubclass(user.__class__, (RequestLogger, ResponseHandler,))
 
             MessageQueueUser._context['message']['header_type'] = 'wrong'
             with pytest.raises(ValueError) as e:
-                MessageQueueUser(environment=locust_fixture.env)
+                MessageQueueUser(environment=behave_fixture.locust.environment)
             assert 'unsupported value for header_type: "wrong"' in str(e)
 
         finally:
@@ -272,7 +284,7 @@ class TestMessageQueueUser:
                 }
             }
 
-    def test_on_start__action_conn_error(self, locust_fixture: LocustFixture, mocker: MockerFixture, noop_zmq: NoopZmqFixture) -> None:
+    def test_on_start__action_conn_error(self, behave_fixture: BehaveFixture, mocker: MockerFixture, noop_zmq: NoopZmqFixture) -> None:
         def mocked_zmq_connect(*args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> Any:
             raise ZMQError(msg='error connecting')
 
@@ -283,7 +295,7 @@ class TestMessageQueueUser:
             mocked_zmq_connect,
         )
 
-        scenario = GrizzlyContextScenario(3)
+        scenario = GrizzlyContextScenario(3, behave=behave_fixture.create_scenario('test scenario'))
 
         def mocked_request_fire(*args: Tuple[Any, ...], **_kwargs: Dict[str, Any]) -> None:
             # ehm, mypy thinks that _kwargs has type dict[str, Dict[str, Any]]
@@ -306,8 +318,9 @@ class TestMessageQueueUser:
             mocked_request_fire,
         )
 
+        MessageQueueUser.__scenario__ = scenario
         MessageQueueUser.host = 'mq://mq.example.com:1337/?QueueManager=QMGR01&Channel=Kanal1'
-        user = MessageQueueUser(locust_fixture.env)
+        user = MessageQueueUser(behave_fixture.locust.environment)
 
         request = RequestTask(RequestMethod.PUT, name='test-put', endpoint='EXAMPLE.QUEUE')
         scenario.name = 'test'
@@ -319,7 +332,11 @@ class TestMessageQueueUser:
             user.on_start()
 
     @pytest.mark.skip(reason='needs real credentials and host etc.')
-    def test_get_tls_real(self, locust_fixture: LocustFixture) -> None:
+    def test_get_tls_real(self, grizzly_fixture: GrizzlyFixture) -> None:
+        parent = grizzly_fixture(user_type=MessageQueueUser, scenario_type=IteratorScenario)
+        assert isinstance(parent, IteratorScenario)
+        assert isinstance(parent.user, MessageQueueUser)
+
         process: Optional[subprocess.Popen] = None
         try:
             process = subprocess.Popen(
@@ -346,15 +363,15 @@ class TestMessageQueueUser:
             }
 
             request = RequestTask(RequestMethod.GET, name='test-get', endpoint=self.real_stuff['endpoint'])
-            scenario = GrizzlyContextScenario(1)
-            scenario.name = 'test'
+            scenario = GrizzlyContextScenario(1, behave=grizzly_fixture.behave.create_scenario('get tls real'))
             scenario.failure_exception = StopUser
             scenario.tasks.add(request)
 
             MessageQueueUser.host = f'mq://{self.real_stuff["host"]}/?QueueManager={self.real_stuff["queue_manager"]}&Channel={self.real_stuff["channel"]}'
-            user = MessageQueueUser(locust_fixture.env)
+            user = MessageQueueUser(parent.user.environment)
+            parent.user = user
 
-            user.request(request)
+            parent.user.request(parent, request)
             assert 0
         finally:
             if process is not None:
@@ -375,7 +392,11 @@ class TestMessageQueueUser:
             }
 
     @pytest.mark.skip(reason='needs real credentials and host etc.')
-    def test_put_tls_real(self, locust_fixture: LocustFixture) -> None:
+    def test_put_tls_real(self, grizzly_fixture: GrizzlyFixture) -> None:
+        parent = grizzly_fixture(user_type=MessageQueueUser, scenario_type=IteratorScenario)
+        assert isinstance(parent, IteratorScenario)
+        assert isinstance(parent.user, MessageQueueUser)
+
         process: Optional[subprocess.Popen] = None
         try:
             process = subprocess.Popen(
@@ -400,15 +421,15 @@ class TestMessageQueueUser:
 
             request = RequestTask(RequestMethod.PUT, name='test-put', endpoint=self.real_stuff['endpoint'])
             request.source = 'we <3 IBM MQ'
-            scenario = GrizzlyContextScenario(1)
-            scenario.name = 'test'
+            scenario = GrizzlyContextScenario(1, behave=grizzly_fixture.behave.create_scenario('put tls real'))
             scenario.failure_exception = StopUser
             scenario.tasks.add(request)
 
             MessageQueueUser.host = f'mq://{self.real_stuff["host"]}/?QueueManager={self.real_stuff["queue_manager"]}&Channel={self.real_stuff["channel"]}'
-            user = MessageQueueUser(locust_fixture.env)
+            user = MessageQueueUser(parent.user.environment)
+            parent.user = user
 
-            user.request(request)
+            parent.user.request(parent, request)
         finally:
             if process is not None:
                 try:
@@ -427,10 +448,12 @@ class TestMessageQueueUser:
                 }
             }
 
-    def test_get(self, mq_user: MqScenarioFixture, mocker: MockerFixture, noop_zmq: NoopZmqFixture) -> None:
-        [user, scenario, _] = mq_user
-
+    def test_get(self, grizzly_fixture: GrizzlyFixture, mq_parent: GrizzlyScenario, mocker: MockerFixture, noop_zmq: NoopZmqFixture) -> None:
         noop_zmq('grizzly.users.messagequeue')
+
+        assert isinstance(mq_parent.user, MessageQueueUser)
+
+        grizzly = grizzly_fixture.grizzly
 
         response_connected: AsyncMessageResponse = {
             'worker': '0000-1337',
@@ -452,10 +475,7 @@ class TestMessageQueueUser:
             }
         ]
 
-        grizzly = GrizzlyContext()
-        grizzly.scenarios.append(scenario)
-
-        user._context = {
+        mq_parent.user._context = {
             'auth': {
                 'username': None,
                 'password': None,
@@ -480,19 +500,19 @@ class TestMessageQueueUser:
             'metadata_variable': '',
         })
 
-        request_event_spy = mocker.spy(user.environment.events.request, 'fire')
-        response_event_spy = mocker.spy(user.response_event, 'fire')
+        request_event_spy = mocker.spy(mq_parent.user.environment.events.request, 'fire')
+        response_event_spy = mocker.spy(mq_parent.user.response_event, 'fire')
 
-        request = cast(RequestTask, scenario.tasks()[-1])
+        request = cast(RequestTask, mq_parent.user._scenario.tasks()[-1])
         request.endpoint = 'queue:test-queue'
         request.method = RequestMethod.GET
         request.source = None
-        scenario.tasks.add(request)
+        mq_parent.user._scenario.tasks.add(request)
 
-        user.add_context(remote_variables)
-        user.on_start()
+        mq_parent.user.add_context(remote_variables)
+        mq_parent.user.on_start()
 
-        metadata, payload = user.request(request)
+        metadata, payload = mq_parent.user.request(mq_parent, request)
 
         assert request_event_spy.call_count == 2
         _, kwargs = request_event_spy.call_args_list[0]
@@ -509,7 +529,7 @@ class TestMessageQueueUser:
         _, kwargs = response_event_spy.call_args_list[0]
         assert kwargs['request'] is request
         assert kwargs['context'] == (pymqi.MD().get(), test_payload)
-        assert kwargs['user'] is user
+        assert kwargs['user'] is mq_parent.user
 
         assert payload == test_payload
         assert metadata == pymqi.MD().get()
@@ -534,9 +554,9 @@ class TestMessageQueueUser:
         request.response.content_type = TransformerContentType.JSON
 
         add_save_handler(grizzly, ResponseTarget.PAYLOAD, '$.test', '.*', 'payload_variable')
-        user.request(request)
+        mq_parent.user.request(mq_parent, request)
 
-        assert user.context_variables['payload_variable'] == ''
+        assert mq_parent.user.context_variables['payload_variable'] == ''
         assert request_event_spy.call_count == 1
         _, kwargs = request_event_spy.call_args_list[0]
         assert kwargs['request_type'] == 'GET'
@@ -545,8 +565,8 @@ class TestMessageQueueUser:
         assert response_event_spy.call_count == 1
         _, kwargs = response_event_spy.call_args_list[0]
         assert kwargs['request'] is request
-        assert kwargs['user'] is user
-        assert kwargs['context'] == (pymqi.MD().get(), test_payload)
+        assert kwargs['user'] is mq_parent.user
+        assert kwargs['context'] == (pymqi.MD().get(), test_payload,)
 
         request_event_spy.reset_mock()
         response_event_spy.reset_mock()
@@ -568,9 +588,9 @@ class TestMessageQueueUser:
         ]
 
         request.response.content_type = TransformerContentType.JSON
-        user.request(request)
+        mq_parent.user.request(mq_parent, request)
 
-        assert user.context_variables['payload_variable'] == 'payload_variable value'
+        assert mq_parent.user.context_variables['payload_variable'] == 'payload_variable value'
 
         assert request_event_spy.call_count == 1
         _, kwargs = request_event_spy.call_args_list[0]
@@ -580,7 +600,7 @@ class TestMessageQueueUser:
         request_event_spy.reset_mock()
         response_event_spy.reset_mock()
 
-        user.request(request)
+        mq_parent.user.request(mq_parent, request)
 
         assert request_event_spy.call_count == 1
         _, kwargs = request_event_spy.call_args_list[0]
@@ -600,7 +620,7 @@ class TestMessageQueueUser:
                 'message': 'no implementation for POST'
             },
         ]
-        user.request(request)
+        mq_parent.user.request(mq_parent, request)
 
         assert request_event_spy.call_count == 1
         _, kwargs = request_event_spy.call_args_list[0]
@@ -620,26 +640,26 @@ class TestMessageQueueUser:
             } for _ in range(3)
         ]
 
-        scenario.failure_exception = None
-        user.request(request)
+        mq_parent.user._scenario.failure_exception = None
+        mq_parent.user.request(mq_parent, request)
 
         assert request_event_spy.call_count == 1
         _, kwargs = request_event_spy.call_args_list[-1]
         assert kwargs['exception'] is not None
         request_event_spy.reset_mock()
 
-        scenario.failure_exception = StopUser
+        mq_parent.user._scenario.failure_exception = StopUser
         with pytest.raises(StopUser):
-            user.request(request)
+            mq_parent.user.request(mq_parent, request)
 
         assert request_event_spy.call_count == 1
         _, kwargs = request_event_spy.call_args_list[-1]
         assert kwargs['exception'] is not None
         request_event_spy.reset_mock()
 
-        scenario.failure_exception = RestartScenario
+        mq_parent.user._scenario.failure_exception = RestartScenario
         with pytest.raises(RestartScenario):
-            user.request(request)
+            mq_parent.user.request(mq_parent, request)
 
         assert request_event_spy.call_count == 1
         _, kwargs = request_event_spy.call_args_list[0]
@@ -668,7 +688,7 @@ class TestMessageQueueUser:
 
         request.method = RequestMethod.GET
         request.endpoint = 'queue:IFKTEST'
-        user.request(request)
+        mq_parent.user.request(mq_parent, request)
         assert send_json_spy.call_count == 1
         args, kwargs = send_json_spy.call_args_list[0]
         assert len(args) == 1
@@ -678,7 +698,7 @@ class TestMessageQueueUser:
 
         # Test with specifying queue: prefix as endpoint
         request.endpoint = 'queue:IFKTEST'
-        user.request(request)
+        mq_parent.user.request(mq_parent, request)
         assert send_json_spy.call_count == 2
         args, kwargs = send_json_spy.call_args_list[-1]
         assert len(args) == 1
@@ -688,7 +708,7 @@ class TestMessageQueueUser:
 
         # Test specifying queue: prefix with expression
         request.endpoint = 'queue:IFKTEST2, expression:/class/student[marks>85]'
-        user.request(request)
+        mq_parent.user.request(mq_parent, request)
         assert send_json_spy.call_count == 3
         args, kwargs = send_json_spy.call_args_list[-1]
         assert len(args) == 1
@@ -698,7 +718,7 @@ class TestMessageQueueUser:
 
         # Test specifying queue: prefix with expression, and spacing
         request.endpoint = 'queue: IFKTEST2  , expression: /class/student[marks>85]'
-        user.request(request)
+        mq_parent.user.request(mq_parent, request)
         assert send_json_spy.call_count == 4
         args, kwargs = send_json_spy.call_args_list[-1]
         assert len(args) == 1
@@ -708,7 +728,7 @@ class TestMessageQueueUser:
 
         # Test specifying queue without prefix, with expression
         request.endpoint = 'queue:IFKTEST3, expression:/class/student[marks<55], max_message_size:13337'
-        user.request(request)
+        mq_parent.user.request(mq_parent, request)
         assert send_json_spy.call_count == 5
         args, kwargs = send_json_spy.call_args_list[-1]
         assert len(args) == 1
@@ -717,7 +737,7 @@ class TestMessageQueueUser:
         assert ctx['endpoint'] == request.endpoint
 
         request.endpoint = 'queue:IFKTEST3, max_message_size:444'
-        user.request(request)
+        mq_parent.user.request(mq_parent, request)
         assert send_json_spy.call_count == 6
         args, kwargs = send_json_spy.call_args_list[-1]
         assert len(args) == 1
@@ -728,14 +748,14 @@ class TestMessageQueueUser:
         # Test error when missing expression: prefix
         request.endpoint = 'queue:IFKTEST3, /class/student[marks<55]'
         with pytest.raises(StopUser):
-            user.request(request)
+            mq_parent.user.request(mq_parent, request)
 
         # Test with expression argument but wrong method
         request.endpoint = 'queue:IFKTEST3, expression:/class/student[marks<55]'
         request.method = RequestMethod.PUT
 
         with pytest.raises(StopUser):
-            user.request(request)
+            mq_parent.user.request(mq_parent, request)
 
         assert response_event_spy.call_count == 8
         assert send_json_spy.call_count == 6
@@ -749,7 +769,7 @@ class TestMessageQueueUser:
         request.method = RequestMethod.GET
 
         with pytest.raises(StopUser):
-            user.request(request)
+            mq_parent.user.request(mq_parent, request)
 
         assert response_event_spy.call_count == 9
         assert send_json_spy.call_count == 6
@@ -764,9 +784,7 @@ class TestMessageQueueUser:
 
         # Test queue / expression END
 
-    def test_send(self, mq_user: MqScenarioFixture, mocker: MockerFixture, noop_zmq: NoopZmqFixture) -> None:
-        [user, scenario, _] = mq_user
-
+    def test_send(self, mq_parent: GrizzlyScenario, mocker: MockerFixture, noop_zmq: NoopZmqFixture) -> None:
         noop_zmq('grizzly.users.messagequeue')
 
         response_connected: AsyncMessageResponse = {
@@ -775,7 +793,7 @@ class TestMessageQueueUser:
             'message': 'connected',
         }
 
-        user._context = {
+        mq_parent.user._context = {
             'auth': {
                 'username': None,
                 'password': None,
@@ -799,14 +817,14 @@ class TestMessageQueueUser:
             side_effect=[ZMQError] * 10,
         )
 
-        request_event_spy = mocker.spy(user.environment.events.request, 'fire')
+        request_event_spy = mocker.spy(mq_parent.user.environment.events.request, 'fire')
 
-        request = cast(RequestTask, scenario.tasks()[-1])
+        request = cast(RequestTask, mq_parent.user._scenario.tasks()[-1])
         request.endpoint = 'queue:TEST.QUEUE'
 
-        user.add_context(remote_variables)
+        mq_parent.user.add_context(remote_variables)
 
-        _, _, payload, _, _ = user.render(request)
+        _, _, payload, _, _ = mq_parent.user.render(request)
 
         assert payload is not None
 
@@ -825,9 +843,9 @@ class TestMessageQueueUser:
             ],
         )
 
-        user.on_start()
+        mq_parent.user.on_start()
 
-        user.request(request)
+        mq_parent.user.request(mq_parent, request)
 
         assert request_event_spy.call_count == 2
         _, kwargs = request_event_spy.call_args_list[0]
@@ -842,7 +860,7 @@ class TestMessageQueueUser:
 
         request_event_spy.reset_mock()
 
-        user.request(request)
+        mq_parent.user.request(mq_parent, request)
 
         assert request_event_spy.call_count == 1
         _, kwargs = request_event_spy.call_args_list[-1]
@@ -866,7 +884,7 @@ class TestMessageQueueUser:
             ],
         )
 
-        user.request(request)
+        mq_parent.user.request(mq_parent, request)
 
         assert request_event_spy.call_count == 1
         _, kwargs = request_event_spy.call_args_list[-1]
@@ -874,37 +892,37 @@ class TestMessageQueueUser:
         assert 'no implementation for POST' in str(kwargs['exception'])
         request_event_spy.reset_mock()
 
-        scenario.failure_exception = None
-        user.request(request)
+        mq_parent.user._scenario.failure_exception = None
+        mq_parent.user.request(mq_parent, request)
 
         assert request_event_spy.call_count == 1
         _, kwargs = request_event_spy.call_args_list[-1]
         assert kwargs['exception'] is not None
         request_event_spy.reset_mock()
 
-        scenario.failure_exception = StopUser
+        mq_parent.user._scenario.failure_exception = StopUser
         with pytest.raises(StopUser):
-            user.request(request)
+            mq_parent.user.request(mq_parent, request)
 
         assert request_event_spy.call_count == 1
         _, kwargs = request_event_spy.call_args_list[-1]
         assert kwargs['exception'] is not None
         request_event_spy.reset_mock()
 
-        scenario.failure_exception = RestartScenario
+        mq_parent.user._scenario.failure_exception = RestartScenario
         with pytest.raises(RestartScenario):
-            user.request(request)
+            mq_parent.user.request(mq_parent, request)
 
         assert request_event_spy.call_count == 1
         _, kwargs = request_event_spy.call_args_list[-1]
         assert kwargs['exception'] is not None
         request_event_spy.reset_mock()
 
-        request.scenario.failure_exception = None
+        mq_parent.user._scenario.failure_exception = None
         request.endpoint = 'sub:TEST.QUEUE'
 
         with pytest.raises(StopUser):
-            user.request(request)
+            mq_parent.user.request(mq_parent, request)
 
         assert request_event_spy.call_count == 1
         _, kwargs = request_event_spy.call_args_list[-1]
@@ -914,7 +932,7 @@ class TestMessageQueueUser:
 
         request.endpoint = 'queue:TEST.QUEUE, argument:False'
         with pytest.raises(StopUser):
-            user.request(request)
+            mq_parent.user.request(mq_parent, request)
 
         assert request_event_spy.call_count == 2
         _, kwargs = request_event_spy.call_args_list[-1]
@@ -924,7 +942,7 @@ class TestMessageQueueUser:
 
         request.endpoint = 'queue:TEST.QUEUE, expression:$.test.result'
         with pytest.raises(StopUser):
-            user.request(request)
+            mq_parent.user.request(mq_parent, request)
 
         assert request_event_spy.call_count == 3
         _, kwargs = request_event_spy.call_args_list[-1]

--- a/tests/unit/test_grizzly/users/test_restapi.py
+++ b/tests/unit/test_grizzly/users/test_restapi.py
@@ -19,6 +19,7 @@ from grizzly.tasks import RequestTask
 from grizzly.testdata.utils import transform
 from grizzly.exceptions import RestartScenario
 from grizzly.auth import GrizzlyAuthHttpContext
+from grizzly.scenarios import GrizzlyScenario
 from grizzly_extras.transformer import TransformerContentType
 
 from tests.fixtures import ResponseContextManagerFixture, MockerFixture, GrizzlyFixture
@@ -27,15 +28,15 @@ from tests.helpers import RequestEvent, ResultSuccess
 
 class TestRestApiUser:
     def test___init__(self, grizzly_fixture: GrizzlyFixture) -> None:
-        _, user, _ = grizzly_fixture(user_type=RestApiUser, host='http://example.net')
-        assert isinstance(user, RestApiUser)
+        parent = grizzly_fixture(user_type=RestApiUser, host='http://example.net')
+        assert isinstance(parent.user, RestApiUser)
 
-        assert issubclass(user.__class__, RequestLogger)
-        assert issubclass(user.__class__, ResponseHandler)
-        assert issubclass(user.__class__, GrizzlyUser)
-        assert issubclass(user.__class__, AsyncRequests)
-        assert user.host == 'http://example.net'
-        assert user._context == {
+        assert issubclass(parent.user.__class__, RequestLogger)
+        assert issubclass(parent.user.__class__, ResponseHandler)
+        assert issubclass(parent.user.__class__, GrizzlyUser)
+        assert issubclass(parent.user.__class__, AsyncRequests)
+        assert parent.user.host == 'http://example.net'
+        assert parent.user._context == {
             'variables': {},
             'log_all_requests': False,
             'verify_certificates': True,
@@ -56,34 +57,34 @@ class TestRestApiUser:
             },
             'metadata': None,
         }
-        assert user.headers == {
+        assert parent.user.headers == {
             'Content-Type': 'application/json',
-            'x-grizzly-user': user.__class__.__name__,
+            'x-grizzly-user': parent.user.__class__.__name__,
         }
 
         RestApiUser._context['metadata'] = {'foo': 'bar'}
 
-        user = RestApiUser(user.environment)
+        user = RestApiUser(parent.user.environment)
 
         assert user.headers.get('foo', None) == 'bar'
 
     def test_on_start(self, grizzly_fixture: GrizzlyFixture) -> None:
-        _, user, _ = grizzly_fixture(user_type=RestApiUser)
-        assert isinstance(user, RestApiUser)
-        assert user.session_started is None
+        parent = grizzly_fixture(user_type=RestApiUser)
+        assert isinstance(parent.user, RestApiUser)
+        assert parent.user.session_started is None
 
-        user.on_start()
+        parent.user.on_start()
 
-        assert user.session_started is not None
+        assert parent.user.session_started is not None
 
     @pytest.mark.skip(reason='needs credentials, should run explicitly manually')
     def test_get_oauth_authorization_real(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture, caplog: LogCaptureFixture) -> None:
         import logging
         with caplog.at_level(logging.DEBUG):
-            _, user, _ = grizzly_fixture(user_type=RestApiUser)
-            assert isinstance(user, RestApiUser)
+            parent = grizzly_fixture(user_type=RestApiUser)
+            assert isinstance(parent.user, RestApiUser)
 
-            user._context = {
+            parent.user._context = {
                 'host': '',
                 'auth': {
                     'client': {
@@ -102,125 +103,126 @@ class TestRestApiUser:
                     'Ocp-Apim-Subscription-Key': '',
                 }
             }
-            user.headers.update({
+            parent.user.headers.update({
                 'Ocp-Apim-Subscription-Key': '',
             })
-            user.host = cast(dict, user._context)['host']
-            user.session_started = time()
+            parent.user.host = cast(dict, parent.user._context)['host']
+            parent.user.session_started = time()
 
-            fire = mocker.spy(user.environment.events.request, 'fire')
+            fire = mocker.spy(parent.user.environment.events.request, 'fire')
 
             # user.get_oauth_authorization()
             request = RequestTask(RequestMethod.GET, name='test', endpoint='/api/test')
-            request.scenario = user._scenario
-            headers, body = user.request(request)
-            user.logger.info(headers)
-            user.logger.info(body)
-            user.logger.info(fire.call_args_list)
+            headers, body = parent.user.request(parent, request)
+            parent.logger.info(headers)
+            parent.logger.info(body)
+            parent.logger.info(fire.call_args_list)
             assert 0
 
     def test_get_error_message(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
-        _, user, _ = grizzly_fixture(user_type=RestApiUser)
-        assert isinstance(user, RestApiUser)
+        parent = grizzly_fixture(user_type=RestApiUser)
+        assert isinstance(parent.user, RestApiUser)
 
         response = Response()
         response._content = ''.encode('utf-8')
         response_context_manager = ResponseContextManager(response, RequestEvent(), {})
 
         response.status_code = 401
-        assert user.get_error_message(response_context_manager) == 'unauthorized'
+        assert parent.user.get_error_message(response_context_manager) == 'unauthorized'
 
         response.status_code = 403
-        assert user.get_error_message(response_context_manager) == 'forbidden'
+        assert parent.user.get_error_message(response_context_manager) == 'forbidden'
 
         response.status_code = 404
-        assert user.get_error_message(response_context_manager) == 'not found'
+        assert parent.user.get_error_message(response_context_manager) == 'not found'
 
         response.status_code = 405
-        assert user.get_error_message(response_context_manager) == 'unknown'
+        assert parent.user.get_error_message(response_context_manager) == 'unknown'
 
         response._content = 'just a simple string'.encode('utf-8')
-        assert user.get_error_message(response_context_manager) == 'just a simple string'
+        assert parent.user.get_error_message(response_context_manager) == 'just a simple string'
 
         response._content = '{"Message": "message\\nproperty\\\\nthat is multiline"}'.encode('utf-8')
-        assert user.get_error_message(response_context_manager) == 'message property'
+        assert parent.user.get_error_message(response_context_manager) == 'message property'
 
         response._content = '{"error_description": "error description\\r\\nthat is multiline"}'.encode('utf-8')
-        assert user.get_error_message(response_context_manager) == 'error description'
+        assert parent.user.get_error_message(response_context_manager) == 'error description'
 
         response._content = '{"success": false}'.encode('utf-8')
-        assert user.get_error_message(response_context_manager) == '{"success": false}'
+        assert parent.user.get_error_message(response_context_manager) == '{"success": false}'
 
         text_mock = mocker.patch('requests.models.Response.text', new_callable=mocker.PropertyMock)
         text_mock.return_value = None
-        assert user.get_error_message(response_context_manager) == "unknown response <class 'locust.clients.ResponseContextManager'>"
+        assert parent.user.get_error_message(response_context_manager) == "unknown response <class 'locust.clients.ResponseContextManager'>"
 
     def test_async_request(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
-        _, user, _ = grizzly_fixture(user_type=RestApiUser)
-        assert isinstance(user, RestApiUser)
+        parent = grizzly_fixture(user_type=RestApiUser)
+        assert isinstance(parent.user, RestApiUser)
 
-        request = cast(RequestTask, user._scenario.tasks()[-1])
+        request = cast(RequestTask, parent.user._scenario.tasks()[-1])
 
-        request_spy = mocker.patch.object(user, '_request')
+        request_spy = mocker.patch.object(parent.user, '_request')
 
-        assert user._context.get('verify_certificates', None)
+        assert parent.user._context.get('verify_certificates', None)
 
-        user.async_request(request)
+        parent.user.async_request(parent, request)
 
         assert request_spy.call_count == 1
         args, _ = request_spy.call_args_list[-1]
-        assert len(args) == 2
-        assert isinstance(args[0], FastHttpSession)
-        assert args[0].environment is user.environment
-        assert args[0].base_url == user.host
-        assert args[0].user is user
-        assert args[0].client.max_retries == 1
-        assert args[0].client.clientpool.client_args.get('connection_timeout', None) == 60.0
-        assert args[0].client.clientpool.client_args.get('network_timeout', None) == 60.0
-        assert args[0].client.clientpool.client_args.get('ssl_context_factory', None) is gevent.ssl.create_default_context  # pylint: disable=no-member
+        assert len(args) == 3
+        assert args[0] is parent
         assert args[1] is request
+        assert isinstance(args[2], FastHttpSession)
+        assert args[2].environment is parent.user.environment
+        assert args[2].base_url == parent.user.host
+        assert args[2].user is parent.user
+        assert args[2].client.max_retries == 1
+        assert args[2].client.clientpool.client_args.get('connection_timeout', None) == 60.0
+        assert args[2].client.clientpool.client_args.get('network_timeout', None) == 60.0
+        assert args[2].client.clientpool.client_args.get('ssl_context_factory', None) is gevent.ssl.create_default_context  # pylint: disable=no-member
 
-        user._context['verify_certificates'] = False
+        parent.user._context['verify_certificates'] = False
 
-        user.async_request(request)
+        parent.user.async_request(parent, request)
 
         assert request_spy.call_count == 2
         args, _ = request_spy.call_args_list[-1]
-        assert args[0].client.clientpool.client_args.get('ssl_context_factory', None) is insecure_ssl_context_factory
+        assert args[2].client.clientpool.client_args.get('ssl_context_factory', None) is insecure_ssl_context_factory
 
     def test_request(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
-        _, user, _ = grizzly_fixture(user_type=RestApiUser)
-        assert isinstance(user, RestApiUser)
+        parent = grizzly_fixture(user_type=RestApiUser)
+        assert isinstance(parent.user, RestApiUser)
 
-        request = cast(RequestTask, user._scenario.tasks()[-1])
+        request = cast(RequestTask, parent.user._scenario.tasks()[-1])
 
-        request_spy = mocker.patch.object(user, '_request')
+        request_spy = mocker.patch.object(parent.user, '_request')
 
-        assert user._context.get('verify_certificates', None)
+        assert parent.user._context.get('verify_certificates', None)
 
-        user.request(request)
+        parent.user.request(parent, request)
 
         assert request_spy.call_count == 1
         args, _ = request_spy.call_args_list[-1]
-        assert len(args) == 2
-        assert args[0] is user.client
+        assert len(args) == 3
+        assert args[0] is parent
         assert args[1] is request
+        assert args[2] is parent.user.client
 
-        user.request(request)
+        parent.user.request(parent, request)
 
     @pytest.mark.parametrize('request_func', [RestApiUser.request, RestApiUser.async_request])
     def test__request(
         self,
         grizzly_fixture: GrizzlyFixture,
         mocker: MockerFixture,
-        request_func: Callable[[RestApiUser, RequestTask], GrizzlyResponse],
+        request_func: Callable[[RestApiUser, GrizzlyScenario, RequestTask], GrizzlyResponse],
         response_context_manager_fixture: ResponseContextManagerFixture,
     ) -> None:
-        _, user, _ = grizzly_fixture(user_type=RestApiUser)
-        assert isinstance(user, RestApiUser)
+        parent = grizzly_fixture(user_type=RestApiUser)
+        assert isinstance(parent.user, RestApiUser)
 
         class ClientRequestMock:
-            def __init__(self, status_code: int, user: GrizzlyUser, request_func: Callable[[RestApiUser, RequestTask], GrizzlyResponse]) -> None:
+            def __init__(self, status_code: int, user: GrizzlyUser, request_func: Callable[[RestApiUser, GrizzlyScenario, RequestTask], GrizzlyResponse]) -> None:
                 self.status_code = status_code
                 self.user = user
                 self.spy = mocker.spy(self, 'request')
@@ -236,11 +238,11 @@ class TestRestApiUser:
                 cls_rcm = cast(Type[GrizzlyResponseContextManager], ResponseContextManager if request_func is RestApiUser.request else FastResponseContextManager)
                 return response_context_manager_fixture(cls_rcm, self.status_code, self.user.environment, response_body={}, **kwargs)  # type: ignore
 
-        request = cast(RequestTask, user._scenario.tasks()[-1])
+        request = cast(RequestTask, parent.user._scenario.tasks()[-1])
 
         # missing template variables
         with pytest.raises(StopUser):
-            request_func(user, request)
+            request_func(parent.user, parent, request)
 
         remote_variables = {
             'variables': transform(GrizzlyContext(), {
@@ -250,45 +252,45 @@ class TestRestApiUser:
             }),
         }
 
-        user.add_context(remote_variables)
+        parent.user.add_context(remote_variables)
 
-        request_mock = ClientRequestMock(status_code=400, user=user, request_func=request_func)
+        request_mock = ClientRequestMock(status_code=400, user=parent.user, request_func=request_func)
 
-        user._scenario.failure_exception = StopUser
+        parent.user._scenario.failure_exception = StopUser
 
         # status_code != 200, stop_on_failure = True
         with pytest.raises(StopUser):
-            request_func(user, request)
+            request_func(parent.user, parent, request)
 
         assert request_mock.spy.call_count == 1
 
-        user._scenario.failure_exception = RestartScenario
+        parent.user._scenario.failure_exception = RestartScenario
 
         # status_code != 200, stop_on_failure = True
         with pytest.raises(RestartScenario):
-            request_func(user, request)
+            request_func(parent.user, parent, request)
 
         assert request_mock.spy.call_count == 2
 
         request.response.add_status_code(400)
 
         with pytest.raises(ResultSuccess):
-            request_func(user, request)
+            request_func(parent.user, parent, request)
 
         assert request_mock.spy.call_count == 3
 
         request.response.add_status_code(-400)
-        user._scenario.failure_exception = None
+        parent.user._scenario.failure_exception = None
 
         # status_code != 200, stop_on_failure = False
-        metadata, payload = request_func(user, request)
+        metadata, payload = request_func(parent.user, parent, request)
 
         assert request_mock.spy.call_count == 4
         _, kwargs = request_mock.spy.call_args_list[-1]
         assert kwargs.get('method', None) == request.method.name
-        assert kwargs.get('name', '').startswith(request.scenario.identifier)
+        assert kwargs.get('name', '').startswith(parent.user._scenario.identifier)
         assert kwargs.get('catch_response', False)
-        assert kwargs.get('url', None) == f'{user.host}{request.endpoint}'
+        assert kwargs.get('url', None) == f'{parent.user.host}{request.endpoint}'
 
         if request_func is RestApiUser.request:
             assert kwargs.get('request', None) is request
@@ -297,19 +299,19 @@ class TestRestApiUser:
         assert metadata is None
         assert payload == '{}'
 
-        request_mock = ClientRequestMock(status_code=200, user=user, request_func=request_func)
+        request_mock = ClientRequestMock(status_code=200, user=parent.user, request_func=request_func)
 
-        user._context['verify_certificates'] = False
+        parent.user._context['verify_certificates'] = False
 
         request.response.add_status_code(-200)
-        request_func(user, request)
+        request_func(parent.user, parent, request)
 
         assert request_mock.spy.call_count == 1
         _, kwargs = request_mock.spy.call_args_list[-1]
         assert kwargs.get('method', None) == request.method.name
-        assert kwargs.get('name', '').startswith(request.scenario.identifier)
+        assert kwargs.get('name', '').startswith(parent.user._scenario.identifier)
         assert kwargs.get('catch_response', False)
-        assert kwargs.get('url', None) == f'{user.host}{request.endpoint}'
+        assert kwargs.get('url', None) == f'{parent.user.host}{request.endpoint}'
 
         if request_func is RestApiUser.request:
             assert kwargs.get('request', None) is request
@@ -319,7 +321,7 @@ class TestRestApiUser:
 
         # status_code == 200
         with pytest.raises(ResultSuccess):
-            request_func(user, request)
+            request_func(parent.user, parent, request)
 
         assert request_mock.spy.call_count == 2
 
@@ -327,7 +329,7 @@ class TestRestApiUser:
         request.source = '{"hello: "world"}'
 
         with pytest.raises(StopUser):
-            request_func(user, request)
+            request_func(parent.user, parent, request)
 
         assert request_mock.spy.call_count == 2
 
@@ -335,97 +337,97 @@ class TestRestApiUser:
         request.method = RequestMethod.RECEIVE
 
         with pytest.raises(NotImplementedError):
-            request_func(user, request)
+            request_func(parent.user, parent, request)
 
         assert request_mock.spy.call_count == 2
 
         # post XML
-        user.host = 'http://localhost:1337'
+        parent.user.host = 'http://localhost:1337'
         request.method = RequestMethod.POST
         request.endpoint = '/'
         request.response.content_type = TransformerContentType.XML
-        request_mock = ClientRequestMock(status_code=200, user=user, request_func=request_func)
+        request_mock = ClientRequestMock(status_code=200, user=parent.user, request_func=request_func)
         request.response.add_status_code(200)
         request.source = '<?xml version="1.0"?><example></example'
 
         with pytest.raises(ResultSuccess):
-            request_func(user, request)
+            request_func(parent.user, parent, request)
 
         assert request_mock.spy.call_count == 1
         _, kwargs = request_mock.spy.call_args_list[-1]
         assert kwargs.get('method', None) == request.method.name
-        assert kwargs.get('name', '').startswith(request.scenario.identifier)
+        assert kwargs.get('name', '').startswith(parent.user._scenario.identifier)
         assert kwargs.get('catch_response', False)
-        assert kwargs.get('url', None) == f'{user.host}{request.endpoint}'
+        assert kwargs.get('url', None) == f'{parent.user.host}{request.endpoint}'
         assert kwargs.get('data', None) == bytes(request.source, 'UTF-8')
         assert 'headers' in kwargs
         assert 'Content-Type' in kwargs['headers']
         assert kwargs['headers']['Content-Type'] == 'application/xml'
 
         # post multipart
-        user.host = 'http://localhost:1337'
+        parent.user.host = 'http://localhost:1337'
         request.method = RequestMethod.POST
         request.endpoint = '/'
         request.arguments = {'multipart_form_data_name': 'input_name', 'multipart_form_data_filename': 'filename'}
         request.response.content_type = TransformerContentType.MULTIPART_FORM_DATA
-        request_mock = ClientRequestMock(status_code=200, user=user, request_func=request_func)
+        request_mock = ClientRequestMock(status_code=200, user=parent.user, request_func=request_func)
         request.response.add_status_code(200)
         request.source = '<?xml version="1.0"?><example></example'
 
         with pytest.raises(ResultSuccess):
-            request_func(user, request)
+            request_func(parent.user, parent, request)
 
         assert request_mock.spy.call_count == 1
         _, kwargs = request_mock.spy.call_args_list[-1]
         assert kwargs.get('method', None) == request.method.name
-        assert kwargs.get('name', '').startswith(request.scenario.identifier)
+        assert kwargs.get('name', '').startswith(parent.user._scenario.identifier)
         assert kwargs.get('catch_response', False)
-        assert kwargs.get('url', None) == f'{user.host}{request.endpoint}'
+        assert kwargs.get('url', None) == f'{parent.user.host}{request.endpoint}'
 
         # post with metadata
-        user.host = 'http://localhost:1337'
+        parent.user.host = 'http://localhost:1337'
         request.method = RequestMethod.POST
         request.endpoint = '/'
         request.arguments = None
         request.metadata = {'my_header': 'value'}
         request.response.content_type = TransformerContentType.JSON
-        request_mock = ClientRequestMock(status_code=200, user=user, request_func=request_func)
+        request_mock = ClientRequestMock(status_code=200, user=parent.user, request_func=request_func)
         request.response.add_status_code(200)
         request.source = '{"alice": 1}'
 
         with pytest.raises(ResultSuccess):
-            request_func(user, request)
+            request_func(parent.user, parent, request)
 
         assert request_mock.spy.call_count == 1
         _, kwargs = request_mock.spy.call_args_list[-1]
         assert kwargs.get('method', None) == request.method.name
-        assert kwargs.get('name', '').startswith(request.scenario.identifier)
+        assert kwargs.get('name', '').startswith(parent.user._scenario.identifier)
         assert kwargs.get('catch_response', False)
-        assert kwargs.get('url', None) == f'{user.host}{request.endpoint}'
+        assert kwargs.get('url', None) == f'{parent.user.host}{request.endpoint}'
         assert 'headers' in kwargs
         assert 'my_header' in kwargs['headers']
         assert kwargs['headers']['my_header'] == 'value'
 
     def test_add_context(self, grizzly_fixture: GrizzlyFixture) -> None:
-        _, user, _ = grizzly_fixture(user_type=RestApiUser)
+        parent = grizzly_fixture(user_type=RestApiUser)
 
-        assert isinstance(user, RestApiUser)
+        assert isinstance(parent.user, RestApiUser)
 
-        assert 'test_context_variable' not in user._context
-        assert cast(GrizzlyAuthHttpContext, user._context['auth'])['provider'] is None
-        assert cast(GrizzlyAuthHttpContext, user._context['auth'])['refresh_time'] == 3000
+        assert 'test_context_variable' not in parent.user._context
+        assert cast(GrizzlyAuthHttpContext, parent.user._context['auth'])['provider'] is None
+        assert cast(GrizzlyAuthHttpContext, parent.user._context['auth'])['refresh_time'] == 3000
 
-        user.add_context({'test_context_variable': 'value'})
+        parent.user.add_context({'test_context_variable': 'value'})
 
-        assert 'test_context_variable' in user._context
+        assert 'test_context_variable' in parent.user._context
 
-        user.add_context({'auth': {'provider': 'http://auth.example.org'}})
+        parent.user.add_context({'auth': {'provider': 'http://auth.example.org'}})
 
-        assert cast(GrizzlyAuthHttpContext, user._context['auth'])['provider'] == 'http://auth.example.org'
-        assert cast(GrizzlyAuthHttpContext, user._context['auth'])['refresh_time'] == 3000
+        assert cast(GrizzlyAuthHttpContext, parent.user._context['auth'])['provider'] == 'http://auth.example.org'
+        assert cast(GrizzlyAuthHttpContext, parent.user._context['auth'])['refresh_time'] == 3000
 
-        user.headers['Authorization'] = 'Bearer asdfasdfasdf'
+        parent.user.headers['Authorization'] = 'Bearer asdfasdfasdf'
 
-        user.add_context({'auth': {'user': {'username': 'something new'}}})
+        parent.user.add_context({'auth': {'user': {'username': 'something new'}}})
 
-        assert 'Authorization' not in user.headers
+        assert 'Authorization' not in parent.user.headers


### PR DESCRIPTION
each user should have a copy of the `GrizzlyContextScenario` that they are part of. this is to make it possible to, per user, change some aspects of the scenario during runtime without affecting other users.

each user type has a reference to the `GrizzlyContextScenario` they belong to via `__scenario__`, when the user type is instantiated it will make a copy of that instance which is accessible via the `_scenario` instance variable. that copy uses the same reference to the `GrizzlyContextTasks`.

references to the scenario from `GrizzlyTask` has been removed, in what ever context a task is executed, that context knows about the scenario.

this caused a lot of small changes, mainly in unit tests. at the same time, some fixtures was rewritten to make them simpler and more straight forward to use.