### PR TITLE
response handlers should execute even though payload/metadata is empty

### DIFF
--- a/grizzly/users/base/response_handler.py
+++ b/grizzly/users/base/response_handler.py
@@ -200,12 +200,12 @@ class ResponseHandler(ResponseEvent):
             response_metadata, response_payload = cast(GrizzlyResponse, context)
             response_context = None
 
-        if len(handlers.payload) > 0 and response_payload is not None and len(response_payload) > 0:
+        if len(handlers.payload) > 0:
             try:
                 # do not guess which transformer to use
                 impl = transformer.available.get(request.response.content_type, None)
                 if impl is not None:
-                    response_payload = impl.transform(response_payload)
+                    response_payload = impl.transform(response_payload or '')
                 else:
                     raise TransformerError(f'failed to transform: {response_payload} with content type {request.response.content_type.name}')
             except TransformerError as e:
@@ -218,6 +218,6 @@ class ResponseHandler(ResponseEvent):
             for handler in handlers.payload:
                 handler((request.response.content_type, response_payload), user, response_context)
 
-        if len(handlers.metadata) > 0 and response_metadata is not None:
+        if len(handlers.metadata) > 0:
             for handler in handlers.metadata:
-                handler((TransformerContentType.JSON, response_metadata), user, response_context)
+                handler((TransformerContentType.JSON, response_metadata or {}), user, response_context)

--- a/grizzly/users/messagequeue.py
+++ b/grizzly/users/messagequeue.py
@@ -305,7 +305,6 @@ class MessageQueueUser(ResponseHandler, RequestLogger, GrizzlyUser):
             yield action
 
             response = async_message_request(self.zmq_client, am_request)
-
         except Exception as e:
             exception = e
             self.logger.error(str(e), exc_info=True)

--- a/grizzly_extras/async_message/mq/__init__.py
+++ b/grizzly_extras/async_message/mq/__init__.py
@@ -1,9 +1,11 @@
-from typing import Optional, Generator, Dict, cast
+from typing import Any, Optional, Generator, Dict, cast
 from time import perf_counter as time, sleep
 from contextlib import contextmanager
 
 from grizzly_extras.transformer import transformer, TransformerError, TransformerContentType
 from grizzly_extras.arguments import parse_arguments, get_unsupported_arguments
