### PR TITLE
persist flagged variables when test is stopping

### DIFF
--- a/grizzly/listeners/__init__.py
+++ b/grizzly/listeners/__init__.py
@@ -122,7 +122,7 @@ def locust_test_start(grizzly: GrizzlyContext) -> Callable[[Environment, KwArg(D
 
 def locust_test_stop(**_kwargs: Dict[str, Any]) -> None:
     if producer is not None:
-        producer.reset()
+        producer.on_test_stop()
 
 
 def spawning_complete(grizzly: GrizzlyContext) -> Callable[[KwArg(Dict[str, Any])], None]:

--- a/grizzly/testdata/variables/__init__.py
+++ b/grizzly/testdata/variables/__init__.py
@@ -1,4 +1,4 @@
-'''
+"""
 @anchor pydoc:grizzly.testdata.variables Variables
 This package contains special variables that can be used in a feature file and is synchronized between locust workers.
 
@@ -8,9 +8,9 @@ It is possible to implement custom testdata variables, the only requirement is t
 When initializing the variable, the full namespace has to be specified as `name` in the scenario {@pylink grizzly.steps.setup.step_setup_variable_value} step.
 
 There are examples of this in the {@link framework.example}.
-'''
-from abc import abstractmethod
-from typing import Generic, Optional, Callable, Set, Any, Tuple, Dict, TypeVar, Protocol, runtime_checkable
+"""
+from abc import abstractmethod, ABCMeta
+from typing import Generic, Optional, Callable, Set, Any, Tuple, Dict, TypeVar
 
 from gevent.lock import Semaphore, DummySemaphore
 
@@ -27,15 +27,15 @@ class AbstractAtomicClass:
     pass
 
 
-@runtime_checkable
-class AtomicVariablePersist(Protocol):
+class AtomicVariablePersist(metaclass=ABCMeta):
     arguments: Dict[str, Any] = {'persist': bool_type}
 
+    @abstractmethod
     def generate_initial_value(self, variable: str) -> str:
         ...
 
 
-class AtomicVariableSettable:
+class AtomicVariableSettable(metaclass=ABCMeta):
     __settable__ = True
 
     @abstractmethod

--- a/tests/unit/test_grizzly/listeners/test___init__.py
+++ b/tests/unit/test_grizzly/listeners/test___init__.py
@@ -304,7 +304,7 @@ def test_locust_test_stop(mocker: MockerFixture, listener_test_mocker: None, gri
         raise Running()
 
     mocker.patch(
-        'grizzly.testdata.communication.TestdataProducer.reset',
+        'grizzly.testdata.communication.TestdataProducer.on_test_stop',
         mocked_reset,
     )
     init_function = _init_testdata_producer(grizzly_fixture.grizzly, '1337', {})

--- a/tests/unit/test_grizzly/testdata/test_communication.py
+++ b/tests/unit/test_grizzly/testdata/test_communication.py
@@ -274,7 +274,7 @@ class TestTestdataProducer:
 
             cleanup()
 
-    def test_reset(self, mocker: MockerFixture, cleanup: AtomicVariableCleanupFixture, grizzly_fixture: GrizzlyFixture, noop_zmq: NoopZmqFixture) -> None:
+    def test_on_stop(self, mocker: MockerFixture, cleanup: AtomicVariableCleanupFixture, grizzly_fixture: GrizzlyFixture, noop_zmq: NoopZmqFixture) -> None:
         noop_zmq('grizzly.testdata.communication')
 
         try:
@@ -284,7 +284,7 @@ class TestTestdataProducer:
                 'test-scenario-2': 5,
             }
 
-            producer.reset()
+            producer.on_test_stop()
 
             for scenario, count in producer.scenarios_iteration.items():
                 assert count == 0, f'iteration count for {scenario} was not reset'


### PR DESCRIPTION
when running distributed and test is aborted with `ctrl + c`, the persistent file wasn't created.

this PR solves that problem by calling `persist_variables` also when `test_stop` event is fired.