### PR TITLE
refactoring of handling RequestTask

### DIFF
--- a/example/features/steps/custom.py
+++ b/example/features/steps/custom.py
@@ -12,10 +12,10 @@ from grizzly.testdata.variables import AtomicVariable
 
 
 class User(RestApiUser):
-    def request(self, parent: GrizzlyScenario, request: RequestTask) -> GrizzlyResponse:
+    def request_impl(self, request: RequestTask) -> GrizzlyResponse:
         self.logger.info(f'executing custom.User.request for {request.name} and {request.endpoint}')
 
-        return super().request(parent, request)
+        return super().request_impl(request)
 
 
 class Task(GrizzlyTask):

--- a/grizzly/steps/_helpers.py
+++ b/grizzly/steps/_helpers.py
@@ -263,7 +263,7 @@ def normalize_step_name(step_name: str) -> str:
     return re.sub(r'"[^"]*"', '""', step_name)
 
 
-def get_task_client(endpoint: str) -> Type[ClientTask]:
+def get_task_client(grizzly: GrizzlyContext, endpoint: str) -> Type[ClientTask]:
     scheme = urlparse(endpoint).scheme
 
     assert scheme is not None and len(scheme) > 0, f'could not find scheme in "{endpoint}"'
@@ -271,6 +271,8 @@ def get_task_client(endpoint: str) -> Type[ClientTask]:
     task_client = client.available.get(scheme, None)
 
     assert task_client is not None, f'no client task registered for {scheme}'
+
+    task_client.__scenario__ = grizzly.scenario
 
     return task_client
 