+
+from grizzly_extras.async_message.utils import tohex
 
 
 from grizzly_extras.async_message import (
@@ -229,6 +231,14 @@ class AsyncMessageQueueHandler(AsyncMessageHandler):
             content_type = TransformerContentType.from_string(value)
         return content_type
 
+    def _get_safe_message_descriptor(self, md: pymqi.MD) -> Dict[str, Any]:
+        metadata: Dict[str, Any] = md.get()
+
+        if 'MsgId' in metadata:
+            metadata['MsgId'] = tohex(metadata['MsgId'])
+
+        return metadata
+
     def _request(self, request: AsyncMessageRequest) -> AsyncMessageResponse:
         if self.qmgr is None:
             raise AsyncMessageError('not connected')
@@ -296,6 +306,8 @@ class AsyncMessageQueueHandler(AsyncMessageHandler):
                     queue.put(request_payload, md)
 
                 elif action == 'GET':
+                    payload = None
+
                     if msg_id_to_fetch is not None:
                         gmo = self._create_gmo()
                         gmo.MatchOptions = pymqi.CMQC.MQMO_MATCH_MSG_ID
@@ -307,9 +319,14 @@ class AsyncMessageQueueHandler(AsyncMessageHandler):
                         try:
                             message = queue.get(max_message_size, md, gmo)
                             payload = self._get_payload(message)
-                            response_length = len(payload) if payload is not None else 0
+                            response_length = len((payload or '').encode())
+
+                            if response_length == 0:
+                                raise pymqi.MQMIError(comp=pymqi.CMQC.MQCC_FAILED, reason=pymqi.CMQC.MQRC_BACKED_OUT, custom_error='response length was 0 bytes')
+
                             if retries > 0:
                                 self.logger.warning(f'got message after {retries} retries')
+
                             self.qmgr.commit()
                         except:
                             self.qmgr.backout()
@@ -327,7 +344,11 @@ class AsyncMessageQueueHandler(AsyncMessageHandler):
                             else:
                                 raise AsyncMessageError(f'message with size {original_length} bytes does not fit in message buffer of {max_message_size} bytes')
                         elif e.reason == pymqi.CMQC.MQRC_BACKED_OUT:
-                            self.logger.warning(f'got MQRC_BACKED_OUT while getting message, {retries=}')
+                            warning_message = ['got MQRC_BACKED_OUT while getting message', f'{retries=}']
+                            custom_error = getattr(e, 'custom_error', None)
+                            if custom_error is not None:
+                                warning_message.insert(1, custom_error)
+                            self.logger.warning(', '.join(warning_message))
                             do_retry = True
                         else:
                             # Some other error condition.
@@ -342,7 +363,7 @@ class AsyncMessageQueueHandler(AsyncMessageHandler):
                     self.logger.info(f'{action} on {queue_name} took {delta} ms, {response_length=}, {retries=}')
                     return {
                         'payload': payload,
-                        'metadata': md.get(),
+                        'metadata': self._get_safe_message_descriptor(md),
                         'response_length': response_length,
                     }
 

--- a/grizzly_extras/async_message/utils.py
+++ b/grizzly_extras/async_message/utils.py
@@ -1,0 +1,12 @@
+from typing import Union
+
+
+def tohex(value: Union[int, str, bytes, bytearray]) -> str:
+    if isinstance(value, str):
+        return ''.join('{:02x}'.format(ord(c)) for c in value)
+    elif isinstance(value, (bytes, bytearray,)):
+        return value.hex()
+    elif isinstance(value, int):
+        return hex(value)[2:]
+    else:
+        raise ValueError(f'{value} has an unsupported type {type(value)}')

--- a/tests/unit/test_grizzly/users/test_messagequeue.py
+++ b/tests/unit/test_grizzly/users/test_messagequeue.py
@@ -483,7 +483,8 @@ class TestMessageQueueUser:
         request_event_spy = mocker.spy(user.environment.events.request, 'fire')
         response_event_spy = mocker.spy(user.response_event, 'fire')
 
-        request = cast(RequestTask, scenario.tasks()[-1])
+        request = scenario.tasks()[-1]
+        assert isinstance(request, RequestTask)
         request.endpoint = 'queue:test-queue'
         request.method = RequestMethod.GET
         request.source = None
@@ -503,7 +504,7 @@ class TestMessageQueueUser:
         _, kwargs = request_event_spy.call_args_list[1]
         assert kwargs['request_type'] == 'GET'
         assert kwargs['exception'] is None
-        assert kwargs['response_length'] == len(test_payload)
+        assert kwargs['response_length'] == len(test_payload.encode())
 
         assert response_event_spy.call_count == 1
         _, kwargs = response_event_spy.call_args_list[0]
@@ -576,6 +577,8 @@ class TestMessageQueueUser:
         _, kwargs = request_event_spy.call_args_list[0]
         assert kwargs['exception'] is None
         assert response_event_spy.call_count == 1
+
+        request.response.handlers.payload.clear()
 
         request_event_spy.reset_mock()
         response_event_spy.reset_mock()
@@ -664,11 +667,14 @@ class TestMessageQueueUser:
         send_json_spy.return_value = None
         send_json_spy.reset_mock()
 
-        noop_zmq.get_mock('zmq.Socket.recv_json').side_effect = the_side_effect * 7
+        recv_json = noop_zmq.get_mock('zmq.Socket.recv_json')
+        recv_json.side_effect = the_side_effect * 7
 
         request.method = RequestMethod.GET
         request.endpoint = 'queue:IFKTEST'
+
         user.request(request)
+
         assert send_json_spy.call_count == 1
         args, kwargs = send_json_spy.call_args_list[0]
         assert len(args) == 1


### PR DESCRIPTION
this is to avoid that a scenario silently continues even though it should fail. if a variable is reused between steps, it can also cause total confusion.