--- a/grizzly/steps/scenario/tasks.py
+++ b/grizzly/steps/scenario/tasks.py
@@ -366,7 +366,7 @@ def step_task_client_get_endpoint_payload_metadata(context: Context, endpoint: s
     """
     grizzly = cast(GrizzlyContext, context.grizzly)
 
-    grizzly.scenario.tasks.add(get_task_client(endpoint)(
+    grizzly.scenario.tasks.add(get_task_client(grizzly, endpoint)(
         RequestDirection.FROM,
         endpoint,
         name,
@@ -399,7 +399,7 @@ def step_task_client_get_endpoint_payload(context: Context, endpoint: str, name:
     """
     grizzly = cast(GrizzlyContext, context.grizzly)
 
-    grizzly.scenario.tasks.add(get_task_client(endpoint)(
+    grizzly.scenario.tasks.add(get_task_client(grizzly, endpoint)(
         RequestDirection.FROM,
         endpoint,
         name,
@@ -432,7 +432,7 @@ def step_task_client_get_endpoint_until(context: Context, endpoint: str, name: s
     """
     grizzly = cast(GrizzlyContext, context.grizzly)
 
-    client_request = get_task_client(endpoint)(
+    client_request = get_task_client(grizzly, endpoint)(
         RequestDirection.FROM,
         endpoint,
         name,
@@ -472,7 +472,7 @@ def step_task_client_put_endpoint_file_destination(context: Context, source: str
 
     grizzly = cast(GrizzlyContext, context.grizzly)
 
-    grizzly.scenario.tasks.add(get_task_client(endpoint)(
+    grizzly.scenario.tasks.add(get_task_client(grizzly, endpoint)(
         RequestDirection.TO,
         endpoint,
         name,
@@ -506,7 +506,7 @@ def step_task_client_put_endpoint_file(context: Context, source: str, endpoint: 
 
     grizzly = cast(GrizzlyContext, context.grizzly)
 
-    grizzly.scenario.tasks.add(get_task_client(endpoint)(
+    grizzly.scenario.tasks.add(get_task_client(grizzly, endpoint)(
         RequestDirection.TO,
         endpoint,
         name,

--- a/grizzly/tasks/clients/http.py
+++ b/grizzly/tasks/clients/http.py
@@ -40,7 +40,7 @@ Then get "https://{{ url }}" with name "authenticated-get" and save response pay
 This will make any requests towards `www.example.com` to get a token from `http://login.example.com/oauth2` and use it in any
 requests towards `www.example.com`.
 '''
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, cast
 from json import dumps as jsondumps
 from time import time
 
@@ -52,6 +52,7 @@ from grizzly_extras.arguments import split_value, parse_arguments
 from grizzly.types import GrizzlyResponse, RequestDirection, bool_type
 from grizzly.scenarios import GrizzlyScenario
 from grizzly.auth import GrizzlyHttpAuthClient, refresh_token, AAD, GrizzlyHttpContext
+from grizzly.utils import merge_dicts
 
 from . import client, ClientTask
 
@@ -117,8 +118,14 @@ class HttpClientTask(ClientTask, GrizzlyHttpAuthClient):
             'auth': None,
         }
 
+        cast(Dict[str, Any], self._context).update({'host': self.host})
+
+        self._context = cast(GrizzlyHttpContext, merge_dicts(cast(Dict[str, Any], self._context), self._scenario.context))
+
     def on_start(self, parent: GrizzlyScenario) -> None:
         super().on_start(parent)
+
+        self.environment = self.grizzly.state.locust.environment
 
         self.session_started = time()
         metadata = self._context.get('metadata', None)

--- a/grizzly/tasks/clients/http.py
+++ b/grizzly/tasks/clients/http.py
@@ -40,7 +40,7 @@ Then get "https://{{ url }}" with name "authenticated-get" and save response pay
 This will make any requests towards `www.example.com` to get a token from `http://login.example.com/oauth2` and use it in any
 requests towards `www.example.com`.
 '''
-from typing import Optional, Dict, Any, cast
+from typing import Optional, Dict, Any
 from json import dumps as jsondumps
 from time import time
 
@@ -51,7 +51,7 @@ from grizzly_extras.arguments import split_value, parse_arguments
 
 from grizzly.types import GrizzlyResponse, RequestDirection, bool_type
 from grizzly.scenarios import GrizzlyScenario
-from grizzly.auth import GrizzlyHttpAuthClient, refresh_token, AAD, GrizzlyHttpContext
+from grizzly.auth import GrizzlyHttpAuthClient, refresh_token, AAD
 from grizzly.utils import merge_dicts
 
 from . import client, ClientTask
@@ -64,7 +64,7 @@ class HttpClientTask(ClientTask, GrizzlyHttpAuthClient):
     session_started: Optional[float]
     host: str
 
-    _context: GrizzlyHttpContext
+    _context: Dict[str, Any]
 
     def __init__(
         self,
@@ -118,9 +118,8 @@ class HttpClientTask(ClientTask, GrizzlyHttpAuthClient):
             'auth': None,
         }
 
-        cast(Dict[str, Any], self._context).update({'host': self.host})
-
-        self._context = cast(GrizzlyHttpContext, merge_dicts(cast(Dict[str, Any], self._context), self._scenario.context))
+        self._context.update({'host': self.host})
+        self._context = merge_dicts(self._context, self._scenario.context)
 
     def on_start(self, parent: GrizzlyScenario) -> None:
         super().on_start(parent)

--- a/grizzly/tasks/request.py
+++ b/grizzly/tasks/request.py
@@ -110,6 +110,7 @@ class RequestTaskResponse:
 
 @template('name', 'endpoint', 'source', 'arguments', 'metadata')
 class RequestTask(GrizzlyMetaRequestTask):
+    __rendered__: bool
     method: RequestMethod
     name: str
     endpoint: str
@@ -118,6 +119,7 @@ class RequestTask(GrizzlyMetaRequestTask):
     arguments: Optional[Dict[str, str]]
     metadata: Optional[Dict[str, str]]
     grizzly = GrizzlyContext()
+    async_request: bool
 
     response: RequestTaskResponse
 
@@ -129,11 +131,13 @@ class RequestTask(GrizzlyMetaRequestTask):
         self.endpoint = endpoint
         self.arguments = None
         self.metadata = None
+        self.async_request = False
 
         self._template = None
         self._source = source
 
         self.response = RequestTaskResponse()
+        self.__rendered__ = False
 
         content_type: TransformerContentType = TransformerContentType.UNDEFINED
 
@@ -182,9 +186,9 @@ class RequestTask(GrizzlyMetaRequestTask):
     def __call__(self) -> grizzlytask:
         @grizzlytask
         def task(parent: 'GrizzlyScenario') -> Any:
-            return parent.user.request(parent, self)
+            return parent.user.request(self)
 
         return task
 
     def execute(self, parent: 'GrizzlyScenario') -> GrizzlyResponse:
-        return parent.user.request(parent, self)
+        return parent.user.request(self)

--- a/grizzly/types/__init__.py
+++ b/grizzly/types/__init__.py
@@ -178,7 +178,7 @@ class RequestType(Enum, AdvancedEnum, metaclass=MixedEnumMeta, init='alias _weig
 
 GrizzlyResponseContextManager = Union[RequestsResponseContextManager, FastResponseContextManager]
 
-GrizzlyResponse = Tuple[Optional[Dict[str, Any]], Optional[Any]]
+GrizzlyResponse = Tuple[Optional[Dict[str, Any]], Optional[str]]
 
 HandlerContextType = Union[GrizzlyResponseContextManager, GrizzlyResponse]
 

--- a/grizzly/users/__init__.py
+++ b/grizzly/users/__init__.py
@@ -1,4 +1,4 @@
-'''
+"""
 @anchor pydoc:grizzly.users Load User
 This package contains implementation for different type of endpoints and protocols.
 
@@ -10,11 +10,7 @@ It is possible to implement custom users, the only requirement is that they inhe
 the full namespace has to be specified as `user_class_name` in the scenarios {@pylink grizzly.steps.scenario.user} step.
 
 There are examples of this in the {@link framework.example}.
-'''
-import logging
-
-
-logger: logging.Logger = logging.getLogger(__name__)
+"""
 
 
 from .restapi import RestApiUser

--- a/grizzly/users/base/__init__.py
+++ b/grizzly/users/base/__init__.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:  # pragma: no cover
     from grizzly.types import GrizzlyResponse
     from grizzly.tasks import RequestTask
-    from grizzly.scenarios import GrizzlyScenario
 
 
 class FileRequests:
@@ -18,7 +17,7 @@ class HttpRequests:
 
 class AsyncRequests:
     @abstractmethod
-    def async_request(self, parent: 'GrizzlyScenario', request: 'RequestTask') -> 'GrizzlyResponse':
+    def async_request_impl(self, request: 'RequestTask') -> 'GrizzlyResponse':
         raise NotImplementedError(f'{self.__class__.__name__} has not implemented async_request')  # pragma: no cover
 
 

--- a/grizzly/users/base/request_logger.py
+++ b/grizzly/users/base/request_logger.py
@@ -18,10 +18,10 @@ from grizzly.tasks import RequestTask
 from grizzly.utils import merge_dicts
 
 from .response_event import ResponseEvent
-from .grizzly_user import GrizzlyUser
+
 
 if TYPE_CHECKING:  # pragma: no cover
-    from grizzly.scenarios import GrizzlyScenario
+    from .grizzly_user import GrizzlyUser
 
 
 LOG_FILE_TEMPLATE = '''
@@ -45,7 +45,7 @@ payload:
 '''.strip()  # noqa: E501
 
 
-class RequestLogger(ResponseEvent, GrizzlyUser):
+class RequestLogger(ResponseEvent):
     abstract: bool = True
 
     log_dir: str
@@ -153,15 +153,12 @@ class RequestLogger(ResponseEvent, GrizzlyUser):
             },
         }
 
-    def request(self, parent: 'GrizzlyScenario', request: RequestTask) -> GrizzlyResponse:  # pragma: no cover
-        return None, None
-
     def request_logger(
         self,
         name: str,
         context: HandlerContextType,
         request: RequestTask,
-        user: GrizzlyUser,
+        user: 'GrizzlyUser',
         exception: Optional[Exception] = None,
         **kwargs: Dict[str, Any],
     ) -> None:

--- a/grizzly/users/blobstorage.py
+++ b/grizzly/users/blobstorage.py
@@ -29,26 +29,21 @@ Then send request "test/blob.file" to endpoint "azure-blobstorage-container-name
 '''
 import os
 
-from typing import Dict, Any, Tuple, Optional, TYPE_CHECKING
+from typing import Dict, Any, Tuple
 from urllib.parse import urlparse, parse_qs
-from time import perf_counter as time
 
 from azure.storage.blob import BlobServiceClient
 
-from grizzly.types import RequestMethod, GrizzlyResponse, RequestType
-from grizzly.types.locust import Environment, StopUser
+from grizzly.types import RequestMethod, GrizzlyResponse
+from grizzly.types.locust import Environment
 from grizzly.tasks import RequestTask
 from grizzly.utils import merge_dicts
 
 from .base import GrizzlyUser
 
 
-if TYPE_CHECKING:  # pragma: no cover
-    from grizzly.scenarios import GrizzlyScenario
-
-
 class BlobStorageUser(GrizzlyUser):
-    client: BlobServiceClient
+    blob_client: BlobServiceClient
     _context: Dict[str, Any] = {}
 
     def __init__(self, environment: Environment, *args: Tuple[Any], **kwargs: Dict[str, Any]) -> None:
@@ -81,45 +76,26 @@ class BlobStorageUser(GrizzlyUser):
 
     def on_start(self) -> None:
         super().on_start()
-        self.client = BlobServiceClient.from_connection_string(conn_str=self.host)
+        self.blob_client = BlobServiceClient.from_connection_string(conn_str=self.host)
 
     def on_stop(self) -> None:
-        self.client.close()
+        self.blob_client.close()
         super().on_stop()
 
-    def request(self, parent: 'GrizzlyScenario', request: RequestTask) -> GrizzlyResponse:
-        request_name, endpoint, payload, _, _ = self.render(request)
+    def request_impl(self, request: RequestTask) -> GrizzlyResponse:
+        blob = os.path.basename(request.endpoint)
+        container = request.endpoint
+        print(f'{request.endpoint=}, {container=}, {blob=}')
 
-        name = f'{self._scenario.identifier} {request_name}'
+        if container.endswith(blob):
+            container = os.path.dirname(container)
+        else:
+            blob = self.normalize(request.name)
 
-        exception: Optional[Exception] = None
-        start_time = time()
-        response_length = 0
+        with self.blob_client.get_blob_client(container=container, blob=blob) as blob_client:
+            if request.method in [RequestMethod.SEND, RequestMethod.PUT]:
+                blob_client.upload_blob(request.source)
+            else:  # pragma: no cover
+                raise NotImplementedError(f'{self.__class__.__name__} has not implemented {request.method.name}')
 
-        try:
-            with self.client.get_blob_client(container=endpoint, blob=os.path.basename(request_name)) as blob_client:
-                if request.method in [RequestMethod.SEND, RequestMethod.PUT]:
-                    blob_client.upload_blob(payload)
-                    response_length = len(payload or '')
-                else:  # pragma: no cover
-                    raise NotImplementedError(f'{self.__class__.__name__} has not implemented {request.method.name}')
-        except Exception as e:
-            exception = e
-        finally:
-            total_time = int((time() - start_time) * 1000)
-            self.environment.events.request.fire(
-                request_type=RequestType.from_method(request.method),
-                name=name,
-                response_time=total_time,
-                response_length=response_length,
-                context=self._context,
-                exception=exception
-            )
-
-            if exception is not None:
-                if isinstance(exception, NotImplementedError):
-                    raise StopUser()
-                elif self._scenario.failure_exception is not None:
-                    raise self._scenario.failure_exception()
-
-            return {}, payload
+        return {}, request.source

--- a/grizzly/users/dummy.py
+++ b/grizzly/users/dummy.py
@@ -14,7 +14,7 @@ Example of how to use it in a scenario:
 Given a user of type "Dummy" load testing "/dev/null"
 ```
 '''
-from typing import Any, Dict, Tuple, TYPE_CHECKING
+from typing import Any, Dict, Tuple
 
 from grizzly.types import GrizzlyResponse
 from grizzly.types.locust import Environment
@@ -23,13 +23,9 @@ from grizzly.tasks import RequestTask
 from .base import GrizzlyUser
 
 
-if TYPE_CHECKING:  # pragma: no cover
-    from grizzly.scenarios import GrizzlyScenario
-
-
 class DummyUser(GrizzlyUser):
     def __init__(self, environment: Environment, *args: Tuple[Any], **kwargs: Dict[str, Any]) -> None:
         super().__init__(environment, *args, **kwargs)
 
-    def request(self, parent: 'GrizzlyScenario', request: RequestTask) -> GrizzlyResponse:
+    def request_impl(self, request: RequestTask) -> GrizzlyResponse:
         return None, None

--- a/grizzly/utils.py
+++ b/grizzly/utils.py
@@ -138,7 +138,10 @@ def merge_dicts(merged: Dict[str, Any], source: Dict[str, Any]) -> Dict[str, Any
                 and isinstance(source[k], Mapping)):
             merged[k] = merge_dicts(merged[k], source[k])
         else:
-            merged[k] = source[k]
+            value = source[k]
+            if value == 'None':
+                value = None
+            merged[k] = value
 
     return merged
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ license = {text = 'MIT'}
 requires-python = ">=3.8"
 dependencies = [
     "locust >=2.15.0,<2.16",
-    "aenum >3.1.8",
+    "aenum >3.1.8,<3.1.13",
     "azure-core >=1.24.0,<2.0.0",
     "azure-servicebus >=7.6.0,<7.10.0",
     "azure-storage-blob >=12.9.0,<13.0.0",
@@ -69,7 +69,7 @@ mq = [
 dev = [
     "wheel>=0.37.0",
     "astunparse >=1.6.3",
-    "mypy >=0.931",
+    "mypy >=1.3.0",
     "flake8-pyproject >=1.1.0",
     "pylint >=2.12.2",
     "pytest >=7.0.0",

--- a/tests/e2e/steps/scenario/test_tasks.py
+++ b/tests/e2e/steps/scenario/test_tasks.py
@@ -22,7 +22,7 @@ def test_e2e_step_task_request_text_with_name_to_endpoint(e2e_fixture: End2EndFi
 
         tasks.pop()  # remove dummy task added by fixture
 
-        assert len(tasks) == 5, f'{len(tasks)} != 5'
+        assert len(tasks) == 4, f'{len(tasks)} != 5'
 
         request = tasks[0]
         assert isinstance(request, RequestTask)
@@ -63,15 +63,6 @@ def test_e2e_step_task_request_text_with_name_to_endpoint(e2e_fixture: End2EndFi
         assert jsonloads(request.source) == {'test': 'send'}
         assert request.response.content_type == TransformerContentType.UNDEFINED
 
-        request = tasks[4]
-        assert isinstance(request, RequestTask)
-        assert request.method == RequestMethod.RECEIVE
-        assert request.name == 'test-receive'
-        assert request.endpoint == 'queue:receive-queue'
-        assert request.template is None
-        assert request.source is None
-        assert request.response.content_type == TransformerContentType.XML
-
     e2e_fixture.add_validator(validate_requests)
 
     feature_file = e2e_fixture.test_steps(
@@ -98,7 +89,6 @@ def test_e2e_step_task_request_text_with_name_to_endpoint(e2e_fixture: End2EndFi
                 }
                 """
             '''),
-            'Then receive request with name "test-receive" from endpoint "queue:receive-queue | content_type=xml"',
         ],
     )
 
@@ -109,8 +99,14 @@ def test_e2e_step_task_request_text_with_name_to_endpoint(e2e_fixture: End2EndFi
     assert rc == 1
 
     assert 'HOOK-ERROR in after_feature: RuntimeError: locust test failed' in result
-    assert 'NotImplementedError: RECEIVE is not implemented for RestApiUser_001' in result
-    assert 'NotImplementedError: SEND is not implemented for RestApiUser_001' in result
+    expected_parts = ['SEND 001 test-send: ', 'NotImplementedError(\'SEND is not implemented for RestApiUser_001\')']
+    if e2e_fixture._distributed:
+        expected_parts.insert(1, '"')
+        expected_parts.append('"')
+
+    expected = ''.join(expected_parts)
+
+    assert expected in result
 
 
 def test_e2e_step_task_request_file_with_name_endpoint(e2e_fixture: End2EndFixture) -> None:
@@ -189,7 +185,14 @@ def test_e2e_step_task_request_file_with_name_endpoint(e2e_fixture: End2EndFixtu
 
     assert rc == 1
     assert 'HOOK-ERROR in after_feature: RuntimeError: locust test failed' in result
-    assert 'NotImplementedError: SEND is not implemented for RestApiUser_001' in result
+    expected_parts = ['SEND 001 test-send: ', 'NotImplementedError(\'SEND is not implemented for RestApiUser_001\')']
+    if e2e_fixture._distributed:
+        expected_parts.insert(1, '"')
+        expected_parts.append('"')
+
+    expected = ''.join(expected_parts)
+
+    assert expected in result
 
 
 def test_e2e_step_task_request_file_with_name(e2e_fixture: End2EndFixture) -> None:

--- a/tests/e2e/test_example.py
+++ b/tests/e2e/test_example.py
@@ -74,7 +74,7 @@ def test_e2e_example(e2e_fixture: End2EndFixture) -> None:
         assert '003      1/1  passed   book api' in result
         assert '------|-----|--------|---------------|' in result
 
-        assert 'executing custom.User.request for get-cat-facts and /facts?limit=' in result
+        assert 'executing custom.User.request for 002 get-cat-facts and /facts?limit=' in result
 
         assert 'sending "client_server" from CLIENT' in result
         assert "received from CLIENT" in result

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -351,6 +351,7 @@ class GrizzlyFixture:
         self.grizzly.scenario.user.class_name = 'TestUser'
         self.grizzly.scenario.context['host'] = 'http://example.com'
         self.grizzly.scenario.tasks.add(self.request_task.request)
+        self.grizzly.state.verbose = True
 
         return self
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -7,6 +7,7 @@ import re
 from typing import Any, Dict, Optional, Tuple, List, Set, Callable, Generator, Union, Pattern
 from types import MethodType, TracebackType
 from pathlib import Path
+from copy import deepcopy
 
 from locust import task
 from locust.event import EventHook
@@ -17,7 +18,6 @@ from grizzly.types import GrizzlyResponse, RequestMethod
 from grizzly.testdata.variables import AtomicVariable
 from grizzly.tasks import RequestTask, GrizzlyTask, template, grizzlytask
 from grizzly.scenarios import GrizzlyScenario
-from grizzly.utils import fastdeepcopy
 
 
 class AtomicCustomVariable(AtomicVariable[str]):
@@ -59,7 +59,7 @@ class TestUser(GrizzlyUser):
     def config_property(self, value: Optional[str]) -> None:
         self._config_property = value
 
-    def request(self, parent: GrizzlyScenario, request: RequestTask) -> GrizzlyResponse:
+    def request_impl(self, request: RequestTask) -> GrizzlyResponse:
         raise RequestCalled(request)
 
 
@@ -69,7 +69,6 @@ class TestScenario(GrizzlyScenario):
     @task
     def task(self) -> None:
         self.user.request(
-            self,
             RequestTask(RequestMethod.POST, name='test', endpoint='payload.j2.json')
         )
 
@@ -104,7 +103,7 @@ class TestTask(GrizzlyTask):
                 name=f'TestTask: {self.name}',
                 response_time=13,
                 response_length=37,
-                context=fastdeepcopy(parent.user._context),
+                context=deepcopy(parent.user._context),
                 exception=None,
             )
             self.task_call_count += 1

--- a/tests/unit/test_grizzly/auth/test_aad.py
+++ b/tests/unit/test_grizzly/auth/test_aad.py
@@ -39,14 +39,14 @@ class TestAAD:
             return_value=None,
         )
 
-        AAD.get_token(parent, parent.user, AuthMethod.CLIENT)
+        AAD.get_token(parent.user, AuthMethod.CLIENT)
         get_oauth_authorization_mock.assert_not_called()
-        get_oauth_token_mock.assert_called_once_with(parent, parent.user)
+        get_oauth_token_mock.assert_called_once_with(parent.user)
         get_oauth_token_mock.reset_mock()
 
-        AAD.get_token(parent, parent.user, AuthMethod.USER)
+        AAD.get_token(parent.user, AuthMethod.USER)
         get_oauth_token_mock.assert_not_called()
-        get_oauth_authorization_mock.assert_called_once_with(parent, parent.user)
+        get_oauth_authorization_mock.assert_called_once_with(parent.user)
         get_oauth_authorization_mock.reset_mock()
 
     @pytest.mark.skip(reason='needs real secrets')
@@ -131,50 +131,101 @@ class TestAAD:
         parent = grizzly_fixture(user_type=RestApiUser)
 
         assert isinstance(parent.user, RestApiUser)
-        parent.user.__class__.__name__ = f'{parent.user.__class__.__name__}_001'
+        original_class_name = parent.user.__class__.__name__
+        try:
+            parent.user.__class__.__name__ = f'{parent.user.__class__.__name__}_001'
 
-        fake_token = 'asdf'
+            fake_token = 'asdf'
 
-        is_token_v2_0 = version == 'v2.0'
+            is_token_v2_0 = version == 'v2.0'
 
-        fire_spy = mocker.spy(parent.user.environment.events.request, 'fire')
-        mocker.patch('grizzly.auth.aad.time_perf_counter', return_value=0.0)
-        get_oauth_token_mock = mocker.patch.object(AAD, 'get_oauth_token', return_value=None)
+            fire_spy = mocker.spy(parent.user.environment.events.request, 'fire')
+            mocker.patch('grizzly.auth.aad.time_perf_counter', return_value=0.0)
+            get_oauth_token_mock = mocker.patch.object(AAD, 'get_oauth_token', return_value=None)
 
-        if is_token_v2_0:
-            get_oauth_token_mock.return_value = (AuthType.HEADER, fake_token,)
+            if is_token_v2_0:
+                get_oauth_token_mock.return_value = (AuthType.HEADER, fake_token,)
 
-        class Error(Enum):
-            REQUEST_1_NO_DOLLAR_CONFIG = 0
-            REQUEST_1_DOLLAR_CONFIG_ERROR = 10
-            REQUEST_1_HTTP_STATUS = 1
-            REQUEST_2_HTTP_STATUS = 2
-            REQUEST_3_HTTP_STATUS = 3
-            REQUEST_4_HTTP_STATUS = 4
-            REQUEST_4_HTTP_STATUS_CONFIG = 9
-            REQUEST_2_ERROR_MESSAGE = 5
-            REQUEST_1_MISSING_STATE = 6
-            REQUEST_3_ERROR_MESSAGE = 7
-            REQUEST_3_MFA_REQUIRED = 8
-            REQUEST_5_HTTP_STATUS = 11
-            REQUEST_5_NO_COOKIE = 12
+            class Error(Enum):
+                REQUEST_1_NO_DOLLAR_CONFIG = 0
+                REQUEST_1_DOLLAR_CONFIG_ERROR = 10
+                REQUEST_1_HTTP_STATUS = 1
+                REQUEST_2_HTTP_STATUS = 2
+                REQUEST_3_HTTP_STATUS = 3
+                REQUEST_4_HTTP_STATUS = 4
+                REQUEST_4_HTTP_STATUS_CONFIG = 9
+                REQUEST_2_ERROR_MESSAGE = 5
+                REQUEST_1_MISSING_STATE = 6
+                REQUEST_3_ERROR_MESSAGE = 7
+                REQUEST_3_MFA_REQUIRED = 8
+                REQUEST_5_HTTP_STATUS = 11
+                REQUEST_5_NO_COOKIE = 12
 
-        def mock_request_session(inject_error: Optional[Error] = None) -> None:
-            def request(self: 'requests.Session', method: str, url: str, name: Optional[str] = None, **kwargs: Dict[str, Any]) -> requests.Response:
-                response = Response()
-                response.status_code = 200
-                response.url = url
-                self.cookies.clear()
+            def mock_request_session(inject_error: Optional[Error] = None) -> None:
+                def request(self: 'requests.Session', method: str, url: str, name: Optional[str] = None, **kwargs: Dict[str, Any]) -> requests.Response:
+                    response = Response()
+                    response.status_code = 200
+                    response.url = url
+                    self.cookies.clear()
 
-                if method == 'GET' and (url.endswith('/authorize') or url.endswith('/app/login')):
-                    if url.endswith('/app/login'):
-                        affix = '/v2.0' if version == 'v2.0' else ''
-                        response.url = f'https://login.example.com/oauth2{affix}/authorize'
+                    if method == 'GET' and (url.endswith('/authorize') or url.endswith('/app/login')):
+                        if url.endswith('/app/login'):
+                            affix = '/v2.0' if version == 'v2.0' else ''
+                            response.url = f'https://login.example.com/oauth2{affix}/authorize'
 
-                    if inject_error == Error.REQUEST_1_NO_DOLLAR_CONFIG:
-                        response._content = ''.encode('utf-8')
-                    else:
-                        dollar_config_raw = {
+                        if inject_error == Error.REQUEST_1_NO_DOLLAR_CONFIG:
+                            response._content = ''.encode('utf-8')
+                        else:
+                            dollar_config_raw = {
+                                'hpgact': 1800,
+                                'hpgid': 11,
+                                'sFT': 'xxxxxxxxxxxxxxxxxxx',
+                                'sCtx': 'yyyyyyyyyyyyyyyyyyy',
+                                'apiCanary': 'zzzzzzzzzzzzzzzzzz',
+                                'canary': 'canary=1:1',
+                                'correlationId': 'aa-bb-cc',
+                                'sessionId': 'session-a-b-c',
+                                'country': 'SE',
+                                'urlGetCredentialType': 'https://login.example.com/GetCredentialType?mkt=en-US',
+                                'urlPost': 'https://login.example.com/login',
+                            }
+                            if inject_error == Error.REQUEST_1_MISSING_STATE:
+                                del dollar_config_raw['hpgact']
+                            elif inject_error == Error.REQUEST_1_DOLLAR_CONFIG_ERROR:
+                                dollar_config_raw['strServiceExceptionMessage'] = 'oh no!'
+
+                            if login_start == 'initialize_uri':
+                                dollar_config_raw.update({'urlPost': '/login'})
+
+                            dollar_config = jsondumps(dollar_config_raw)
+                            response._content = f'$Config={dollar_config};'.encode('utf-8')
+
+                        if inject_error == Error.REQUEST_1_HTTP_STATUS:
+                            response.status_code = 400
+
+                        response.headers['x-ms-request-id'] = 'aaaa-bbbb-cccc-dddd'
+                    elif method == 'POST' and url.endswith('/GetCredentialType'):
+                        data: Dict[str, Any] = {
+                            'FlowToken': 'xxxxxxxxxxxxxxxxxxx',
+                            'apiCanary': 'zzzzzzzzzzzz',
+                        }
+
+                        if inject_error == Error.REQUEST_2_ERROR_MESSAGE:
+                            data = {
+                                'error': {
+                                    'code': 12345678,
+                                    'message': 'error! error!'
+                                }
+                            }
+
+                        payload = jsondumps(data)
+                        response._content = payload.encode('utf-8')
+                        response.headers['x-ms-request-id'] = 'aaaa-bbbb-cccc-dddd'
+
+                        if inject_error == Error.REQUEST_2_HTTP_STATUS:
+                            response.status_code = 400
+                    elif method == 'POST' and url.endswith('/login'):
+                        dollar_dict = {
                             'hpgact': 1800,
                             'hpgid': 11,
                             'sFT': 'xxxxxxxxxxxxxxxxxxx',
@@ -184,471 +235,141 @@ class TestAAD:
                             'correlationId': 'aa-bb-cc',
                             'sessionId': 'session-a-b-c',
                             'country': 'SE',
-                            'urlGetCredentialType': 'https://login.example.com/GetCredentialType?mkt=en-US',
-                            'urlPost': 'https://login.example.com/login',
+                            'urlGetCredentialType': 'https://test.nu/GetCredentialType?mkt=en-US',
+                            'urlPost': '/kmsi',
                         }
-                        if inject_error == Error.REQUEST_1_MISSING_STATE:
-                            del dollar_config_raw['hpgact']
-                        elif inject_error == Error.REQUEST_1_DOLLAR_CONFIG_ERROR:
-                            dollar_config_raw['strServiceExceptionMessage'] = 'oh no!'
 
-                        if login_start == 'initialize_uri':
-                            dollar_config_raw.update({'urlPost': '/login'})
+                        if inject_error == Error.REQUEST_3_ERROR_MESSAGE:
+                            dollar_dict.update({
+                                'strServiceExceptionMessage': 'failed big time',
+                            })
+                        elif inject_error == Error.REQUEST_3_MFA_REQUIRED:
+                            dollar_dict.update({
+                                'arrUserProofs': [{
+                                    'authMethodId': 'fax',
+                                    'display': '+46 1234',
+                                }]
+                            })
 
-                        dollar_config = jsondumps(dollar_config_raw)
+                        dollar_config = jsondumps(dollar_dict)
                         response._content = f'$Config={dollar_config};'.encode('utf-8')
-
-                    if inject_error == Error.REQUEST_1_HTTP_STATUS:
-                        response.status_code = 400
-
-                    response.headers['x-ms-request-id'] = 'aaaa-bbbb-cccc-dddd'
-                elif method == 'POST' and url.endswith('/GetCredentialType'):
-                    data: Dict[str, Any] = {
-                        'FlowToken': 'xxxxxxxxxxxxxxxxxxx',
-                        'apiCanary': 'zzzzzzzzzzzz',
-                    }
-
-                    if inject_error == Error.REQUEST_2_ERROR_MESSAGE:
-                        data = {
-                            'error': {
-                                'code': 12345678,
-                                'message': 'error! error!'
-                            }
-                        }
-
-                    payload = jsondumps(data)
-                    response._content = payload.encode('utf-8')
-                    response.headers['x-ms-request-id'] = 'aaaa-bbbb-cccc-dddd'
-
-                    if inject_error == Error.REQUEST_2_HTTP_STATUS:
-                        response.status_code = 400
-                elif method == 'POST' and url.endswith('/login'):
-                    dollar_dict = {
-                        'hpgact': 1800,
-                        'hpgid': 11,
-                        'sFT': 'xxxxxxxxxxxxxxxxxxx',
-                        'sCtx': 'yyyyyyyyyyyyyyyyyyy',
-                        'apiCanary': 'zzzzzzzzzzzzzzzzzz',
-                        'canary': 'canary=1:1',
-                        'correlationId': 'aa-bb-cc',
-                        'sessionId': 'session-a-b-c',
-                        'country': 'SE',
-                        'urlGetCredentialType': 'https://test.nu/GetCredentialType?mkt=en-US',
-                        'urlPost': '/kmsi',
-                    }
-
-                    if inject_error == Error.REQUEST_3_ERROR_MESSAGE:
-                        dollar_dict.update({
-                            'strServiceExceptionMessage': 'failed big time',
-                        })
-                    elif inject_error == Error.REQUEST_3_MFA_REQUIRED:
-                        dollar_dict.update({
-                            'arrUserProofs': [{
-                                'authMethodId': 'fax',
-                                'display': '+46 1234',
-                            }]
-                        })
-
-                    dollar_config = jsondumps(dollar_dict)
-                    response._content = f'$Config={dollar_config};'.encode('utf-8')
-                    response.headers['x-ms-request-id'] = 'aaaa-bbbb-cccc-dddd'
-                    if inject_error == Error.REQUEST_3_HTTP_STATUS:
-                        response.status_code = 400
-                elif method == 'POST' and url.endswith('/kmsi'):
-                    if inject_error == Error.REQUEST_4_HTTP_STATUS:
-                        if login_start == 'redirect_uri':
-                            response.status_code = 200
+                        response.headers['x-ms-request-id'] = 'aaaa-bbbb-cccc-dddd'
+                        if inject_error == Error.REQUEST_3_HTTP_STATUS:
+                            response.status_code = 400
+                    elif method == 'POST' and url.endswith('/kmsi'):
+                        if inject_error == Error.REQUEST_4_HTTP_STATUS:
+                            if login_start == 'redirect_uri':
+                                response.status_code = 200
+                            else:
+                                response.status_code = 302
+                        elif inject_error == Error.REQUEST_4_HTTP_STATUS_CONFIG:
+                            response.status_code = 400
+                            dollar_config = jsondumps({
+                                'strServiceExceptionMessage': 'error! error! error!'
+                            })
+                            response._content = f'$Config={dollar_config};'.encode('utf-8')
                         else:
-                            response.status_code = 302
-                    elif inject_error == Error.REQUEST_4_HTTP_STATUS_CONFIG:
-                        response.status_code = 400
-                        dollar_config = jsondumps({
-                            'strServiceExceptionMessage': 'error! error! error!'
-                        })
-                        response._content = f'$Config={dollar_config};'.encode('utf-8')
+                            if login_start == 'redirect_uri':
+                                response.status_code = 302
+                            else:
+                                response.status_code = 200
+
+                        auth_user_context = parent.user._context['auth']['user']
+
+                        if login_start == 'redirect_uri':
+                            redirect_uri_parsed = urlparse(auth_user_context['redirect_uri'])
+                            if len(redirect_uri_parsed.netloc) == 0:
+                                redirect_uri = f"{parent.user._context['host']}{auth_user_context['redirect_uri']}"
+                            else:
+                                redirect_uri = auth_user_context['redirect_uri']
+
+                            if is_token_v2_0:
+                                token_name = 'code'
+                            else:
+                                token_name = 'id_token'
+
+                            response.headers['Location'] = f'{redirect_uri}#{token_name}={fake_token}'
+                        elif inject_error != Error.REQUEST_4_HTTP_STATUS_CONFIG:
+                            response._content = f'''<form action="https://www.example.com/app/login/signin-oidc" method="post">
+                                <input type="hidden" name="id_token" value="{fake_token}"/>
+                                <input type="hidden" name="client_info" value="0000aaaa1111bbbb"/>
+                                <input type="hidden" name="state" value="1111bbbb2222cccc"/>
+                                <input type="hidden" name="session_state" value="2222cccc3333dddd"/>
+                            </form>
+                            '''.encode('utf-8')
+                    elif method == 'POST' and url.endswith('/signin-oidc'):
+                        if inject_error == Error.REQUEST_5_HTTP_STATUS:
+                            response.status_code = 500
+                        elif inject_error != Error.REQUEST_5_NO_COOKIE:
+                            self.cookies.set_cookie(create_cookie('auth', fake_token, domain='www.example.com'))
                     else:
-                        if login_start == 'redirect_uri':
-                            response.status_code = 302
-                        else:
-                            response.status_code = 200
+                        response._content = jsondumps({'error_description': 'error'}).encode('utf-8')
 
-                    auth_user_context = parent.user._context['auth']['user']
+                    return response
 
-                    if login_start == 'redirect_uri':
-                        redirect_uri_parsed = urlparse(auth_user_context['redirect_uri'])
-                        if len(redirect_uri_parsed.netloc) == 0:
-                            redirect_uri = f"{parent.user._context['host']}{auth_user_context['redirect_uri']}"
-                        else:
-                            redirect_uri = auth_user_context['redirect_uri']
+                mocker.patch(
+                    'requests.Session.request',
+                    request,
+                )
 
-                        if is_token_v2_0:
-                            token_name = 'code'
-                        else:
-                            token_name = 'id_token'
+            session_started = time()
 
-                        response.headers['Location'] = f'{redirect_uri}#{token_name}={fake_token}'
-                    elif inject_error != Error.REQUEST_4_HTTP_STATUS_CONFIG:
-                        response._content = f'''<form action="https://www.example.com/app/login/signin-oidc" method="post">
-                            <input type="hidden" name="id_token" value="{fake_token}"/>
-                            <input type="hidden" name="client_info" value="0000aaaa1111bbbb"/>
-                            <input type="hidden" name="state" value="1111bbbb2222cccc"/>
-                            <input type="hidden" name="session_state" value="2222cccc3333dddd"/>
-                        </form>
-                        '''.encode('utf-8')
-                elif method == 'POST' and url.endswith('/signin-oidc'):
-                    if inject_error == Error.REQUEST_5_HTTP_STATUS:
-                        response.status_code = 500
-                    elif inject_error != Error.REQUEST_5_NO_COOKIE:
-                        self.cookies.set_cookie(create_cookie('auth', fake_token, domain='www.example.com'))
-                else:
-                    response._content = jsondumps({'error_description': 'error'}).encode('utf-8')
+            if login_start == 'redirect_uri':
+                auth_user_uri = 'http://www.example.com/app/authenticated'
+            else:
+                auth_user_uri = 'http://www.example.com/app/login'
 
-                return response
+            provider_url = 'https://login.example.com/oauth2'
+            if version != 'v1.0':
+                provider_url = f'{provider_url}/{version}'
 
-            mocker.patch(
-                'requests.Session.request',
-                request,
-            )
-
-        session_started = time()
-
-        if login_start == 'redirect_uri':
-            auth_user_uri = 'http://www.example.com/app/authenticated'
-        else:
-            auth_user_uri = 'http://www.example.com/app/login'
-
-        provider_url = 'https://login.example.com/oauth2'
-        if version != 'v1.0':
-            provider_url = f'{provider_url}/{version}'
-
-        parent.user._context = {
-            'host': 'https://www.example.com',
-            'auth': {
-                'client': {
-                    'id': 'aaaa',
-                },
-                'user': {
-                    'username': 'test-user@example.com',
-                    'password': 'H3ml1g4Arn3',
-                    'redirect_uri': None,
-                    'initialize_uri': None,
-                },
-                'provider': None,
+            parent.user._context = {
+                'host': 'https://www.example.com',
+                'auth': {
+                    'client': {
+                        'id': 'aaaa',
+                    },
+                    'user': {
+                        'username': 'test-user@example.com',
+                        'password': 'H3ml1g4Arn3',
+                        'redirect_uri': None,
+                        'initialize_uri': None,
+                    },
+                    'provider': None,
+                }
             }
-        }
-        parent.user.host = cast(str, parent.user._context['host'])
+            parent.user.host = cast(str, parent.user._context['host'])
 
-        mock_request_session()
+            mock_request_session()
 
-        # both initialize and provider uri set
-        cast(dict, parent.user._context['auth'])['user'].update({'initialize_uri': auth_user_uri, 'redirect_uri': auth_user_uri})
+            # both initialize and provider uri set
+            cast(dict, parent.user._context['auth'])['user'].update({'initialize_uri': auth_user_uri, 'redirect_uri': auth_user_uri})
 
-        with pytest.raises(AssertionError) as ae:
-            AAD.get_oauth_authorization(parent, parent.user)
-        assert str(ae.value) == 'both auth.user.initialize_uri and auth.user.redirect_uri is set'
-
-        fire_spy.assert_not_called()
-
-        cast(dict, parent.user._context['auth'])['user'].update({'initialize_uri': None, 'redirect_uri': None})
-
-        cast(dict, parent.user._context['auth'])['user'].update({login_start: auth_user_uri})
-
-        if login_start == 'redirect_uri':
-            # test when auth.provider is not set
             with pytest.raises(AssertionError) as ae:
-                AAD.get_oauth_authorization(parent, parent.user)
-            assert str(ae.value) == 'context variable auth.provider is not set'
+                AAD.get_oauth_authorization(parent.user)
+            assert str(ae.value) == 'both auth.user.initialize_uri and auth.user.redirect_uri is set'
 
             fire_spy.assert_not_called()
 
-            cast(GrizzlyAuthHttpContext, parent.user._context['auth'])['provider'] = provider_url
+            cast(dict, parent.user._context['auth'])['user'].update({'initialize_uri': None, 'redirect_uri': None})
 
-        # test when login sequence returns bad request
-        mock_request_session(Error.REQUEST_1_HTTP_STATUS)
+            cast(dict, parent.user._context['auth'])['user'].update({login_start: auth_user_uri})
 
-        with pytest.raises(StopUser):
-            AAD.get_oauth_authorization(parent, parent.user)
+            if login_start == 'redirect_uri':
+                # test when auth.provider is not set
+                with pytest.raises(AssertionError) as ae:
+                    AAD.get_oauth_authorization(parent.user)
+                assert str(ae.value) == 'context variable auth.provider is not set'
 
-        fire_spy.assert_called_once_with(
-            request_type='AUTH',
-            response_time=0,
-            name=f'001 AAD OAuth2 user token {version}',
-            context=parent.user._context,
-            response_length=0,
-            response=None,
-            exception=ANY,
-        )
-        _, kwargs = fire_spy.call_args_list[-1]
-        exception = kwargs.get('exception', None)
-        print(exception)
-        assert isinstance(exception, RuntimeError)
-        assert str(exception) == f'user auth request 1: {provider_url}/authorize had unexpected status code 400'
-        fire_spy.reset_mock()
+                fire_spy.assert_not_called()
 
-        mock_request_session(Error.REQUEST_2_HTTP_STATUS)
+                cast(GrizzlyAuthHttpContext, parent.user._context['auth'])['provider'] = provider_url
 
-        with pytest.raises(StopUser):
-            AAD.get_oauth_authorization(parent, parent.user)
+            # test when login sequence returns bad request
+            mock_request_session(Error.REQUEST_1_HTTP_STATUS)
 
-        fire_spy.assert_called_once_with(
-            request_type='AUTH',
-            response_time=0,
-            name=f'001 AAD OAuth2 user token {version}',
-            context=parent.user._context,
-            response_length=0,
-            response=None,
-            exception=ANY,
-        )
-        _, kwargs = fire_spy.call_args_list[-1]
-        exception = kwargs.get('exception', None)
-        assert isinstance(exception, RuntimeError)
-        assert str(exception) == 'user auth request 2: https://login.example.com/GetCredentialType had unexpected status code 400'
-        fire_spy.reset_mock()
-
-        mock_request_session(Error.REQUEST_3_HTTP_STATUS)
-
-        with pytest.raises(StopUser):
-            AAD.get_oauth_authorization(parent, parent.user)
-
-        fire_spy.assert_called_once_with(
-            request_type='AUTH',
-            response_time=0,
-            name=f'001 AAD OAuth2 user token {version}',
-            context=parent.user._context,
-            response_length=0,
-            response=None,
-            exception=ANY,
-        )
-        _, kwargs = fire_spy.call_args_list[-1]
-        exception = kwargs.get('exception', None)
-        assert isinstance(exception, RuntimeError)
-        assert str(exception) == 'user auth request 3: https://login.example.com/login had unexpected status code 400'
-        fire_spy.reset_mock()
-
-        mock_request_session(Error.REQUEST_3_ERROR_MESSAGE)
-
-        with caplog.at_level(logging.ERROR):
             with pytest.raises(StopUser):
-                AAD.get_oauth_authorization(parent, parent.user)
-
-        fire_spy.assert_called_once_with(
-            request_type='AUTH',
-            response_time=0,
-            name=f'001 AAD OAuth2 user token {version}',
-            context=parent.user._context,
-            response_length=0,
-            response=None,
-            exception=ANY,
-        )
-        _, kwargs = fire_spy.call_args_list[-1]
-        exception = kwargs.get('exception', None)
-        assert isinstance(exception, RuntimeError)
-        assert str(exception) == 'failed big time'
-        fire_spy.reset_mock()
-
-        assert caplog.messages[-1] == 'failed big time'
-        caplog.clear()
-
-        mock_request_session(Error.REQUEST_3_MFA_REQUIRED)
-
-        with caplog.at_level(logging.ERROR):
-            with pytest.raises(StopUser):
-                AAD.get_oauth_authorization(parent, parent.user)
-
-        expected_error_message = 'test-user@example.com requires MFA for login: fax = +46 1234'
-
-        fire_spy.assert_called_once_with(
-            request_type='AUTH',
-            response_time=0,
-            name=f'001 AAD OAuth2 user token {version}',
-            context=parent.user._context,
-            response_length=0,
-            response=None,
-            exception=ANY,
-        )
-        _, kwargs = fire_spy.call_args_list[-1]
-        exception = kwargs.get('exception', None)
-        assert isinstance(exception, RuntimeError)
-        assert str(exception) == expected_error_message
-        fire_spy.reset_mock()
-
-        assert caplog.messages[-1] == expected_error_message
-        caplog.clear()
-
-        mock_request_session(Error.REQUEST_4_HTTP_STATUS)
-
-        with pytest.raises(StopUser):
-            AAD.get_oauth_authorization(parent, parent.user)
-
-        assert parent.user.session_started is None
-
-        fire_spy.assert_called_once_with(
-            request_type='AUTH',
-            response_time=0,
-            name=f'001 AAD OAuth2 user token {version}',
-            context=parent.user._context,
-            response_length=0,
-            response=None,
-            exception=ANY,
-        )
-        _, kwargs = fire_spy.call_args_list[-1]
-        exception = kwargs.get('exception', None)
-        assert isinstance(exception, RuntimeError)
-        expected_status_code = 200 if login_start == 'redirect_uri' else 302
-        assert str(exception) == f'user auth request 4: https://login.example.com/kmsi had unexpected status code {expected_status_code}'
-        fire_spy.reset_mock()
-
-        mock_request_session(Error.REQUEST_4_HTTP_STATUS_CONFIG)
-
-        with pytest.raises(StopUser):
-            AAD.get_oauth_authorization(parent, parent.user)
-
-        assert parent.user.session_started is None
-
-        fire_spy.assert_called_once_with(
-            request_type='AUTH',
-            response_time=0,
-            name=f'001 AAD OAuth2 user token {version}',
-            context=parent.user._context,
-            response_length=0,
-            response=None,
-            exception=ANY,
-        )
-        _, kwargs = fire_spy.call_args_list[-1]
-        exception = kwargs.get('exception', None)
-        assert isinstance(exception, RuntimeError)
-        assert str(exception) == 'error! error! error!'
-        fire_spy.reset_mock()
-
-        # test error handling when login sequence response doesn't contain expected payload
-        mock_request_session(Error.REQUEST_1_NO_DOLLAR_CONFIG)
-        with pytest.raises(StopUser):
-            AAD.get_oauth_authorization(parent, parent.user)
-
-        fire_spy.assert_called_once_with(
-            request_type='AUTH',
-            response_time=0,
-            name=f'001 AAD OAuth2 user token {version}',
-            context=parent.user._context,
-            response_length=0,
-            response=None,
-            exception=ANY,
-        )
-        _, kwargs = fire_spy.call_args_list[-1]
-        exception = kwargs.get('exception', None)
-        assert isinstance(exception, ValueError)
-        assert str(exception) == f'no config found in response from {provider_url}/authorize'
-        fire_spy.reset_mock()
-
-        mock_request_session(Error.REQUEST_1_MISSING_STATE)
-        with pytest.raises(StopUser):
-            AAD.get_oauth_authorization(parent, parent.user)
-
-        fire_spy.assert_called_once_with(
-            request_type='AUTH',
-            response_time=0,
-            name=f'001 AAD OAuth2 user token {version}',
-            context=parent.user._context,
-            response_length=0,
-            response=None,
-            exception=ANY,
-        )
-        _, kwargs = fire_spy.call_args_list[-1]
-        exception = kwargs.get('exception', None)
-        assert isinstance(exception, ValueError)
-        assert str(exception) == f'unexpected response body from {provider_url}/authorize: missing "hpgact" in config'
-        fire_spy.reset_mock()
-
-        mock_request_session(Error.REQUEST_1_DOLLAR_CONFIG_ERROR)
-        with pytest.raises(StopUser):
-            AAD.get_oauth_authorization(parent, parent.user)
-
-        fire_spy.assert_called_once_with(
-            request_type='AUTH',
-            response_time=0,
-            name=f'001 AAD OAuth2 user token {version}',
-            context=parent.user._context,
-            response_length=0,
-            response=None,
-            exception=ANY,
-        )
-        _, kwargs = fire_spy.call_args_list[-1]
-        exception = kwargs.get('exception', None)
-        assert isinstance(exception, RuntimeError)
-        assert str(exception) == 'oh no!'
-        fire_spy.reset_mock()
-
-        mock_request_session(Error.REQUEST_2_ERROR_MESSAGE)
-        with pytest.raises(StopUser):
-            AAD.get_oauth_authorization(parent, parent.user)
-
-        fire_spy.assert_called_once_with(
-            request_type='AUTH',
-            response_time=0,
-            name=f'001 AAD OAuth2 user token {version}',
-            context=parent.user._context,
-            response_length=0,
-            response=None,
-            exception=ANY,
-        )
-        _, kwargs = fire_spy.call_args_list[-1]
-        exception = kwargs.get('exception', None)
-        assert isinstance(exception, RuntimeError)
-        assert str(exception) == 'error response from https://login.example.com/GetCredentialType: code=12345678, message=error! error!'
-        fire_spy.reset_mock()
-
-        # successful login sequence
-        mock_request_session()
-
-        parent.user.session_started = session_started
-
-        expected_auth: Tuple[AuthType, str]
-        if login_start == 'redirect_uri':
-            expected_auth = (AuthType.HEADER, fake_token,)
-        else:
-            expected_auth = (AuthType.COOKIE, f'auth={fake_token}',)
-
-        assert AAD.get_oauth_authorization(parent, parent.user) == expected_auth
-
-        if not is_token_v2_0 or login_start == 'initialize_uri':
-            get_oauth_token_mock.assert_not_called()
-        else:
-            get_oauth_token_mock.assert_called_once_with(parent, parent.user, (ANY, ANY,))
-            get_oauth_token_mock.reset_mock()
-
-        fire_spy.assert_called_once_with(
-            request_type='AUTH',
-            response_time=0,
-            name=f'001 AAD OAuth2 user token {version}',
-            context=parent.user._context,
-            response_length=0,
-            response=None,
-            exception=None,
-        )
-        fire_spy.reset_mock()
-
-        # test no host in redirect/initialize uri
-        auth_user_uri = '/app/authenticated' if login_start == 'redirect_uri' else '/app/login'
-
-        cast(GrizzlyAuthHttpContextUser, cast(GrizzlyAuthHttpContext, parent.user._context['auth'])['user'])[login_start] = auth_user_uri  # type: ignore
-
-        assert AAD.get_oauth_authorization(parent, parent.user) == expected_auth
-
-        fire_spy.assert_called_once_with(
-            request_type='AUTH',
-            response_time=0,
-            name=f'001 AAD OAuth2 user token {version}',
-            context=parent.user._context,
-            response_length=0,
-            response=None,
-            exception=None,
-        )
-        fire_spy.reset_mock()
-
-        if login_start == 'initialize_uri':
-            mock_request_session(Error.REQUEST_5_HTTP_STATUS)
-            with pytest.raises(StopUser):
-                AAD.get_oauth_authorization(parent, parent.user)
+                AAD.get_oauth_authorization(parent.user)
 
             fire_spy.assert_called_once_with(
                 request_type='AUTH',
@@ -662,12 +383,13 @@ class TestAAD:
             _, kwargs = fire_spy.call_args_list[-1]
             exception = kwargs.get('exception', None)
             assert isinstance(exception, RuntimeError)
-            assert str(exception) == 'user auth request 5: https://www.example.com/app/login/signin-oidc had unexpected status code 500'
+            assert str(exception) == f'user auth request 1: {provider_url}/authorize had unexpected status code 400'
             fire_spy.reset_mock()
 
-            mock_request_session(Error.REQUEST_5_NO_COOKIE)
+            mock_request_session(Error.REQUEST_2_HTTP_STATUS)
+
             with pytest.raises(StopUser):
-                AAD.get_oauth_authorization(parent, parent.user)
+                AAD.get_oauth_authorization(parent.user)
 
             fire_spy.assert_called_once_with(
                 request_type='AUTH',
@@ -681,8 +403,289 @@ class TestAAD:
             _, kwargs = fire_spy.call_args_list[-1]
             exception = kwargs.get('exception', None)
             assert isinstance(exception, RuntimeError)
-            assert str(exception) == 'did not find AAD cookie in authorization flow response session'
+            assert str(exception) == 'user auth request 2: https://login.example.com/GetCredentialType had unexpected status code 400'
             fire_spy.reset_mock()
+
+            mock_request_session(Error.REQUEST_3_HTTP_STATUS)
+
+            with pytest.raises(StopUser):
+                AAD.get_oauth_authorization(parent.user)
+
+            fire_spy.assert_called_once_with(
+                request_type='AUTH',
+                response_time=0,
+                name=f'001 AAD OAuth2 user token {version}',
+                context=parent.user._context,
+                response_length=0,
+                response=None,
+                exception=ANY,
+            )
+            _, kwargs = fire_spy.call_args_list[-1]
+            exception = kwargs.get('exception', None)
+            assert isinstance(exception, RuntimeError)
+            assert str(exception) == 'user auth request 3: https://login.example.com/login had unexpected status code 400'
+            fire_spy.reset_mock()
+
+            mock_request_session(Error.REQUEST_3_ERROR_MESSAGE)
+
+            with caplog.at_level(logging.ERROR):
+                with pytest.raises(StopUser):
+                    AAD.get_oauth_authorization(parent.user)
+
+            fire_spy.assert_called_once_with(
+                request_type='AUTH',
+                response_time=0,
+                name=f'001 AAD OAuth2 user token {version}',
+                context=parent.user._context,
+                response_length=0,
+                response=None,
+                exception=ANY,
+            )
+            _, kwargs = fire_spy.call_args_list[-1]
+            exception = kwargs.get('exception', None)
+            assert isinstance(exception, RuntimeError)
+            assert str(exception) == 'failed big time'
+            fire_spy.reset_mock()
+
+            assert caplog.messages[-1] == 'failed big time'
+            caplog.clear()
+
+            mock_request_session(Error.REQUEST_3_MFA_REQUIRED)
+
+            with caplog.at_level(logging.ERROR):
+                with pytest.raises(StopUser):
+                    AAD.get_oauth_authorization(parent.user)
+
+            expected_error_message = 'test-user@example.com requires MFA for login: fax = +46 1234'
+
+            fire_spy.assert_called_once_with(
+                request_type='AUTH',
+                response_time=0,
+                name=f'001 AAD OAuth2 user token {version}',
+                context=parent.user._context,
+                response_length=0,
+                response=None,
+                exception=ANY,
+            )
+            _, kwargs = fire_spy.call_args_list[-1]
+            exception = kwargs.get('exception', None)
+            assert isinstance(exception, RuntimeError)
+            assert str(exception) == expected_error_message
+            fire_spy.reset_mock()
+
+            assert caplog.messages[-1] == expected_error_message
+            caplog.clear()
+
+            mock_request_session(Error.REQUEST_4_HTTP_STATUS)
+
+            with pytest.raises(StopUser):
+                AAD.get_oauth_authorization(parent.user)
+
+            assert parent.user.session_started is None
+
+            fire_spy.assert_called_once_with(
+                request_type='AUTH',
+                response_time=0,
+                name=f'001 AAD OAuth2 user token {version}',
+                context=parent.user._context,
+                response_length=0,
+                response=None,
+                exception=ANY,
+            )
+            _, kwargs = fire_spy.call_args_list[-1]
+            exception = kwargs.get('exception', None)
+            assert isinstance(exception, RuntimeError)
+            expected_status_code = 200 if login_start == 'redirect_uri' else 302
+            assert str(exception) == f'user auth request 4: https://login.example.com/kmsi had unexpected status code {expected_status_code}'
+            fire_spy.reset_mock()
+
+            mock_request_session(Error.REQUEST_4_HTTP_STATUS_CONFIG)
+
+            with pytest.raises(StopUser):
+                AAD.get_oauth_authorization(parent.user)
+
+            assert parent.user.session_started is None
+
+            fire_spy.assert_called_once_with(
+                request_type='AUTH',
+                response_time=0,
+                name=f'001 AAD OAuth2 user token {version}',
+                context=parent.user._context,
+                response_length=0,
+                response=None,
+                exception=ANY,
+            )
+            _, kwargs = fire_spy.call_args_list[-1]
+            exception = kwargs.get('exception', None)
+            assert isinstance(exception, RuntimeError)
+            assert str(exception) == 'error! error! error!'
+            fire_spy.reset_mock()
+
+            # test error handling when login sequence response doesn't contain expected payload
+            mock_request_session(Error.REQUEST_1_NO_DOLLAR_CONFIG)
+            with pytest.raises(StopUser):
+                AAD.get_oauth_authorization(parent.user)
+
+            fire_spy.assert_called_once_with(
+                request_type='AUTH',
+                response_time=0,
+                name=f'001 AAD OAuth2 user token {version}',
+                context=parent.user._context,
+                response_length=0,
+                response=None,
+                exception=ANY,
+            )
+            _, kwargs = fire_spy.call_args_list[-1]
+            exception = kwargs.get('exception', None)
+            assert isinstance(exception, ValueError)
+            assert str(exception) == f'no config found in response from {provider_url}/authorize'
+            fire_spy.reset_mock()
+
+            mock_request_session(Error.REQUEST_1_MISSING_STATE)
+            with pytest.raises(StopUser):
+                AAD.get_oauth_authorization(parent.user)
+
+            fire_spy.assert_called_once_with(
+                request_type='AUTH',
+                response_time=0,
+                name=f'001 AAD OAuth2 user token {version}',
+                context=parent.user._context,
+                response_length=0,
+                response=None,
+                exception=ANY,
+            )
+            _, kwargs = fire_spy.call_args_list[-1]
+            exception = kwargs.get('exception', None)
+            assert isinstance(exception, ValueError)
+            assert str(exception) == f'unexpected response body from {provider_url}/authorize: missing "hpgact" in config'
+            fire_spy.reset_mock()
+
+            mock_request_session(Error.REQUEST_1_DOLLAR_CONFIG_ERROR)
+            with pytest.raises(StopUser):
+                AAD.get_oauth_authorization(parent.user)
+
+            fire_spy.assert_called_once_with(
+                request_type='AUTH',
+                response_time=0,
+                name=f'001 AAD OAuth2 user token {version}',
+                context=parent.user._context,
+                response_length=0,
+                response=None,
+                exception=ANY,
+            )
+            _, kwargs = fire_spy.call_args_list[-1]
+            exception = kwargs.get('exception', None)
+            assert isinstance(exception, RuntimeError)
+            assert str(exception) == 'oh no!'
+            fire_spy.reset_mock()
+
+            mock_request_session(Error.REQUEST_2_ERROR_MESSAGE)
+            with pytest.raises(StopUser):
+                AAD.get_oauth_authorization(parent.user)
+
+            fire_spy.assert_called_once_with(
+                request_type='AUTH',
+                response_time=0,
+                name=f'001 AAD OAuth2 user token {version}',
+                context=parent.user._context,
+                response_length=0,
+                response=None,
+                exception=ANY,
+            )
+            _, kwargs = fire_spy.call_args_list[-1]
+            exception = kwargs.get('exception', None)
+            assert isinstance(exception, RuntimeError)
+            assert str(exception) == 'error response from https://login.example.com/GetCredentialType: code=12345678, message=error! error!'
+            fire_spy.reset_mock()
+
+            # successful login sequence
+            mock_request_session()
+
+            parent.user.session_started = session_started
+
+            expected_auth: Tuple[AuthType, str]
+            if login_start == 'redirect_uri':
+                expected_auth = (AuthType.HEADER, fake_token,)
+            else:
+                expected_auth = (AuthType.COOKIE, f'auth={fake_token}',)
+
+            assert AAD.get_oauth_authorization(parent.user) == expected_auth
+
+            if not is_token_v2_0 or login_start == 'initialize_uri':
+                get_oauth_token_mock.assert_not_called()
+            else:
+                get_oauth_token_mock.assert_called_once_with(parent.user, (ANY, ANY,))
+                get_oauth_token_mock.reset_mock()
+
+            fire_spy.assert_called_once_with(
+                request_type='AUTH',
+                response_time=0,
+                name=f'001 AAD OAuth2 user token {version}',
+                context=parent.user._context,
+                response_length=0,
+                response=None,
+                exception=None,
+            )
+            fire_spy.reset_mock()
+
+            # test no host in redirect/initialize uri
+            auth_user_uri = '/app/authenticated' if login_start == 'redirect_uri' else '/app/login'
+
+            cast(GrizzlyAuthHttpContextUser, cast(GrizzlyAuthHttpContext, parent.user._context['auth'])['user'])[login_start] = auth_user_uri  # type: ignore
+
+            assert AAD.get_oauth_authorization(parent.user) == expected_auth
+
+            fire_spy.assert_called_once_with(
+                request_type='AUTH',
+                response_time=0,
+                name=f'001 AAD OAuth2 user token {version}',
+                context=parent.user._context,
+                response_length=0,
+                response=None,
+                exception=None,
+            )
+            fire_spy.reset_mock()
+
+            if login_start == 'initialize_uri':
+                mock_request_session(Error.REQUEST_5_HTTP_STATUS)
+                with pytest.raises(StopUser):
+                    AAD.get_oauth_authorization(parent.user)
+
+                fire_spy.assert_called_once_with(
+                    request_type='AUTH',
+                    response_time=0,
+                    name=f'001 AAD OAuth2 user token {version}',
+                    context=parent.user._context,
+                    response_length=0,
+                    response=None,
+                    exception=ANY,
+                )
+                _, kwargs = fire_spy.call_args_list[-1]
+                exception = kwargs.get('exception', None)
+                assert isinstance(exception, RuntimeError)
+                assert str(exception) == 'user auth request 5: https://www.example.com/app/login/signin-oidc had unexpected status code 500'
+                fire_spy.reset_mock()
+
+                mock_request_session(Error.REQUEST_5_NO_COOKIE)
+                with pytest.raises(StopUser):
+                    AAD.get_oauth_authorization(parent.user)
+
+                fire_spy.assert_called_once_with(
+                    request_type='AUTH',
+                    response_time=0,
+                    name=f'001 AAD OAuth2 user token {version}',
+                    context=parent.user._context,
+                    response_length=0,
+                    response=None,
+                    exception=ANY,
+                )
+                _, kwargs = fire_spy.call_args_list[-1]
+                exception = kwargs.get('exception', None)
+                assert isinstance(exception, RuntimeError)
+                assert str(exception) == 'did not find AAD cookie in authorization flow response session'
+                fire_spy.reset_mock()
+        finally:
+            parent.user.__class__.__name__ = original_class_name
 
     @pytest.mark.parametrize('grant_type', [
         'client_credentials::v1',
@@ -694,159 +697,163 @@ class TestAAD:
 
         grant_type, version = grant_type.split('::', 1)
 
-        parent.user.__class__.__name__ = f'{parent.user.__class__.__name__}_001'
+        original_class_name = parent.user.__class__.__name__
+        try:
+            parent.user.__class__.__name__ = f'{parent.user.__class__.__name__}_001'
 
-        def mock_requests_post(payload: str, status_code: int) -> MagicMock:
-            response = Response()
-            response.status_code = status_code
-            response._content = payload.encode()
+            def mock_requests_post(payload: str, status_code: int) -> MagicMock:
+                response = Response()
+                response.status_code = status_code
+                response._content = payload.encode()
 
-            return mocker.patch('grizzly.auth.aad.requests.Session.post', return_value=response)
+                return mocker.patch('grizzly.auth.aad.requests.Session.post', return_value=response)
 
-        assert isinstance(parent.user, RestApiUser)
+            assert isinstance(parent.user, RestApiUser)
 
-        provider_url = 'https://login.example.com/foobarinc/oauth2'
+            provider_url = 'https://login.example.com/foobarinc/oauth2'
 
-        if grant_type == 'authorization_code':
-            pkcs = ('code', 'code_verifier',)
-            token_name = 'id_token'
-        else:
-            pkcs = None
-            token_name = 'access_token'
-            if version == 'v2':
-                provider_url = f'{provider_url}/v2.0'
+            if grant_type == 'authorization_code':
+                pkcs = ('code', 'code_verifier',)
+                token_name = 'id_token'
+            else:
+                pkcs = None
+                token_name = 'access_token'
+                if version == 'v2':
+                    provider_url = f'{provider_url}/v2.0'
 
-        fire_spy = mocker.spy(parent.user.environment.events.request, 'fire')
+            fire_spy = mocker.spy(parent.user.environment.events.request, 'fire')
 
-        safe_del(parent.user._context, 'auth')
+            safe_del(parent.user._context, 'auth')
 
-        with pytest.raises(AssertionError) as ae:
-            AAD.get_oauth_token(parent, parent.user, pkcs)
-        assert str(ae.value) == 'context variable auth is not set'
-
-        parent.user._context['auth'] = {}
-
-        with pytest.raises(AssertionError) as ae:
-            AAD.get_oauth_token(parent, parent.user, pkcs)
-        assert str(ae.value) == 'context variable auth.provider is not set'
-
-        cast(GrizzlyAuthHttpContext, parent.user._context['auth']).update({'provider': provider_url})
-
-        with pytest.raises(AssertionError) as ae:
-            AAD.get_oauth_token(parent, parent.user, pkcs)
-        assert str(ae.value) == 'context variable auth.client is not set'
-
-        cast(GrizzlyAuthHttpContext, parent.user._context['auth']).update({'client': {'id': None, 'secret': None, 'resource': None}})
-
-        if grant_type == 'authorization_code':
             with pytest.raises(AssertionError) as ae:
-                AAD.get_oauth_token(parent, parent.user, pkcs)
-            assert str(ae.value) == 'context variable auth.user is not set'
+                AAD.get_oauth_token(parent.user, pkcs)
+            assert str(ae.value) == 'context variable auth is not set'
 
-            cast(GrizzlyAuthHttpContext, parent.user._context['auth']).update({'user': {'username': None, 'password': None, 'redirect_uri': '/auth', 'initialize_uri': None}})
+            parent.user._context['auth'] = {}
 
-        parent.user._context['host'] = parent.user.host = 'https://example.com'
-        cast(GrizzlyAuthHttpContext, parent.user._context['auth']).update({
-            'provider': provider_url,
-            'client': {
-                'id': 'asdf',
-                'secret': 'asdf',
-                'resource': 'asdf',
-            },
-        })
+            with pytest.raises(AssertionError) as ae:
+                AAD.get_oauth_token(parent.user, pkcs)
+            assert str(ae.value) == 'context variable auth.provider is not set'
 
-        payload = jsondumps({'error_description': 'fake error message'})
-        requests_mock = mock_requests_post(payload, 400)
+            cast(GrizzlyAuthHttpContext, parent.user._context['auth']).update({'provider': provider_url})
 
-        session_started = time()
+            with pytest.raises(AssertionError) as ae:
+                AAD.get_oauth_token(parent.user, pkcs)
+            assert str(ae.value) == 'context variable auth.client is not set'
 
-        assert parent.user.session_started is None
+            cast(GrizzlyAuthHttpContext, parent.user._context['auth']).update({'client': {'id': None, 'secret': None, 'resource': None}})
 
-        with pytest.raises(StopUser):
-            AAD.get_oauth_token(parent, parent.user, pkcs)
+            if grant_type == 'authorization_code':
+                with pytest.raises(AssertionError) as ae:
+                    AAD.get_oauth_token(parent.user, pkcs)
+                assert str(ae.value) == 'context variable auth.user is not set'
 
-        requests_mock.assert_called_once_with(f'{provider_url}/token', verify=True, data=ANY, headers=ANY, allow_redirects=(pkcs is None))
-        _, kwargs = requests_mock.call_args_list[-1]
-        data = kwargs.get('data', None)
-        assert data['grant_type'] == grant_type
-        assert data['client_id'] == 'asdf'
-        if pkcs is None:
-            if version == 'v1':
-                assert data['resource'] == 'asdf'
-                assert len(data) == 4
+                cast(GrizzlyAuthHttpContext, parent.user._context['auth']).update({'user': {'username': None, 'password': None, 'redirect_uri': '/auth', 'initialize_uri': None}})
+
+            parent.user._context['host'] = parent.user.host = 'https://example.com'
+            cast(GrizzlyAuthHttpContext, parent.user._context['auth']).update({
+                'provider': provider_url,
+                'client': {
+                    'id': 'asdf',
+                    'secret': 'asdf',
+                    'resource': 'asdf',
+                },
+            })
+
+            payload = jsondumps({'error_description': 'fake error message'})
+            requests_mock = mock_requests_post(payload, 400)
+
+            session_started = time()
+
+            assert parent.user.session_started is None
+
+            with pytest.raises(StopUser):
+                AAD.get_oauth_token(parent.user, pkcs)
+
+            requests_mock.assert_called_once_with(f'{provider_url}/token', verify=True, data=ANY, headers=ANY, allow_redirects=(pkcs is None))
+            _, kwargs = requests_mock.call_args_list[-1]
+            data = kwargs.get('data', None)
+            assert data['grant_type'] == grant_type
+            assert data['client_id'] == 'asdf'
+            if pkcs is None:
+                if version == 'v1':
+                    assert data['resource'] == 'asdf'
+                    assert len(data) == 4
+                else:
+                    assert data['scope'] == 'asdf'
+                    assert data['tenant'] == 'foobarinc'
+                    assert len(data) == 5
             else:
-                assert data['scope'] == 'asdf'
-                assert data['tenant'] == 'foobarinc'
+                assert data['redirect_uri'] == f'{parent.user.host}/auth'
+                assert data['code'] == pkcs[0]
+                assert data['code_verifier'] == pkcs[1]
                 assert len(data) == 5
-        else:
-            assert data['redirect_uri'] == f'{parent.user.host}/auth'
-            assert data['code'] == pkcs[0]
-            assert data['code_verifier'] == pkcs[1]
-            assert len(data) == 5
-        assert parent.user.session_started is None
+            assert parent.user.session_started is None
 
-        if pkcs is not None:
-            fire_spy.assert_not_called()
-        else:
-            fire_spy.assert_called_once_with(
-                request_type='AUTH',
-                response_time=ANY,
-                name=f'001 AAD OAuth2 user token {version}.0',
-                context=parent.user._context,
-                response=None,
-                exception=ANY,
-                response_length=len(payload.encode()),
-            )
-
-            _, kwargs = fire_spy.call_args_list[-1]
-            exception = kwargs.get('exception', None)
-            assert isinstance(exception, RuntimeError)
-            assert str(exception) == 'fake error message'
-
-        requests_mock.reset_mock()
-
-        parent.user.session_started = session_started
-        parent.user.headers.update({
-            'Authorization': 'foobar',
-            'Content-Type': 'plain/text',
-            'Ocp-Apim-Subscription-Key': 'secret',
-        })
-        parent.user._context['verify_certificates'] = False
-
-        requests_mock = mock_requests_post(jsondumps({token_name: 'asdf'}), 200)
-
-        assert AAD.get_oauth_token(parent, parent.user, pkcs) == (AuthType.HEADER, 'asdf',)
-
-        assert parent.user.session_started >= session_started
-        requests_mock.assert_called_once_with(f'{provider_url}/token', verify=True, data=ANY, headers=ANY, allow_redirects=(pkcs is None))
-        _, kwargs = requests_mock.call_args_list[-1]
-        data = kwargs.get('data', None)
-        headers = kwargs.get('headers', None)
-
-        assert data['grant_type'] == grant_type
-        assert data['client_id'] == 'asdf'
-        assert 'Authorization' not in headers
-        assert 'Content-Type' not in headers
-        assert 'Ocp-Apim-Subscription-Key' not in headers
-
-        if pkcs is None:
-            if version == 'v1':
-                assert data['resource'] == 'asdf'
-                assert len(data) == 4
+            if pkcs is not None:
+                fire_spy.assert_not_called()
             else:
-                assert data['scope'] == 'asdf'
-                assert data['tenant'] == 'foobarinc'
+                fire_spy.assert_called_once_with(
+                    request_type='AUTH',
+                    response_time=ANY,
+                    name=f'001 AAD OAuth2 user token {version}.0',
+                    context=parent.user._context,
+                    response=None,
+                    exception=ANY,
+                    response_length=len(payload.encode()),
+                )
+
+                _, kwargs = fire_spy.call_args_list[-1]
+                exception = kwargs.get('exception', None)
+                assert isinstance(exception, RuntimeError)
+                assert str(exception) == 'fake error message'
+
+            requests_mock.reset_mock()
+
+            parent.user.session_started = session_started
+            parent.user.headers.update({
+                'Authorization': 'foobar',
+                'Content-Type': 'plain/text',
+                'Ocp-Apim-Subscription-Key': 'secret',
+            })
+            parent.user._context['verify_certificates'] = False
+
+            requests_mock = mock_requests_post(jsondumps({token_name: 'asdf'}), 200)
+
+            assert AAD.get_oauth_token(parent.user, pkcs) == (AuthType.HEADER, 'asdf',)
+
+            assert parent.user.session_started >= session_started
+            requests_mock.assert_called_once_with(f'{provider_url}/token', verify=True, data=ANY, headers=ANY, allow_redirects=(pkcs is None))
+            _, kwargs = requests_mock.call_args_list[-1]
+            data = kwargs.get('data', None)
+            headers = kwargs.get('headers', None)
+
+            assert data['grant_type'] == grant_type
+            assert data['client_id'] == 'asdf'
+            assert 'Authorization' not in headers
+            assert 'Content-Type' not in headers
+            assert 'Ocp-Apim-Subscription-Key' not in headers
+
+            if pkcs is None:
+                if version == 'v1':
+                    assert data['resource'] == 'asdf'
+                    assert len(data) == 4
+                else:
+                    assert data['scope'] == 'asdf'
+                    assert data['tenant'] == 'foobarinc'
+                    assert len(data) == 5
+            else:
+                assert data['redirect_uri'] == f'{parent.user.host}/auth'
+                assert data['code'] == pkcs[0]
+                assert data['code_verifier'] == pkcs[1]
                 assert len(data) == 5
-        else:
-            assert data['redirect_uri'] == f'{parent.user.host}/auth'
-            assert data['code'] == pkcs[0]
-            assert data['code_verifier'] == pkcs[1]
-            assert len(data) == 5
-            assert headers.get('Origin', None) == 'https://example.com'
-            assert headers.get('Referer', None) == 'https://example.com'
+                assert headers.get('Origin', None) == 'https://example.com'
+                assert headers.get('Referer', None) == 'https://example.com'
 
-        cast(GrizzlyAuthHttpContext, parent.user._context['auth']).update({'provider': None})
+            cast(GrizzlyAuthHttpContext, parent.user._context['auth']).update({'provider': None})
 
-        with pytest.raises(AssertionError) as ae:
-            AAD.get_oauth_token(parent, parent.user, pkcs)
-        assert str(ae.value) == 'context variable auth.provider is not set'
+            with pytest.raises(AssertionError) as ae:
+                AAD.get_oauth_token(parent.user, pkcs)
+            assert str(ae.value) == 'context variable auth.provider is not set'
+        finally:
+            parent.user.__class__.__name__ = original_class_name

--- a/tests/unit/test_grizzly/steps/scenario/test_response.py
+++ b/tests/unit/test_grizzly/steps/scenario/test_response.py
@@ -366,9 +366,9 @@ def test_step_response_content_type(behave_fixture: BehaveFixture) -> None:
         step_response_content_type(behave, TransformerContentType.JSON)
     assert 'Latest task in scenario is not a request' in str(ae)
 
-    request = RequestTask(RequestMethod.POST, 'test-request', endpoint='queue:INCOMMING.MESSAGE')
+    request: RequestTask = RequestTask(RequestMethod.POST, 'test-request', endpoint='queue:INCOMMING.MESSAGE')
 
-    assert request.response.content_type == TransformerContentType.UNDEFINED
+    assert getattr(request.response, 'content_type', None) == TransformerContentType.UNDEFINED
 
     grizzly.scenario.tasks.add(request)
 

--- a/tests/unit/test_grizzly/steps/test__helpers.py
+++ b/tests/unit/test_grizzly/steps/test__helpers.py
@@ -485,19 +485,19 @@ def test_normalize_step_name() -> None:
     assert expected == actual
 
 
-def test_get_task_client_error() -> None:
+def test_get_task_client_error(grizzly_fixture: GrizzlyFixture) -> None:
     with pytest.raises(AssertionError) as ae:
-        get_task_client('')
+        get_task_client(grizzly_fixture.grizzly, '')
     assert 'could not find scheme in ""' == str(ae.value)
 
     with pytest.raises(AssertionError) as ae:
-        get_task_client('obscure://obscure.example.io')
+        get_task_client(grizzly_fixture.grizzly, 'obscure://obscure.example.io')
     assert 'no client task registered for obscure' == str(ae.value)
 
 
 @pytest.mark.parametrize('test_scheme', client.available.keys())
-def test_get_task_client(test_scheme: str) -> None:
-    task_client = get_task_client(f'{test_scheme}://example.net')
+def test_get_task_client(grizzly_fixture: GrizzlyFixture, test_scheme: str) -> None:
+    task_client = get_task_client(grizzly_fixture.grizzly, f'{test_scheme}://example.net')
 
     assert task_client is not None
     assert issubclass(task_client, ClientTask)

--- a/tests/unit/test_grizzly/tasks/clients/test___init__.py
+++ b/tests/unit/test_grizzly/tasks/clients/test___init__.py
@@ -29,19 +29,30 @@ def test_task_failing(grizzly_fixture: GrizzlyFixture, mocker: MockerFixture, ca
 
     assert isinstance(parent, IteratorScenario)
 
+    parent.user._context.update({'test': 'was here'})
+
     task_factory = TestTask(RequestDirection.FROM, 'test://foo.bar', 'dummy-stuff')
 
     task = task_factory()
 
+    assert task_factory._context.get('test', None) is None
     parent.user._scenario.failure_exception = StopUser
 
     with pytest.raises(StopUser):
         task(parent)
 
+    assert task_factory._context.get('test', None) == 'was here'
+
     parent.user._scenario.failure_exception = RestartScenario
+    parent.user._context.update({'test': 'is here', 'foo': 'bar'})
+
+    assert task_factory._context.get('foo', None) is None
 
     with pytest.raises(RestartScenario):
         task(parent)
+
+    assert parent.user._context.get('test', None) == 'is here'
+    assert parent.user._context.get('foo', None) == 'bar'
 
     parent.user._scenario.failure_exception = None
 

--- a/tests/unit/test_grizzly/tasks/clients/test___init__.py
+++ b/tests/unit/test_grizzly/tasks/clients/test___init__.py
@@ -16,6 +16,8 @@ def test_task_failing(grizzly_fixture: GrizzlyFixture, mocker: MockerFixture, ca
 
     @client('test')
     class TestTask(ClientTask):
+        __scenario__ = grizzly_fixture.grizzly.scenario
+
         def get(self, parent: GrizzlyScenario) -> GrizzlyResponse:
             with self.action(parent):
                 raise RuntimeError('failed get')

--- a/tests/unit/test_grizzly/tasks/clients/test_blobstorage.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_blobstorage.py
@@ -18,6 +18,7 @@ from tests.fixtures import BehaveFixture, GrizzlyFixture
 
 class TestBlobStorageClientTask:
     def test___init__(self, grizzly_fixture: GrizzlyFixture) -> None:
+        BlobStorageClientTask.__scenario__ = grizzly_fixture.grizzly.scenario
         with pytest.raises(AttributeError) as ae:
             BlobStorageClientTask(
                 RequestDirection.TO,
@@ -122,6 +123,8 @@ class TestBlobStorageClientTask:
         grizzly = cast(GrizzlyContext, behave.grizzly)
         grizzly.state.variables['test'] = 'none'
 
+        BlobStorageClientTask.__scenario__ = grizzly.scenario
+
         task_factory = BlobStorageClientTask(
             RequestDirection.FROM,
             'bs://my-storage?AccountKey=aaaabbb=&Container=my-container',
@@ -151,6 +154,8 @@ class TestBlobStorageClientTask:
                 'storage.account_key': 'aaaa+bbb/64=',
                 'storage.container': 'my-container',
             })
+
+            BlobStorageClientTask.__scenario__ = grizzly.scenario
 
             with pytest.raises(ValueError) as ve:
                 BlobStorageClientTask(

--- a/tests/unit/test_grizzly/tasks/clients/test_http.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_http.py
@@ -46,6 +46,8 @@ class TestHttpClientTask:
         behave = grizzly_fixture.behave.context
         grizzly = cast(GrizzlyContext, behave.grizzly)
 
+        HttpClientTask.__scenario__ = grizzly.scenario
+
         with pytest.raises(AttributeError) as ae:
             HttpClientTask(RequestDirection.TO, 'http://example.org', payload_variable='test')
         assert 'HttpClientTask: variable argument is not applicable for direction TO' in str(ae.value)

--- a/tests/unit/test_grizzly/tasks/clients/test_messagequeue.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_messagequeue.py
@@ -71,6 +71,7 @@ class TestMessageQueueClientTask:
 
         zmq_context: Optional[zmq.Context] = None
         try:
+            MessageQueueClientTask.__scenario__ = grizzly_fixture.grizzly.scenario
             task_factory = MessageQueueClientTask(RequestDirection.FROM, 'mqs://localhost:1')
             zmq_context = task_factory._zmq_context
 
@@ -124,6 +125,7 @@ class TestMessageQueueClientTask:
 
         zmq_context: Optional[zmq.Context] = None
         try:
+            MessageQueueClientTask.__scenario__ = grizzly_fixture.grizzly.scenario
             task_factory = MessageQueueClientTask(RequestDirection.FROM, (
                 'mqs://mq_username:mq_password@mq.example.com:1415/queue:INCOMING.MESSAGES?QueueManager=QM01&Channel=IN.CHAN'
                 '&wait=133&heartbeat=432&KeyFile=/tmp/mq_keys&SslCipher=NUL&CertLabel=something'
@@ -283,6 +285,7 @@ class TestMessageQueueClientTask:
 
         zmq_context: Optional[zmq.Context] = None
         try:
+            MessageQueueClientTask.__scenario__ = grizzly_fixture.grizzly.scenario
             task_factory = MessageQueueClientTask(
                 RequestDirection.FROM,
                 'mqs://mq_username:mq_password@mq.example.io/topic:INCOMING.MSG?QueueManager=QM01&Channel=TCP.IN',
@@ -313,6 +316,7 @@ class TestMessageQueueClientTask:
 
         zmq_context: Optional[zmq.Context] = None
         try:
+            MessageQueueClientTask.__scenario__ = grizzly_fixture.grizzly.scenario
             task_factory = MessageQueueClientTask(
                 RequestDirection.FROM,
                 'mqs://mq_username:mq_password@mq.example.io/topic:INCOMING.MSG?QueueManager=QM01&Channel=TCP.IN',
@@ -443,6 +447,7 @@ class TestMessageQueueClientTask:
 
         zmq_context: Optional[zmq.Context] = None
         try:
+            MessageQueueClientTask.__scenario__ = grizzly_fixture.grizzly.scenario
             task_factory = MessageQueueClientTask(
                 RequestDirection.FROM,
                 'mqs://mq_username:mq_password@mq.example.io/topic:INCOMING.MSG?QueueManager=QM01&Channel=TCP.IN',
@@ -601,6 +606,8 @@ class TestMessageQueueClientTask:
 
         zmq_context: Optional[zmq.Context] = None
         try:
+            MessageQueueClientTask.__scenario__ = grizzly_fixture.grizzly.scenario
+
             with pytest.raises(ValueError) as ve:
                 task_factory = MessageQueueClientTask(
                     RequestDirection.TO,

--- a/tests/unit/test_grizzly/tasks/clients/test_servicebus.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_servicebus.py
@@ -18,6 +18,7 @@ class TestServiceBusClientTask:
     def test___init__(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
         context_mock = mocker.patch('grizzly.tasks.clients.servicebus.zmq.Context', autospec=True)
 
+        ServiceBusClientTask.__scenario__ = grizzly_fixture.grizzly.scenario
         task = ServiceBusClientTask(RequestDirection.FROM, 'sb://my-sbns.servicebus.windows.net/;SharedAccessKeyName=AccessKey;SharedAccessKey=37aabb777f454324=', 'test')
 
         assert task.endpoint == 'sb://my-sbns.servicebus.windows.net/;SharedAccessKeyName=AccessKey;SharedAccessKey=37aabb777f454324='
@@ -174,6 +175,7 @@ class TestServiceBusClientTask:
         context_mock.reset_mock()
 
     def test_text(self, grizzly_fixture: GrizzlyFixture) -> None:
+        ServiceBusClientTask.__scenario__ = grizzly_fixture.grizzly.scenario
         task = ServiceBusClientTask(RequestDirection.FROM, 'sb://my-sbns.servicebus.windows.net/;SharedAccessKeyName=AccessKey;SharedAccessKey=37aabb777f454324=', 'test')
 
         assert task.text is None
@@ -197,6 +199,7 @@ class TestServiceBusClientTask:
 
         grizzly_fixture.grizzly.state.configuration.update({'sbns.key.secret': 'fooBARfoo'})
 
+        ServiceBusClientTask.__scenario__ = grizzly_fixture.grizzly.scenario
         task = ServiceBusClientTask(
             RequestDirection.FROM,
             'sb://my-sbns.servicebus.windows.net/queue:my-queue;SharedAccessKeyName=AccessKey;SharedAccessKey=$conf::sbns.key.secret$',
@@ -229,6 +232,7 @@ class TestServiceBusClientTask:
 
         async_message_request_mock = mocker.patch('grizzly.utils.async_message_request')
 
+        ServiceBusClientTask.__scenario__ = grizzly_fixture.grizzly.scenario
         task = ServiceBusClientTask(
             RequestDirection.FROM,
             'sb://my-sbns.servicebus.windows.net/queue:my-queue;SharedAccessKeyName=AccessKey;SharedAccessKey=37aabb777f454324=',
@@ -265,6 +269,7 @@ class TestServiceBusClientTask:
 
         async_message_request_mock = mocker.patch('grizzly.utils.async_message_request', return_value={'message': 'foobar!'})
 
+        ServiceBusClientTask.__scenario__ = grizzly_fixture.grizzly.scenario
         task = ServiceBusClientTask(
             RequestDirection.FROM,
             'sb://my-sbns.servicebus.windows.net/topic:my-topic/subscription:"my-subscription-{{ id }}";SharedAccessKeyName=AccessKey;SharedAccessKey=37aabb777f454324=',

--- a/tests/unit/test_grizzly/tasks/test_async_group.py
+++ b/tests/unit/test_grizzly/tasks/test_async_group.py
@@ -113,11 +113,9 @@ class TestAsyncRequestGroup:
 
         assert spawn_mock.call_count == len(task_factory.tasks)
         args, _ = spawn_mock.call_args_list[0]
-        assert args[1] is parent
-        assert args[2] is task_factory.tasks[0]
+        assert args == (parent.user.request, task_factory.tasks[0],)
         args, _ = spawn_mock.call_args_list[1]
-        assert args[1] is parent
-        assert args[2] is task_factory.tasks[1]
+        assert args == (parent.user.request, task_factory.tasks[1],)
         assert settrace_mock.call_count == 0
 
         assert joinall_mock.call_count == 2

--- a/tests/unit/test_grizzly/tasks/test_loop.py
+++ b/tests/unit/test_grizzly/tasks/test_loop.py
@@ -113,30 +113,33 @@ class TestLoopTask:
 
         assert request_spy.call_count == 7  # loop task + 3 tasks * 2 values
 
-        for i, (_, kwargs) in enumerate(request_spy.call_args_list[:3]):
+        for i, (args, kwargs) in enumerate(request_spy.call_args_list[:3]):
+            assert args == ()
             assert kwargs.get('request_type', None) == 'TSTSK'
             assert kwargs.get('name', None) == f'TestTask: test:{{{{ foobar }}}}-test-{i}'
             assert kwargs.get('response_time', None) == 13
             assert kwargs.get('response_length', None) == 37
             assert kwargs.get('exception', '') is None
-            assert kwargs.get('context', None) == {'variables': {'foobar': 'hello'}}
+            assert kwargs.get('context', None) == {'variables': {'foobar': 'hello'}, 'log_all_requests': False}
 
-        for i, (_, kwargs) in enumerate(request_spy.call_args_list[3:-1]):
+        for i, (args, kwargs) in enumerate(request_spy.call_args_list[3:-1]):
+            assert args == ()
             assert kwargs.get('request_type', None) == 'TSTSK'
             assert kwargs.get('name', None) == f'TestTask: test:{{{{ foobar }}}}-test-{i}'
             assert kwargs.get('response_time', None) == 13
             assert kwargs.get('response_length', None) == 37
             assert kwargs.get('exception', '') is None
-            assert kwargs.get('context', None) == {'variables': {'foobar': 'world'}}
+            assert kwargs.get('context', None) == {'variables': {'foobar': 'world'}, 'log_all_requests': False}
 
-        _, kwargs = request_spy.call_args_list[-1]
+        args, kwargs = request_spy.call_args_list[-1]
 
+        assert args == ()
         assert kwargs.get('request_type', None) == 'LOOP'
         assert kwargs.get('name', None) == '003 test (3)'
         assert kwargs.get('response_time', None) >= 0
         assert kwargs.get('response_length', None) == 2
         assert kwargs.get('exception', '') is None
-        assert kwargs.get('context', None) == {'variables': {'foobar': 'none'}}
+        assert kwargs.get('context', None) == {'variables': {'foobar': 'none'}, 'log_all_requests': False}
 
         request_spy.reset_mock()
 
@@ -148,30 +151,33 @@ class TestLoopTask:
 
         assert request_spy.call_count == 7  # loop task + 3 tasks * 2 values
 
-        for i, (_, kwargs) in enumerate(request_spy.call_args_list[:3]):
+        for i, (args, kwargs) in enumerate(request_spy.call_args_list[:3]):
+            assert args == ()
             assert kwargs.get('request_type', None) == 'TSTSK'
             assert kwargs.get('name', None) == f'TestTask: test:{{{{ foobar }}}}-test-{i}'
             assert kwargs.get('response_time', None) == 13
             assert kwargs.get('response_length', None) == 37
             assert kwargs.get('exception', '') is None
-            assert kwargs.get('context', None) == {'variables': {'foobar': 'foo', 'json_input': '["foo", "bar"]'}}
+            assert kwargs.get('context', None) == {'variables': {'foobar': 'foo', 'json_input': '["foo", "bar"]'}, 'log_all_requests': False}
 
-        for i, (_, kwargs) in enumerate(request_spy.call_args_list[3:-1]):
+        for i, (args, kwargs) in enumerate(request_spy.call_args_list[3:-1]):
+            assert args == ()
             assert kwargs.get('request_type', None) == 'TSTSK'
             assert kwargs.get('name', None) == f'TestTask: test:{{{{ foobar }}}}-test-{i}'
             assert kwargs.get('response_time', None) == 13
             assert kwargs.get('response_length', None) == 37
             assert kwargs.get('exception', '') is None
-            assert kwargs.get('context', None) == {'variables': {'foobar': 'bar', 'json_input': '["foo", "bar"]'}}
+            assert kwargs.get('context', None) == {'variables': {'foobar': 'bar', 'json_input': '["foo", "bar"]'}, 'log_all_requests': False}
 
-        _, kwargs = request_spy.call_args_list[-1]
+        args, kwargs = request_spy.call_args_list[-1]
 
+        assert args == ()
         assert kwargs.get('request_type', None) == 'LOOP'
         assert kwargs.get('name', None) == '003 test (3)'
         assert kwargs.get('response_time', None) >= 0
         assert kwargs.get('response_length', None) == 2
         assert kwargs.get('exception', '') is None
-        assert kwargs.get('context', None) == {'variables': {'foobar': 'none', 'json_input': '["foo", "bar"]'}}
+        assert kwargs.get('context', None) == {'variables': {'foobar': 'none', 'json_input': '["foo", "bar"]'}, 'log_all_requests': False}
 
         request_spy.reset_mock()
         del grizzly.state.variables['json_input']
@@ -187,12 +193,13 @@ class TestLoopTask:
             task(parent)
 
         assert request_spy.call_count == 1
-        _, kwargs = request_spy.call_args_list[-1]
+        args, kwargs = request_spy.call_args_list[-1]
+        assert args == ()
         assert kwargs.get('request_type', None) == 'LOOP'
         assert kwargs.get('name', None) == '003 test (3)'
         assert kwargs.get('response_time', None) >= 0
         assert kwargs.get('response_length', None) == 0
-        assert kwargs.get('context', None) == {'variables': {'foobar': 'none'}}
+        assert kwargs.get('context', None) == {'variables': {'foobar': 'none'}, 'log_all_requests': False}
         exception = kwargs.get('exception', None)
         assert isinstance(exception, JSONDecodeError)
         assert str(exception).startswith('Unterminated string starting at:')
@@ -208,12 +215,13 @@ class TestLoopTask:
             task(parent)
 
         assert request_spy.call_count == 1
-        _, kwargs = request_spy.call_args_list[-1]
+        args, kwargs = request_spy.call_args_list[-1]
+        assert args == ()
         assert kwargs.get('request_type', None) == 'LOOP'
         assert kwargs.get('name', None) == '003 test (3)'
         assert kwargs.get('response_time', None) >= 0
         assert kwargs.get('response_length', None) == 0
-        assert kwargs.get('context', None) == {'variables': {'foobar': 'none'}}
+        assert kwargs.get('context', None) == {'variables': {'foobar': 'none'}, 'log_all_requests': False}
         exception = kwargs.get('exception', None)
         assert str(exception) == '"{"hello": "world"}" is not a list'
 
@@ -233,13 +241,14 @@ class TestLoopTask:
 
         assert request_spy.call_count == 4
 
-        _, kwargs = request_spy.call_args_list[-1]
+        args, kwargs = request_spy.call_args_list[-1]
 
+        assert args == ()
         assert kwargs.get('request_type', None) == 'LOOP'
         assert kwargs.get('name', None) == '003 test (2)'
         assert kwargs.get('response_time', None) >= 0
         assert kwargs.get('response_length', None) == 2
-        assert kwargs.get('context', None) == {'variables': {'foobar': 'world'}}
+        assert kwargs.get('context', None) == {'variables': {'foobar': 'world'}, 'log_all_requests': False}
         exception = kwargs.get('exception', '')
         assert isinstance(exception, ValueError)
         assert str(exception) == 'error'

--- a/tests/unit/test_grizzly/tasks/test_request.py
+++ b/tests/unit/test_grizzly/tasks/test_request.py
@@ -94,9 +94,7 @@ class TestRequestTask:
 
         assert request_spy.call_count == 1
         args, kwargs = request_spy.call_args_list[0]
-        assert args[0] is parent
-        assert args[1] is task_factory
-        assert len(args) == 2
+        assert args == (task_factory,)
         assert kwargs == {}
 
         # automagically create template if not set

--- a/tests/unit/test_grizzly/tasks/test_until.py
+++ b/tests/unit/test_grizzly/tasks/test_until.py
@@ -158,7 +158,7 @@ class TestUntilRequestTask:
         assert kwargs.get('name', None) == f'{parent.user._scenario.identifier} test-request, w=100.0s, r=10, em=1'
         assert kwargs.get('response_time', None) == 153500
         assert kwargs.get('response_length', None) == 103
-        assert kwargs.get('context', None) == {'variables': {}}
+        assert kwargs.get('context', None) == {'variables': {}, 'log_all_requests': False}
         assert kwargs.get('exception', '') is None
 
         # -->
@@ -187,7 +187,7 @@ class TestUntilRequestTask:
         assert kwargs.get('name', None) == f'{parent.user._scenario.identifier} test-request, w=100.0s, r=10, em=1'
         assert kwargs.get('response_time', None) == 12250
         assert kwargs.get('response_length', None) == 33
-        assert kwargs.get('context', None) == {'variables': {}}
+        assert kwargs.get('context', None) == {'variables': {}, 'log_all_requests': False}
         assert kwargs.get('exception', '') is None
         # <--
 
@@ -215,7 +215,7 @@ class TestUntilRequestTask:
         assert kwargs.get('name', None) == f'{parent.user._scenario.identifier} test-request, w=10.0s, r=2, em=1'
         assert kwargs.get('response_time', None) == 12250
         assert kwargs.get('response_length', None) == 70
-        assert kwargs.get('context', None) == {'variables': {}}
+        assert kwargs.get('context', None) == {'variables': {}, 'log_all_requests': False}
         exception = kwargs.get('exception', None)
         assert exception is not None
         assert isinstance(exception, RuntimeError)
@@ -251,7 +251,7 @@ class TestUntilRequestTask:
         assert kwargs.get('name', None) == f'{parent.user._scenario.identifier} test-request, w=10.0s, r=2, em=1'
         assert kwargs.get('response_time', None) == 1500
         assert kwargs.get('response_length', None) == 35
-        assert kwargs.get('context', None) == {'variables': {}}
+        assert kwargs.get('context', None) == {'variables': {}, 'log_all_requests': False}
         exception = kwargs.get('exception', None)
         assert exception is not None
         assert isinstance(exception, RuntimeError)
@@ -295,7 +295,7 @@ class TestUntilRequestTask:
         assert kwargs.get('name', None) == f'{parent.user._scenario.identifier} test-request, w=4.0s, r=4, em=1'
         assert kwargs.get('response_time', None) == 800
         assert kwargs.get('response_length', None) == 103
-        assert kwargs.get('context', None) == {'variables': {}}
+        assert kwargs.get('context', None) == {'variables': {}, 'log_all_requests': False}
         assert kwargs.get('exception', '') is None
 
         return_value_object = {
@@ -344,7 +344,7 @@ class TestUntilRequestTask:
         assert kwargs.get('name', None) == f'{parent.user._scenario.identifier} test-request, w=4.0s, r=4, em=3'
         assert kwargs.get('response_time', None) == 800
         assert kwargs.get('response_length', None) == 213
-        assert kwargs.get('context', None) == {'variables': {}}
+        assert kwargs.get('context', None) == {'variables': {}, 'log_all_requests': False}
         assert kwargs.get('exception', '') is None
 
         task_factory = UntilRequestTask(grizzly, meta_request_task, '$.list[?(@.count > 19)] | wait=4, expected_matches=4, retries=4')
@@ -372,7 +372,7 @@ class TestUntilRequestTask:
         assert kwargs.get('name', None) == f'{parent.user._scenario.identifier} test-request, w=4.0s, r=4, em=4'
         assert kwargs.get('response_time', None) == 555
         assert kwargs.get('response_length', None) == 852
-        assert kwargs.get('context', None) == {'variables': {}}
+        assert kwargs.get('context', None) == {'variables': {}, 'log_all_requests': False}
         exception = kwargs.get('exception', None)
         assert isinstance(exception, RuntimeError)
         assert str(exception) == 'found 3 matching values for $.list[?(@.count > 19)] in payload'
@@ -392,7 +392,7 @@ class TestUntilRequestTask:
         assert kwargs.get('name', None) == f'{parent.user._scenario.identifier} test-request, w=4.0s, r=4, em=2'
         assert kwargs.get('response_time', None) == 666
         assert kwargs.get('response_length', None) == 213
-        assert kwargs.get('context', None) == {'variables': {}}
+        assert kwargs.get('context', None) == {'variables': {}, 'log_all_requests': False}
         assert kwargs.get('exception', '') is None
 
         task_factory = UntilRequestTask(grizzly, meta_request_task, '$.list[?(@.count == 18)] | wait=4, expected_matches=1, retries=1')
@@ -409,7 +409,7 @@ class TestUntilRequestTask:
         assert kwargs.get('name', None) == f'{parent.user._scenario.identifier} test-request, w=4.0s, r=1, em=1'
         assert kwargs.get('response_time', None) == 666
         assert kwargs.get('response_length', None) == 0
-        assert kwargs.get('context', None) == {'variables': {}}
+        assert kwargs.get('context', None) == {'variables': {}, 'log_all_requests': False}
         assert isinstance(kwargs.get('exception', ''), TransformerError)
 
         mocker.patch.object(parent.logger, 'error', side_effect=[RuntimeError, None])
@@ -424,7 +424,7 @@ class TestUntilRequestTask:
         assert kwargs.get('name', None) == f'{parent.user._scenario.identifier} test-request, w=4.0s, r=1, em=1'
         assert kwargs.get('response_time', None) == 111
         assert kwargs.get('response_length', None) == 0
-        assert kwargs.get('context', None) == {'variables': {}}
+        assert kwargs.get('context', None) == {'variables': {}, 'log_all_requests': False}
         assert isinstance(kwargs.get('exception', ''), RuntimeError)
 
     @pytest.mark.parametrize(*parameterize)

--- a/tests/unit/test_grizzly/tasks/test_until.py
+++ b/tests/unit/test_grizzly/tasks/test_until.py
@@ -72,9 +72,12 @@ class TestUntilRequestTask:
     ) -> None:
         parent = grizzly_fixture()
 
-        meta_request_task = meta_request_task_type(*meta_args, **meta_kwargs)
-
         grizzly = grizzly_fixture.grizzly
+
+        if meta_request_task_type == HttpClientTask:
+            meta_request_task_type.__scenario__ = grizzly.scenario  # type: ignore
+
+        meta_request_task = meta_request_task_type(*meta_args, **meta_kwargs)
 
         def create_response(status: str) -> str:
             return jsondumps({
@@ -438,11 +441,14 @@ class TestUntilRequestTask:
     ) -> None:
         parent = grizzly_fixture()
 
+        grizzly = grizzly_fixture.grizzly
+
+        if meta_request_task_type == HttpClientTask:
+            meta_request_task_type.__scenario__ = grizzly.scenario  # type: ignore
+
         meta_request_task = meta_request_task_type(*meta_args, **meta_kwargs)
 
         on_start_spy = mocker.spy(meta_request_task, 'on_start')
-
-        grizzly = grizzly_fixture.grizzly
 
         task_factory = UntilRequestTask(grizzly, meta_request_task, "$.`this`[?status='ready'] | wait=100, retries=10")
         task = task_factory()
@@ -462,11 +468,14 @@ class TestUntilRequestTask:
     ) -> None:
         parent = grizzly_fixture()
 
+        grizzly = grizzly_fixture.grizzly
+
+        if meta_request_task_type == HttpClientTask:
+            meta_request_task_type.__scenario__ = grizzly.scenario  # type: ignore
+
         meta_request_task = meta_request_task_type(*meta_args, **meta_kwargs)
 
         on_stop_spy = mocker.spy(meta_request_task, 'on_stop')
-
-        grizzly = grizzly_fixture.grizzly
 
         task_factory = UntilRequestTask(grizzly, meta_request_task, "$.`this`[?status='ready'] | wait=100, retries=10")
         task = task_factory()

--- a/tests/unit/test_grizzly/test_locust.py
+++ b/tests/unit/test_grizzly/test_locust.py
@@ -233,6 +233,7 @@ def test_setup_locust_scenarios(behave_fixture: BehaveFixture, noop_zmq: NoopZmq
 
         grizzly.scenario.user.class_name = 'RestApiUser'
         grizzly.scenario.context['host'] = 'https://api.example.io'
+        MessageQueueClientTask.__scenario__ = grizzly.scenario
         grizzly.scenario.tasks.add(MessageQueueClientTask(RequestDirection.FROM, 'mqs://username:password@mq.example.io/queue:INCOMING?QueueManager=QM01&Channel=TCP.IN'))
         user_classes, start_messagequeue_daemon = setup_locust_scenarios(grizzly)
 

--- a/tests/unit/test_grizzly/users/base/test_grizzly_user.py
+++ b/tests/unit/test_grizzly/users/base/test_grizzly_user.py
@@ -4,6 +4,7 @@ import logging
 from typing import cast
 from os import environ, path
 from json import loads as jsonloads
+from unittest.mock import ANY
 
 import pytest
 
@@ -18,7 +19,6 @@ from grizzly.types.locust import StopUser
 from grizzly.context import GrizzlyContextScenario, GrizzlyContext
 from grizzly.tasks import RequestTask
 from grizzly.testdata.utils import templatingfilter
-from grizzly.scenarios import GrizzlyScenario
 
 from tests.fixtures import BehaveFixture, GrizzlyFixture
 
@@ -29,7 +29,7 @@ logging.getLogger().setLevel(logging.CRITICAL)
 class DummyGrizzlyUser(GrizzlyUser):
     host: str = 'http://example.com'
 
-    def request(self, parent: GrizzlyScenario, request: RequestTask) -> GrizzlyResponse:
+    def request_impl(self, request: RequestTask) -> GrizzlyResponse:
         raise NotImplementedError(f'{self.__class__.__name__} has not implemented request')
 
 
@@ -52,37 +52,64 @@ class TestGrizzlyUser:
         try:
             DummyGrizzlyUser.__scenario__ = grizzly.scenario
             user = DummyGrizzlyUser(behave_fixture.locust.environment)
-            request = RequestTask(RequestMethod.POST, name='test', endpoint='/api/test')
-
-            request.source = 'hello {{ name | uppercase }}'
+            template = RequestTask(RequestMethod.POST, name='test', endpoint='/api/test')
+            template.source = 'hello {{ name | uppercase }}'
 
             user.add_context({'variables': {'name': 'bob'}})
-
-            assert user.render(request) == ('test', '/api/test', 'hello BOB', None, None)
+            request = user.render(template)
+            assert request.name == '001 test'
+            assert request.endpoint == '/api/test'
+            assert request.source == 'hello BOB'
+            assert request.arguments is None
+            assert request.metadata is None
 
             user.set_context_variable('name', 'alice')
+            request = user.render(template)
+            assert request.name == '001 test'
+            assert request.endpoint == '/api/test'
+            assert request.source == 'hello ALICE'
+            assert request.arguments is None
+            assert request.metadata is None
 
-            assert user.render(request) == ('test', '/api/test', 'hello ALICE', None, None)
-
-            request.endpoint = '/api/test?data={{ querystring | uppercase }}'
+            template.endpoint = '/api/test?data={{ querystring | uppercase }}'
             user.set_context_variable('querystring', 'querystring_data')
-            assert user.render(request) == ('test', '/api/test?data=QUERYSTRING_DATA', 'hello ALICE', None, None)
+            request = user.render(template)
+            assert request.name == '001 test'
+            assert request.endpoint == '/api/test?data=QUERYSTRING_DATA'
+            assert request.source == 'hello ALICE'
+            assert request.arguments is None
+            assert request.metadata is None
 
-            request.source = None
-            assert user.render(request) == ('test', '/api/test?data=QUERYSTRING_DATA', None, None, None)
+            template.source = None
+            request = user.render(template)
+            assert request.name == '001 test'
+            assert request.endpoint == '/api/test?data=QUERYSTRING_DATA'
+            assert request.source is None
+            assert request.arguments is None
+            assert request.metadata is None
 
-            request.name = '{{ name | uppercase }}'
-            assert user.render(request) == ('ALICE', '/api/test?data=QUERYSTRING_DATA', None, None, None)
+            template.name = '{{ name | uppercase }}'
+            request = user.render(template)
+            assert request.name == '001 ALICE'
+            assert request.endpoint == '/api/test?data=QUERYSTRING_DATA'
+            assert request.source is None
+            assert request.arguments is None
+            assert request.metadata is None
 
-            request.name = '{{ name'
+            template.name = '{{ name'
             with pytest.raises(StopUser):
-                user.render(request)
+                user.render(template)
 
             test_file.write_text('this is a test {{ name }}')
-            request.name = '{{ name }}'
-            request.source = '{{ blobfile }}'
+            template.name = '{{ name }}'
+            template.source = '{{ blobfile }}'
             user.set_context_variable('blobfile', str(test_file))
-            assert user.render(request) == ('alice', '/api/test?data=QUERYSTRING_DATA', 'this is a test alice', None, None)
+            request = user.render(template)
+            assert request.name == '001 alice'
+            assert request.endpoint == '/api/test?data=QUERYSTRING_DATA'
+            assert request.source == 'this is a test alice'
+            assert request.arguments is None
+            assert request.metadata is None
 
             user_type = type(
                 'ContextVariablesUserFileRequest',
@@ -95,17 +122,21 @@ class TestGrizzlyUser:
             user = user_type(behave_fixture.locust.environment)
             assert issubclass(user.__class__, (FileRequests,))
 
-            request.source = f'{str(test_file)}'
-            request.endpoint = '/tmp'
-            _, endpoint, _, _, _ = user.render(request)
-            assert endpoint == '/tmp/blobfile.txt'
+            template.source = f'{str(test_file)}'
+            template.endpoint = '/tmp'
+            request = user.render(template)
+            assert request.endpoint == '/tmp/blobfile.txt'
 
-            request = RequestTask(RequestMethod.POST, name='test', endpoint='/api/test | my_argument="{{ argument_variable | uppercase }}"')
+            template = RequestTask(RequestMethod.POST, name='test', endpoint='/api/test | my_argument="{{ argument_variable | uppercase }}"')
             user.set_context_variable('argument_variable', 'argument variable value')
             user.set_context_variable('name', 'donovan')
-            request.source = 'hello {{ name }}'
-            assert user.render(request) == ('test', '/api/test', 'hello donovan', {'my_argument': 'ARGUMENT VARIABLE VALUE'}, None)
-
+            template.source = 'hello {{ name }}'
+            request = user.render(template)
+            assert request.name == '001 test'
+            assert request.endpoint == '/api/test'
+            assert request.source == 'hello donovan'
+            assert request.arguments == {'my_argument': 'ARGUMENT VARIABLE VALUE'}
+            assert request.metadata is None
         finally:
             del FILTERS['uppercase']
             shutil.rmtree(test_file_context)
@@ -143,9 +174,9 @@ class TestGrizzlyUser:
             grizzly._scenarios.append(GrizzlyContextScenario(999, behave=behave_fixture.create_scenario('test')))
             DummyGrizzlyUser.__scenario__ = grizzly.scenario
             user = DummyGrizzlyUser(behave_fixture.locust.environment)
-            request = RequestTask(RequestMethod.POST, name='{{ name }}', endpoint='/api/test/{{ value }}')
+            template = RequestTask(RequestMethod.POST, name='{{ name }}', endpoint='/api/test/{{ value }}')
 
-            request.source = '{{ file_path }}'
+            template.source = '{{ file_path }}'
 
             user.add_context({
                 'variables': {
@@ -156,15 +187,15 @@ class TestGrizzlyUser:
                 }
             })
 
-            name, endpoint, payload, arguments, metadata = user.render(request)
+            request = user.render(template)
 
-            assert name == 'test-name'
-            assert endpoint == '/api/test/test-value'
-            assert payload is not None
-            assert arguments is None
-            assert metadata is None
+            assert request.name == '999 test-name'
+            assert request.endpoint == '/api/test/test-value'
+            assert request.source is not None
+            assert request.arguments is None
+            assert request.metadata is None
 
-            data = jsonloads(payload)
+            data = jsonloads(request.source)
             assert data['MeasureResult']['ID'] == user.context_variables['messageID']
             assert data['MeasureResult']['name'] == user.context_variables['name']
             assert data['MeasureResult']['value'] == user.context_variables['value']
@@ -172,15 +203,27 @@ class TestGrizzlyUser:
             shutil.rmtree(test_file_context)
             del environ['GRIZZLY_CONTEXT_ROOT']
 
-    def test_request(self, grizzly_fixture: GrizzlyFixture) -> None:
-        parent = grizzly_fixture()
-        grizzly = grizzly_fixture.grizzly
-        DummyGrizzlyUser.__scenario__ = grizzly.scenario
-        user = DummyGrizzlyUser(grizzly_fixture.behave.locust.environment)
+    def test_request(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
+        parent = grizzly_fixture(user_type=DummyGrizzlyUser)
         payload = RequestTask(RequestMethod.GET, name='test', endpoint='/api/test')
 
-        with pytest.raises(NotImplementedError):
-            user.request(parent, payload)
+        request_spy = mocker.spy(parent.user.environment.events.request, 'fire')
+
+        with pytest.raises(StopUser):
+            parent.user.request(payload)
+
+        request_spy.assert_called_once_with(
+            request_type='GET',
+            name='001 test',
+            response_time=ANY,
+            response_length=0,
+            context={'variables': {}, 'log_all_requests': False},
+            exception=ANY,
+        )
+        _, kwargs = request_spy.call_args_list[-1]
+        exception = kwargs.get('exception', None)
+        assert isinstance(exception, NotImplementedError)
+        assert str(exception) == 'DummyGrizzlyUser has not implemented request'
 
     def test_context(self, behave_fixture: BehaveFixture) -> None:
         behave_fixture.grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
@@ -190,32 +233,30 @@ class TestGrizzlyUser:
         context = user.context()
 
         assert isinstance(context, dict)
-        assert context == {'variables': {}}
+        assert context == {'variables': {}, 'log_all_requests': False}
 
         user.set_context_variable('test', 'value')
         assert user.context_variables == {'test': 'value'}
 
-    def test_stop(self, behave_fixture: BehaveFixture, caplog: LogCaptureFixture, mocker: MockerFixture) -> None:
-        behave_fixture.grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
-        DummyGrizzlyUser.__scenario__ = behave_fixture.grizzly.scenario
-        user = DummyGrizzlyUser(behave_fixture.locust.environment)
+    def test_stop(self, grizzly_fixture: GrizzlyFixture, caplog: LogCaptureFixture, mocker: MockerFixture) -> None:
+        parent = grizzly_fixture(user_type=DummyGrizzlyUser)
 
-        mocker.patch('grizzly.users.base.grizzly_user.User.stop', return_value=True)
+        mocker.patch('locust.user.users.User.stop', return_value=True)
 
         with caplog.at_level(logging.DEBUG):
-            assert user._state is None
-            assert user._scenario_state is None
+            assert parent.user._state is None
+            assert getattr(parent.user, '_scenario_state', None) == ScenarioState.STOPPED
 
-            assert user.stop(force=True)
+            assert parent.user.stop(force=True)
 
             assert len(caplog.messages) == 0
-            assert user._state is None
-            assert user._scenario_state is None
+            assert parent.user._state is None
+            assert getattr(parent.user, '_scenario_state', None) == ScenarioState.STOPPED
 
-            assert not user.stop(force=False)
+            assert not parent.user.stop(force=False)
 
             assert len(caplog.messages) == 2
             assert caplog.messages[0] == 'stop scenarios before stopping user'
-            assert caplog.messages[1] == 'scenario state=None -> ScenarioState.STOPPING'
-            assert user._state == 'running'
-            assert user._scenario_state == ScenarioState.STOPPING
+            assert caplog.messages[1] == 'scenario state=ScenarioState.STOPPED -> ScenarioState.STOPPING'
+            assert parent.user._state == 'running'
+            assert parent.user._scenario_state == ScenarioState.STOPPING

--- a/tests/unit/test_grizzly/users/test_dummy.py
+++ b/tests/unit/test_grizzly/users/test_dummy.py
@@ -15,12 +15,11 @@ class TestDummyUser:
         assert isinstance(DummyUser(environment), GrizzlyUser)
 
     def test_request(self, grizzly_fixture: GrizzlyFixture) -> None:
-        parent = grizzly_fixture()
         DummyUser.__scenario__ = grizzly_fixture.grizzly.scenario
         DummyUser.host = '/dev/null'
         user = DummyUser(grizzly_fixture.behave.locust.environment)
 
         for method in RequestMethod:
-            assert user.request(parent, RequestTask(method, 'dummy', '/api/what/ever')) == (None, None,)
+            assert user.request(RequestTask(method, 'dummy', '/api/what/ever')) == (None, None,)
 
         assert user._scenario is not DummyUser.__scenario__

--- a/tests/unit/test_grizzly/users/test_restapi.py
+++ b/tests/unit/test_grizzly/users/test_restapi.py
@@ -1,8 +1,11 @@
-from typing import cast, Dict, Any, Tuple, Callable, Type
+import json
+
+from typing import cast, Dict, Any, Callable
 from time import time
+from unittest.mock import ANY
 
 from locust.clients import ResponseContextManager
-from locust.contrib.fasthttp import FastHttpSession, ResponseContextManager as FastResponseContextManager, insecure_ssl_context_factory
+from locust.contrib.fasthttp import FastHttpSession, insecure_ssl_context_factory
 
 import pytest
 import gevent
@@ -12,18 +15,16 @@ from requests.models import Response
 
 from grizzly.users.restapi import RestApiUser
 from grizzly.users.base import AsyncRequests, RequestLogger, ResponseHandler, GrizzlyUser
-from grizzly.types import GrizzlyResponse, RequestMethod, GrizzlyResponseContextManager
+from grizzly.types import GrizzlyResponse, RequestMethod
 from grizzly.types.locust import StopUser
 from grizzly.context import GrizzlyContext
 from grizzly.tasks import RequestTask
 from grizzly.testdata.utils import transform
-from grizzly.exceptions import RestartScenario
 from grizzly.auth import GrizzlyAuthHttpContext
-from grizzly.scenarios import GrizzlyScenario
 from grizzly_extras.transformer import TransformerContentType
 
-from tests.fixtures import ResponseContextManagerFixture, MockerFixture, GrizzlyFixture
-from tests.helpers import RequestEvent, ResultSuccess
+from tests.fixtures import MockerFixture, GrizzlyFixture
+from tests.helpers import RequestEvent
 
 
 class TestRestApiUser:
@@ -113,7 +114,7 @@ class TestRestApiUser:
 
             # user.get_oauth_authorization()
             request = RequestTask(RequestMethod.GET, name='test', endpoint='/api/test')
-            headers, body = parent.user.request(parent, request)
+            headers, body = parent.user.request(request)
             parent.logger.info(headers)
             parent.logger.info(body)
             parent.logger.info(fire.call_args_list)
@@ -126,6 +127,9 @@ class TestRestApiUser:
         response = Response()
         response._content = ''.encode('utf-8')
         response_context_manager = ResponseContextManager(response, RequestEvent(), {})
+
+        response.status_code = 400
+        assert parent.user.get_error_message(response_context_manager) == 'bad request'
 
         response.status_code = 401
         assert parent.user.get_error_message(response_context_manager) == 'unauthorized'
@@ -165,84 +169,79 @@ class TestRestApiUser:
 
         assert parent.user._context.get('verify_certificates', None)
 
-        parent.user.async_request(parent, request)
+        parent.user.async_request_impl(request)
 
         assert request_spy.call_count == 1
-        args, _ = request_spy.call_args_list[-1]
-        assert len(args) == 3
-        assert args[0] is parent
-        assert args[1] is request
-        assert isinstance(args[2], FastHttpSession)
-        assert args[2].environment is parent.user.environment
-        assert args[2].base_url == parent.user.host
-        assert args[2].user is parent.user
-        assert args[2].client.max_retries == 1
-        assert args[2].client.clientpool.client_args.get('connection_timeout', None) == 60.0
-        assert args[2].client.clientpool.client_args.get('network_timeout', None) == 60.0
-        assert args[2].client.clientpool.client_args.get('ssl_context_factory', None) is gevent.ssl.create_default_context  # pylint: disable=no-member
+        args, kwargs = request_spy.call_args_list[-1]
+        assert kwargs == {}
+        assert len(args) == 2
+        assert args[0] is request
+        assert isinstance(args[1], FastHttpSession)
+        assert args[1].environment is parent.user.environment
+        assert args[1].base_url == parent.user.host
+        assert args[1].user is parent.user
+        assert args[1].client.max_retries == 1
+        assert args[1].client.clientpool.client_args.get('connection_timeout', None) == 60.0
+        assert args[1].client.clientpool.client_args.get('network_timeout', None) == 60.0
+        assert args[1].client.clientpool.client_args.get('ssl_context_factory', None) is gevent.ssl.create_default_context  # pylint: disable=no-member
 
         parent.user._context['verify_certificates'] = False
 
-        parent.user.async_request(parent, request)
+        parent.user.async_request_impl(request)
 
         assert request_spy.call_count == 2
-        args, _ = request_spy.call_args_list[-1]
-        assert args[2].client.clientpool.client_args.get('ssl_context_factory', None) is insecure_ssl_context_factory
+        args, kwargs = request_spy.call_args_list[-1]
+        assert kwargs == {}
+        assert args[1].client.clientpool.client_args.get('ssl_context_factory', None) is insecure_ssl_context_factory
 
-    def test_request(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
+    def test_request_impl(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
         parent = grizzly_fixture(user_type=RestApiUser)
         assert isinstance(parent.user, RestApiUser)
 
         request = cast(RequestTask, parent.user._scenario.tasks()[-1])
+        request.source = 'hello'
 
         request_spy = mocker.patch.object(parent.user, '_request')
 
         assert parent.user._context.get('verify_certificates', None)
 
-        parent.user.request(parent, request)
+        parent.user.request_impl(request)
 
         assert request_spy.call_count == 1
         args, _ = request_spy.call_args_list[-1]
-        assert len(args) == 3
-        assert args[0] is parent
-        assert args[1] is request
-        assert args[2] is parent.user.client
+        assert len(args) == 2
+        assert args[0] is request
+        assert args[1] is parent.user.client
 
-        parent.user.request(parent, request)
+        parent.user.request(request)
 
-    @pytest.mark.parametrize('request_func', [RestApiUser.request, RestApiUser.async_request])
+    @pytest.mark.parametrize('request_func', [RestApiUser.request_impl, RestApiUser.async_request_impl])
     def test__request(
         self,
         grizzly_fixture: GrizzlyFixture,
         mocker: MockerFixture,
-        request_func: Callable[[RestApiUser, GrizzlyScenario, RequestTask], GrizzlyResponse],
-        response_context_manager_fixture: ResponseContextManagerFixture,
+        request_func: Callable[[RestApiUser, RequestTask], GrizzlyResponse],
     ) -> None:
         parent = grizzly_fixture(user_type=RestApiUser)
         assert isinstance(parent.user, RestApiUser)
 
-        class ClientRequestMock:
-            def __init__(self, status_code: int, user: GrizzlyUser, request_func: Callable[[RestApiUser, GrizzlyScenario, RequestTask], GrizzlyResponse]) -> None:
-                self.status_code = status_code
-                self.user = user
-                self.spy = mocker.spy(self, 'request')
+        assert parent.user.__class__.__name__ == 'RestApiUser'
 
-                if request_func is RestApiUser.request:
-                    namespace = 'grizzly.clients.ResponseEventSession.request'
-                else:
-                    namespace = 'grizzly.users.restapi.FastHttpSession.request'
+        is_async_request = request_func is RestApiUser.async_request_impl
 
-                mocker.patch(namespace, self.request)
+        request_event_spy = mocker.patch.object(parent.user.environment.events.request, 'fire')
+        response_magic = mocker.MagicMock()
 
-            def request(self, *args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> GrizzlyResponseContextManager:
-                cls_rcm = cast(Type[GrizzlyResponseContextManager], ResponseContextManager if request_func is RestApiUser.request else FastResponseContextManager)
-                return response_context_manager_fixture(cls_rcm, self.status_code, self.user.environment, response_body={}, **kwargs)  # type: ignore
+        if is_async_request:
+            request_spy = mocker.patch('locust.contrib.fasthttp.FastHttpSession.request', return_value=response_magic)
+        else:
+            request_spy = mocker.patch.object(parent.user.client, 'request', return_value=response_magic)
+
+        response_spy = response_magic.__enter__.return_value
+        response_spy.request_meta = {}
 
         request = cast(RequestTask, parent.user._scenario.tasks()[-1])
-
-        # missing template variables
-        with pytest.raises(StopUser):
-            request_func(parent.user, parent, request)
+        request.async_request = is_async_request
 
         remote_variables = {
             'variables': transform(GrizzlyContext(), {
@@ -253,160 +252,213 @@ class TestRestApiUser:
         }
 
         parent.user.add_context(remote_variables)
+        parent.user.host = 'http://test'
 
-        request_mock = ClientRequestMock(status_code=400, user=parent.user, request_func=request_func)
+        # incorrect method
+        request.method = RequestMethod.SEND
+
+        with pytest.raises(StopUser):
+            parent.user.request(request)
+
+        request_spy.assert_not_called()
+        request_event_spy.assert_called_once_with(
+            request_type='SEND',
+            name='001 TestScenario',
+            response_time=ANY,
+            response_length=0,
+            context=parent.user._context,
+            exception=ANY,
+        )
+
+        _, kwargs = request_event_spy.call_args_list[-1]
+        exception = kwargs.get('exception', None)
+        assert isinstance(exception, NotImplementedError)
+        assert str(exception) == 'SEND is not implemented for RestApiUser'
+
+        request_event_spy.reset_mock()
+
+        # request GET, 200
+        response_spy._manual_result = None
+        response_spy.status_code = 200
+        response_spy.text = '{"foo": "bar"}'
+        response_spy.headers = {'x-bar': 'foo'}
+        request.method = RequestMethod.GET
+
+        assert parent.user.request(request) == ({'x-bar': 'foo'}, '{"foo": "bar"}')
+
+        expected_parameters: Dict[str, Any] = {
+            'headers': parent.user.headers,
+        }
+
+        if not is_async_request:
+            expected_parameters.update({
+                'request': ANY,
+                'verify': parent.user._context.get('verify_certificates', True),
+            })
+
+        request_spy.assert_called_once_with(
+            method='GET',
+            name='001 TestScenario',
+            url='http://test/api/test',
+            catch_response=True,
+            cookies=parent.user.cookies,
+            **expected_parameters,
+        )
+
+        response_spy.success.assert_called_once_with()
+
+        response_spy.reset_mock()
+        request_spy.reset_mock()
+
+        # request GET, 400, StopUser, request.metadata populated
+        response_spy._manual_result = None
+        response_spy.status_code = 400
+        response_spy.text = ''
+        request.metadata = {'x-foo': 'bar'}
+        expected_parameters['headers'].update({'x-foo': 'bar'})
 
         parent.user._scenario.failure_exception = StopUser
 
-        # status_code != 200, stop_on_failure = True
         with pytest.raises(StopUser):
-            request_func(parent.user, parent, request)
+            parent.user.request(request)
 
-        assert request_mock.spy.call_count == 1
+        request_spy.assert_called_once_with(
+            method='GET',
+            name='001 TestScenario',
+            url='http://test/api/test',
+            catch_response=True,
+            cookies=parent.user.cookies,
+            **expected_parameters,
+        )
 
-        parent.user._scenario.failure_exception = RestartScenario
+        response_spy.success.assert_not_called()
+        response_spy.failure.assert_called_once_with(
+            '400 not in [200]: bad request'
+        )
 
-        # status_code != 200, stop_on_failure = True
-        with pytest.raises(RestartScenario):
-            request_func(parent.user, parent, request)
+        response_spy.reset_mock()
+        request_spy.reset_mock()
 
-        assert request_mock.spy.call_count == 2
-
-        request.response.add_status_code(400)
-
-        with pytest.raises(ResultSuccess):
-            request_func(parent.user, parent, request)
-
-        assert request_mock.spy.call_count == 3
-
-        request.response.add_status_code(-400)
+        # request GET, 404, no failure exception
+        response_spy.status_code = 404
+        response_spy.text = '{"error_description": "borked"}'
         parent.user._scenario.failure_exception = None
+        request.metadata = None
 
-        # status_code != 200, stop_on_failure = False
-        metadata, payload = request_func(parent.user, parent, request)
+        assert parent.user.request(request) == ({'x-bar': 'foo'}, '{"error_description": "borked"}')
 
-        assert request_mock.spy.call_count == 4
-        _, kwargs = request_mock.spy.call_args_list[-1]
-        assert kwargs.get('method', None) == request.method.name
-        assert kwargs.get('name', '').startswith(parent.user._scenario.identifier)
-        assert kwargs.get('catch_response', False)
-        assert kwargs.get('url', None) == f'{parent.user.host}{request.endpoint}'
+        request_spy.assert_called_once_with(
+            method='GET',
+            name='001 TestScenario',
+            url='http://test/api/test',
+            catch_response=True,
+            cookies=parent.user.cookies,
+            **expected_parameters,
+        )
 
-        if request_func is RestApiUser.request:
-            assert kwargs.get('request', None) is request
-            assert kwargs.get('verify', False)
+        response_spy.success.assert_not_called()
+        response_spy.failure.assert_called_once_with(
+            '404 not in [200]: borked'
+        )
 
-        assert metadata is None
-        assert payload == '{}'
+        request_spy.reset_mock()
+        response_spy.reset_mock()
 
-        request_mock = ClientRequestMock(status_code=200, user=parent.user, request_func=request_func)
+        # request POST, 200, json
+        request.method = RequestMethod.POST
+        response_spy.status_code = 200
+        response_spy.text = 'success'
 
-        parent.user._context['verify_certificates'] = False
+        assert parent.user.request(request) == ({'x-bar': 'foo'}, 'success')
 
-        request.response.add_status_code(-200)
-        request_func(parent.user, parent, request)
+        expected_source = parent.user.render(request).source
+        assert expected_source is not None
+        expected_source_json = json.loads(expected_source)
 
-        assert request_mock.spy.call_count == 1
-        _, kwargs = request_mock.spy.call_args_list[-1]
-        assert kwargs.get('method', None) == request.method.name
-        assert kwargs.get('name', '').startswith(parent.user._scenario.identifier)
-        assert kwargs.get('catch_response', False)
-        assert kwargs.get('url', None) == f'{parent.user.host}{request.endpoint}'
+        # this is done automagically for requests, but not for grequests
+        if not is_async_request:
+            response_spy.request_body = expected_source
 
-        if request_func is RestApiUser.request:
-            assert kwargs.get('request', None) is request
-            assert not kwargs.get('verify', True)
+        assert json.loads(response_spy.request_body) == expected_source_json
+        expected_parameters.update({'json': expected_source_json})
 
-        request.response.add_status_code(200)
+        request_spy.assert_called_once_with(
+            method='POST',
+            name='001 TestScenario',
+            url='http://test/api/test',
+            catch_response=True,
+            cookies=parent.user.cookies,
+            **expected_parameters,
+        )
 
-        # status_code == 200
-        with pytest.raises(ResultSuccess):
-            request_func(parent.user, parent, request)
+        response_spy.success.assert_called_once_with()
+        response_spy.failure.assert_not_called()
 
-        assert request_mock.spy.call_count == 2
+        response_spy.reset_mock()
+        request_spy.reset_mock()
 
-        # incorrect formated [json] payload
-        request.source = '{"hello: "world"}'
+        # request POST, invalid json
+        request.source = '{"hello}'
+        parent.user._scenario.failure_exception = None  # always stop for this error
 
         with pytest.raises(StopUser):
-            request_func(parent.user, parent, request)
+            parent.user.request(request)
 
-        assert request_mock.spy.call_count == 2
+        request_spy.assert_not_called()
+        response_spy.assert_not_called()
 
-        # unsupported request method
-        request.method = RequestMethod.RECEIVE
-
-        with pytest.raises(NotImplementedError):
-            request_func(parent.user, parent, request)
-
-        assert request_mock.spy.call_count == 2
-
-        # post XML
-        parent.user.host = 'http://localhost:1337'
-        request.method = RequestMethod.POST
-        request.endpoint = '/'
-        request.response.content_type = TransformerContentType.XML
-        request_mock = ClientRequestMock(status_code=200, user=parent.user, request_func=request_func)
-        request.response.add_status_code(200)
-        request.source = '<?xml version="1.0"?><example></example'
-
-        with pytest.raises(ResultSuccess):
-            request_func(parent.user, parent, request)
-
-        assert request_mock.spy.call_count == 1
-        _, kwargs = request_mock.spy.call_args_list[-1]
-        assert kwargs.get('method', None) == request.method.name
-        assert kwargs.get('name', '').startswith(parent.user._scenario.identifier)
-        assert kwargs.get('catch_response', False)
-        assert kwargs.get('url', None) == f'{parent.user.host}{request.endpoint}'
-        assert kwargs.get('data', None) == bytes(request.source, 'UTF-8')
-        assert 'headers' in kwargs
-        assert 'Content-Type' in kwargs['headers']
-        assert kwargs['headers']['Content-Type'] == 'application/xml'
-
-        # post multipart
-        parent.user.host = 'http://localhost:1337'
-        request.method = RequestMethod.POST
-        request.endpoint = '/'
-        request.arguments = {'multipart_form_data_name': 'input_name', 'multipart_form_data_filename': 'filename'}
+        # request PUT, 200, multipart form data
+        request.method = RequestMethod.PUT
+        del expected_parameters['json']
+        request.arguments = {
+            'multipart_form_data_name': 'foobar',
+            'multipart_form_data_filename': 'foobar.txt',
+        }
+        request.source = 'foobar'
         request.response.content_type = TransformerContentType.MULTIPART_FORM_DATA
-        request_mock = ClientRequestMock(status_code=200, user=parent.user, request_func=request_func)
-        request.response.add_status_code(200)
-        request.source = '<?xml version="1.0"?><example></example'
+        expected_parameters.update({
+            'files': {'foobar': ('foobar.txt', request.source,)}
+        })
 
-        with pytest.raises(ResultSuccess):
-            request_func(parent.user, parent, request)
+        assert parent.user.request(request) == ({'x-bar': 'foo'}, 'success')
 
-        assert request_mock.spy.call_count == 1
-        _, kwargs = request_mock.spy.call_args_list[-1]
-        assert kwargs.get('method', None) == request.method.name
-        assert kwargs.get('name', '').startswith(parent.user._scenario.identifier)
-        assert kwargs.get('catch_response', False)
-        assert kwargs.get('url', None) == f'{parent.user.host}{request.endpoint}'
+        request_spy.assert_called_once_with(
+            method='PUT',
+            name='001 TestScenario',
+            url='http://test/api/test',
+            catch_response=True,
+            cookies=parent.user.cookies,
+            **expected_parameters,
+        )
 
-        # post with metadata
-        parent.user.host = 'http://localhost:1337'
-        request.method = RequestMethod.POST
-        request.endpoint = '/'
-        request.arguments = None
-        request.metadata = {'my_header': 'value'}
-        request.response.content_type = TransformerContentType.JSON
-        request_mock = ClientRequestMock(status_code=200, user=parent.user, request_func=request_func)
-        request.response.add_status_code(200)
-        request.source = '{"alice": 1}'
+        response_spy.success.assert_called_once_with()
+        response_spy.failure.assert_not_called()
 
-        with pytest.raises(ResultSuccess):
-            request_func(parent.user, parent, request)
+        response_spy.reset_mock()
+        request_spy.reset_mock()
 
-        assert request_mock.spy.call_count == 1
-        _, kwargs = request_mock.spy.call_args_list[-1]
-        assert kwargs.get('method', None) == request.method.name
-        assert kwargs.get('name', '').startswith(parent.user._scenario.identifier)
-        assert kwargs.get('catch_response', False)
-        assert kwargs.get('url', None) == f'{parent.user.host}{request.endpoint}'
-        assert 'headers' in kwargs
-        assert 'my_header' in kwargs['headers']
-        assert kwargs['headers']['my_header'] == 'value'
+        # request PUT, data
+        request.response.content_type = TransformerContentType.XML
+        request.source = '<?xml version="1.0" encoding="utf-8"?><hello><foo/></hello>'
+        del expected_parameters['files']
+        expected_parameters.update({'data': request.source.encode('utf-8')})
+
+        assert parent.user.request(request) == ({'x-bar': 'foo'}, 'success')
+
+        request_spy.assert_called_once_with(
+            method='PUT',
+            name='001 TestScenario',
+            url='http://test/api/test',
+            catch_response=True,
+            cookies=parent.user.cookies,
+            **expected_parameters,
+        )
+
+        response_spy.success.assert_called_once_with()
+        response_spy.failure.assert_not_called()
+
+        response_spy.reset_mock()
+        request_spy.reset_mock()
 
     def test_add_context(self, grizzly_fixture: GrizzlyFixture) -> None:
         parent = grizzly_fixture(user_type=RestApiUser)

--- a/tests/unit/test_grizzly/users/test_restapi.py
+++ b/tests/unit/test_grizzly/users/test_restapi.py
@@ -20,7 +20,6 @@ from grizzly.types.locust import StopUser
 from grizzly.context import GrizzlyContext
 from grizzly.tasks import RequestTask
 from grizzly.testdata.utils import transform
-from grizzly.auth import GrizzlyAuthHttpContext
 from grizzly_extras.transformer import TransformerContentType
 
 from tests.fixtures import MockerFixture, GrizzlyFixture
@@ -466,8 +465,8 @@ class TestRestApiUser:
         assert isinstance(parent.user, RestApiUser)
 
         assert 'test_context_variable' not in parent.user._context
-        assert cast(GrizzlyAuthHttpContext, parent.user._context['auth'])['provider'] is None
-        assert cast(GrizzlyAuthHttpContext, parent.user._context['auth'])['refresh_time'] == 3000
+        assert parent.user._context['auth']['provider'] is None
+        assert parent.user._context['auth']['refresh_time'] == 3000
 
         parent.user.add_context({'test_context_variable': 'value'})
 
@@ -475,8 +474,8 @@ class TestRestApiUser:
 
         parent.user.add_context({'auth': {'provider': 'http://auth.example.org'}})
 
-        assert cast(GrizzlyAuthHttpContext, parent.user._context['auth'])['provider'] == 'http://auth.example.org'
-        assert cast(GrizzlyAuthHttpContext, parent.user._context['auth'])['refresh_time'] == 3000
+        assert parent.user._context['auth']['provider'] == 'http://auth.example.org'
+        assert parent.user._context['auth']['refresh_time'] == 3000
 
         parent.user.headers['Authorization'] = 'Bearer asdfasdfasdf'
 


### PR DESCRIPTION
rendering a RequestTask now returns a copy of the "template" RequestTask, where all attributes has been rendered (closes #153).

all logic around firing request events, response events etc. har handled in the final decorated method `GrizzlyUser.request`. all users has an `request_impl` which is specific to the protocol/transport method that user implements. this make user implementations cleaner.

a user does not need to know about the scenario it is executing, hence removed `parent` argument. this caused that `grizzly.auth` needed to be rewritten again, but for the better. a `ClientTask` now know about the locust environment and the context for the scenario it is executing.