### PR TITLE
bump versions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.10, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.10-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.10-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
-ARG VARIANT="3.10"
+ARG VARIANT="3.11"
 
 # IBM MQ libraries dependencies
 FROM alpine:latest as dependencies

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
             // Update 'VARIANT' to pick a Python version: 3, 3.10, 3.9, 3.8, 3.7, 3.6
             // Append -bullseye or -buster to pin to an OS version.
             // Use -bullseye variants on local on arm64/Apple Silicon.
-            "VARIANT": "3.10",
+            "VARIANT": "3.11",
             // Options
             "INSTALL_NODE": "true",
             "NODE_VERSION": "lts/*"
@@ -20,20 +20,9 @@
             "settings": {
                 "python.defaultInterpreterPath": "/usr/local/bin/python",
                 "python.pythonPath": "/usr/local/bin/python",
-                "python.linting.enabled": true,
-                "python.linting.pylintEnabled": true,
-                "python.linting.flake8Enabled": true,
-                "python.linting.mypyEnabled": false,
-                "python.linting.pycodestyleEnabled": false,
-                "python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
-                "python.formatting.blackPath": "/usr/local/py-utils/bin/black",
-                "python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
-                "python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
-                "python.linting.flake8Path": "flake8",
-                "python.linting.mypyPath": "mypy",
-                "python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
-                "python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
-                "python.linting.pylintPath": "pylint",
+                "pylint.path": ["pylint"],
+                "flake8.path": ["flake8"],
+                "mypy-type-checker.path": ["mypy"],
                 "python.languageServer": "Pylance",
                 "pythonTestExplorer.testFramework": "pytest",
                 "files.associations": {
@@ -59,6 +48,9 @@
             "extensions": [
                 "ms-python.python",
                 "ms-python.vscode-pylance",
+                "ms-python.pylint",
+                "ms-python.flake8",
+                "ms-python.mypy-type-checker",
                 "editorconfig.editorconfig",
                 "eamodio.gitlens",
                 "samuelcolvin.jinjahtml",

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -21,7 +21,7 @@ jobs:
       id: setup-python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
         cache: 'pip'
 
     - name: install python dependencies
@@ -53,10 +53,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         runs-on: ['ubuntu-latest']
         include:
-          - python-version: '3.10'
+          - python-version: '3.11'
             runs-on: windows-latest
 
     env:
@@ -122,7 +122,7 @@ jobs:
       id: setup-python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
         cache: 'pip'
 
     - name: setup environment
@@ -140,7 +140,7 @@ jobs:
       if: matrix.run_mode == 'dist'
       uses: KengoTODA/actions-setup-docker-compose@main
       with:
-        version: '2.17.2'
+        version: '2.20.3'
 
     - name: ssh agent
       id: ssh-agent
@@ -193,7 +193,7 @@ jobs:
       id: setup-python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
         cache: 'pip'
 
     - name: install python dependencies
@@ -223,7 +223,7 @@ jobs:
       id: setup-python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
         cache: 'pip'
 
     - name: setup node

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
       id: setup-python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
         cache: 'pip'
 
     - name: setup node

--- a/docs/content/command-line-interface/changelog.md
+++ b/docs/content/command-line-interface/changelog.md
@@ -1,3 +1,6 @@
+---
+title: Changelog
+---
 # Changelog
 
 @shell cd .. && script/docs-generate.bash cli --changelog

--- a/docs/content/command-line-interface/licenses.md
+++ b/docs/content/command-line-interface/licenses.md
@@ -1,3 +1,6 @@
+---
+title: Licenses
+---
 # Licenses
 
 @shell cd .. && script/docs-generate.bash cli --licenses

--- a/docs/content/command-line-interface/usage/index.md
+++ b/docs/content/command-line-interface/usage/index.md
@@ -1,5 +1,5 @@
 ---
 title: Usage
 ---
-@anchor command-line-interface.usage
+@anchor command-line-interface.usage Usage
 @shell cd .. && script/docs-generate.bash cli --usage

--- a/docs/content/command-line-interface/usage/metadata.md
+++ b/docs/content/command-line-interface/usage/metadata.md
@@ -1,7 +1,7 @@
 ---
 title: Metadata
 ---
-@anchor command-line-interface.usage.metadata
+@anchor command-line-interface.usage.metadata Metadata
 # Metadata
 
 It is possible to add metadata in feature files that `grizzly-cli` will use. Metadata comments can be added anywhere in the feature file, but
@@ -22,7 +22,7 @@ have to remember all combinations in memory.
 ```
 
 No validation is done that an argument actually exists in the subparser, other than that `grizzly-cli` will fail with an argument error.
-Which is solved by checking {@link command-line-interface.usage} usage and correct the metadata comments.
+Which is solved by checking {@link command-line-interface.usage} and correct the metadata comments.
 
 ### Examples
 

--- a/docs/content/editor-support/changelog.md
+++ b/docs/content/editor-support/changelog.md
@@ -1,3 +1,6 @@
+---
+title: Changelog
+---
 # Changelog
 
 @shell cd .. && script/docs-generate.bash lsp --changelog

--- a/docs/content/editor-support/editors/index.md
+++ b/docs/content/editor-support/editors/index.md
@@ -1,3 +1,6 @@
+---
+title: Licenses
+---
 # Editors
 
 Implementations for your favorite editor is always welcome!

--- a/docs/content/editor-support/editors/vscode.md
+++ b/docs/content/editor-support/editors/vscode.md
@@ -1,1 +1,4 @@
+---
+title: Visual Studio Code
+---
 @shell curl -L https://raw.githubusercontent.com/Biometria-se/grizzly-lsp/main/client/vscode/README.md

--- a/docs/content/editor-support/index.md
+++ b/docs/content/editor-support/index.md
@@ -1,3 +1,6 @@
+---
+title: Editor support
+---
 # Editor support
 
 It can be hard to remember all the step expressions by heart; that's why `grizzly-ls` exists! Which is a server implementation of LSP[^1], providing auto-complete of step expressions.

--- a/docs/content/editor-support/language-server.md
+++ b/docs/content/editor-support/language-server.md
@@ -1,1 +1,4 @@
+---
+title: Language server
+---
 @shell curl -L https://raw.githubusercontent.com/Biometria-se/grizzly-lsp/main/grizzly-ls/README.md

--- a/docs/content/editor-support/licenses.md
+++ b/docs/content/editor-support/licenses.md
@@ -1,3 +1,6 @@
+---
+title: Licenses
+---
 # Licenses
 
 @shell cd .. && script/docs-generate.bash lsp --licenses

--- a/docs/content/example.md
+++ b/docs/content/example.md
@@ -1,4 +1,7 @@
-@anchor framework.example
+---
+title: Example
+---
+@anchor framework.example Example
 # Example
 
 The directory `example/` is an working project that sends requests to public REST API endpoints, **please do not abuse these**.

--- a/docs/content/framework/changelog.md
+++ b/docs/content/framework/changelog.md
@@ -1,3 +1,6 @@
+---
+title: Changelog
+---
 # Changelog
 
 @shell cd ../ && python3 script/docs-generate-changelog.py

--- a/docs/content/framework/licenses.md
+++ b/docs/content/framework/licenses.md
@@ -1,3 +1,6 @@
+---
+title: Licenses
+---
 # Licenses
 
 @shell cd .. && python3 script/docs-generate-licenses.py

--- a/grizzly/tasks/clients/messagequeue.py
+++ b/grizzly/tasks/clients/messagequeue.py
@@ -80,7 +80,6 @@ from json import dumps as jsondumps
 import zmq.green as zmq
 
 from zmq.error import ZMQError
-from zmq.sugar.constants import REQ as ZMQ_REQ, LINGER as ZMQ_LINGER
 
 from grizzly_extras.async_message import AsyncMessageContext, AsyncMessageResponse, AsyncMessageRequest, async_message_request
 
@@ -236,7 +235,7 @@ class MessageQueueClientTask(ClientTask):
         try:
             client = cast(
                 zmq.Socket,
-                self._zmq_context.socket(ZMQ_REQ),
+                self._zmq_context.socket(zmq.REQ),
             )
             client.connect(self._zmq_url)
 
@@ -246,7 +245,7 @@ class MessageQueueClientTask(ClientTask):
             raise
         finally:
             if client is not None:
-                client.setsockopt(ZMQ_LINGER, 0)
+                client.setsockopt(zmq.LINGER, 0)
                 client.close()
 
     def connect(self, client_id: int, client: zmq.Socket, meta: Dict[str, Any]) -> None:

--- a/grizzly/tasks/clients/servicebus.py
+++ b/grizzly/tasks/clients/servicebus.py
@@ -73,8 +73,6 @@ from dataclasses import dataclass, field
 
 import zmq.green as zmq
 
-from zmq.sugar.constants import REQ as ZMQ_REQ, LINGER as ZMQ_LINGER
-
 from grizzly_extras.async_message import AsyncMessageContext, AsyncMessageRequest, AsyncMessageResponse
 from grizzly_extras.transformer import TransformerContentType
 from grizzly_extras.arguments import parse_arguments
@@ -203,7 +201,7 @@ class ServiceBusClientTask(ClientTask):
 
             state = State(
                 parent=parent,
-                client=cast(zmq.Socket, self._zmq_context.socket(ZMQ_REQ)),
+                client=cast(zmq.Socket, self._zmq_context.socket(zmq.REQ)),
                 context=context,
             )
             state.client.connect(self._zmq_url)
@@ -247,7 +245,7 @@ class ServiceBusClientTask(ClientTask):
 
         async_message_request_wrapper(parent, state.client, request)
 
-        state.client.setsockopt(ZMQ_LINGER, 0)
+        state.client.setsockopt(zmq.LINGER, 0)
         state.client.close()
 
         del self._state[parent]

--- a/grizzly/types/__init__.py
+++ b/grizzly/types/__init__.py
@@ -75,12 +75,7 @@ class RequestDirection(PermutationEnum):
         return methods
 
 
-# Enum is needed for keeping mypy happy
-class MixedEnumMeta(AdvancedEnumType, EnumMeta):
-    pass
-
-
-class RequestMethod(Enum, AdvancedEnum, metaclass=MixedEnumMeta, settings=NoAlias):
+class RequestMethod(AdvancedEnum, settings=NoAlias):
     SEND = RequestDirection.TO
     POST = RequestDirection.TO
     PUT = RequestDirection.TO
@@ -107,7 +102,7 @@ class RequestMethod(Enum, AdvancedEnum, metaclass=MixedEnumMeta, settings=NoAlia
         return self.value
 
 
-class RequestType(Enum, AdvancedEnum, metaclass=MixedEnumMeta, init='alias _weight'):
+class RequestType(AdvancedEnum, init='alias _weight'):
     AUTH = ('AUTH', 0,)
     SCENARIO = ('SCEN', 1,)
     TESTDATA = ('TSTD', 2,)

--- a/grizzly/types/__init__.py
+++ b/grizzly/types/__init__.py
@@ -1,8 +1,6 @@
-from enum import Enum, EnumMeta
+from enum import Enum
 from typing import Callable, Optional, Tuple, Any, Union, Dict, TypeVar, List, cast
 from mypy_extensions import KwArg, Arg
-
-from aenum import Enum as AdvancedEnum, NoAlias, EnumType as AdvancedEnumType
 
 from locust.clients import ResponseContextManager as RequestsResponseContextManager
 from locust.contrib.fasthttp import ResponseContextManager as FastResponseContextManager
@@ -75,20 +73,21 @@ class RequestDirection(PermutationEnum):
         return methods
 
 
-class RequestMethod(AdvancedEnum, settings=NoAlias):
-    SEND = RequestDirection.TO
-    POST = RequestDirection.TO
-    PUT = RequestDirection.TO
-    RECEIVE = RequestDirection.FROM
-    GET = RequestDirection.FROM
+class RequestDirectionWrapper:
+    wrapped: RequestDirection
 
-    @classmethod
-    def get_vector(cls) -> Tuple[bool, bool]:
-        """
-        aenum.Enum has a definition of __getattr__ that makes it "impossible" to implement vector the same
-        was as for the enums that only inherits enum.Enum.
-        """
-        return (False, True,)
+    def __init__(self, /, wrapped: RequestDirection) -> None:
+        self.wrapped = wrapped
+
+
+class RequestMethod(PermutationEnum):
+    __vector__ = (False, True,)
+
+    SEND = RequestDirectionWrapper(wrapped=RequestDirection.TO)
+    POST = RequestDirectionWrapper(wrapped=RequestDirection.TO)
+    PUT = RequestDirectionWrapper(wrapped=RequestDirection.TO)
+    RECEIVE = RequestDirectionWrapper(wrapped=RequestDirection.FROM)
+    GET = RequestDirectionWrapper(wrapped=RequestDirection.FROM)
 
     @classmethod
     def from_string(cls, value: str) -> 'RequestMethod':
@@ -99,10 +98,10 @@ class RequestMethod(AdvancedEnum, settings=NoAlias):
 
     @property
     def direction(self) -> RequestDirection:
-        return self.value
+        return cast(RequestDirection, self.value.wrapped)
 
 
-class RequestType(AdvancedEnum, init='alias _weight'):
+class RequestType(Enum):
     AUTH = ('AUTH', 0,)
     SCENARIO = ('SCEN', 1,)
     TESTDATA = ('TSTD', 2,)
@@ -118,16 +117,29 @@ class RequestType(AdvancedEnum, init='alias _weight'):
     SUBSCRIBE = ('SUB', None,)
     UNSUBSCRIBE = ('UNSUB', None,)
 
+    _value: str
+    _weight: Optional[int]
+
+    def __new__(cls, value: str, weight: Optional[int] = None) -> 'RequestType':
+        obj = object.__new__(cls)
+        obj._value = value
+        obj._weight = weight
+
+        return obj
+
     def __call__(self) -> str:
         return str(self)
 
     def __str__(self) -> str:
-        return cast(str, getattr(self, 'alias'))
+        return self.alias
 
     @property
     def weight(self) -> int:
-        weight = getattr(self, '_weight', None)
-        return cast(int, weight) if weight is not None else 10
+        return self._weight if self._weight is not None else 10
+
+    @property
+    def alias(self) -> str:
+        return self._value
 
     @classmethod
     def get_method_weight(cls, method: str) -> int:
@@ -143,13 +155,13 @@ class RequestType(AdvancedEnum, init='alias _weight'):
     def from_method(cls, request_type: RequestMethod) -> str:
         method_name = cast(Optional[RequestType], getattr(cls, request_type.name, None))
         if method_name is not None:
-            return cast(str, method_name.alias)
+            return method_name.alias
 
         return request_type.name
 
     @classmethod
     def from_alias(cls, alias: str) -> 'RequestType':
-        for request_type in cls:
+        for request_type in cls.__iter__():
             if request_type.alias == alias:
                 return request_type
 
@@ -157,16 +169,16 @@ class RequestType(AdvancedEnum, init='alias _weight'):
 
     @classmethod
     def from_string(cls, key: str) -> str:
-        attribute = cast(Optional[RequestType], getattr(cls, key, None))
-        if attribute is not None:
-            return cast(str, attribute.alias)
+        rt_attribute = cast(Optional[RequestType], getattr(cls, key, None))
+        if rt_attribute is not None:
+            return rt_attribute.alias
 
-        if key in [e.alias for e in cls]:
+        if key in [e.alias for e in cls.__iter__()]:
             return key
 
-        attribute = cast(Optional[RequestMethod], getattr(RequestMethod, key, None))
-        if attribute is not None:
-            return attribute.name
+        rm_attribute = cast(Optional[RequestMethod], getattr(RequestMethod, key, None))
+        if rm_attribute is not None:
+            return rm_attribute.name
 
         raise AttributeError(f'{key} does not exist')
 

--- a/grizzly/users/messagequeue.py
+++ b/grizzly/users/messagequeue.py
@@ -127,7 +127,6 @@ from typing import Dict, Any, Generator, Tuple, Optional, cast
 from urllib.parse import urlparse, parse_qs, unquote
 from contextlib import contextmanager
 
-from zmq.sugar.constants import REQ as ZMQ_REQ
 import zmq.green as zmq
 
 from grizzly_extras.async_message import AsyncMessageContext, AsyncMessageRequest, AsyncMessageResponse, async_message_request
@@ -255,7 +254,7 @@ class MessageQueueUser(ResponseHandler, GrizzlyUser):
                 'client': id(self),
                 'context': self.am_context,
             }):
-                self.zmq_client = self.zmq_context.socket(ZMQ_REQ)
+                self.zmq_client = self.zmq_context.socket(zmq.REQ)
                 self.zmq_client.connect(self.zmq_url)
         except:
             self.logger.error('on_start failed', exc_info=True)

--- a/grizzly/users/servicebus.py
+++ b/grizzly/users/servicebus.py
@@ -73,7 +73,6 @@ from typing import Generator, Dict, Any, Tuple, Optional, Set, cast
 from urllib.parse import urlparse, parse_qs
 from contextlib import contextmanager
 
-from zmq.sugar.constants import REQ as ZMQ_REQ
 import zmq.green as zmq
 
 from grizzly_extras.async_message import AsyncMessageContext, AsyncMessageResponse, AsyncMessageRequest, async_message_request
@@ -149,7 +148,7 @@ class ServiceBusUser(ResponseHandler, GrizzlyUser):
     def on_start(self) -> None:
         super().on_start()
 
-        self.zmq_client = self.zmq_context.socket(ZMQ_REQ)
+        self.zmq_client = self.zmq_context.socket(zmq.REQ)
         self.zmq_client.connect(self.zmq_url)
 
         for task in self._scenario.tasks:

--- a/grizzly_extras/async_message/__init__.py
+++ b/grizzly_extras/async_message/__init__.py
@@ -15,7 +15,6 @@ from time import sleep, perf_counter
 import zmq.green as zmq
 
 from zmq.error import Again as ZMQAgain
-from zmq.sugar.constants import NOBLOCK as ZMQ_NOBLOCK
 from grizzly_extras.transformer import JsonBytesEncoder
 
 
@@ -216,7 +215,7 @@ def async_message_request(client: zmq.Socket, request: AsyncMessageRequest) -> A
         while True:
             start = perf_counter()
             try:
-                response = cast(AsyncMessageResponse, client.recv_json(flags=ZMQ_NOBLOCK))
+                response = cast(AsyncMessageResponse, client.recv_json(flags=zmq.NOBLOCK))
                 break
             except ZMQAgain:
                 sleep(0.1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ license = {text = 'MIT'}
 requires-python = ">=3.8"
 dependencies = [
     "locust >=2.16.0,<2.17.0",
-    "aenum >3.1.8,<3.1.13",
+    "aenum >3.1.13",
     "azure-core >=1.24.0,<2.0.0",
     "azure-servicebus >=7.6.0,<7.10.0",
     "azure-storage-blob >=12.9.0,<13.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ license = {text = 'MIT'}
 requires-python = ">=3.8"
 dependencies = [
     "locust >=2.16.0,<2.17.0",
-    "aenum >3.1.13",
     "azure-core >=1.24.0,<2.0.0",
     "azure-servicebus >=7.6.0,<7.10.0",
     "azure-storage-blob >=12.9.0,<13.0.0",
@@ -43,6 +42,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: Implementation :: CPython"
 ]
 keywords = [
@@ -244,10 +244,6 @@ module = "parse.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
-module = "aenum"
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
 module = "opencensus.ext.azure.*"
 ignore_missing_imports = true
 
@@ -280,5 +276,6 @@ timeout = 10
 filterwarnings = [
     "ignore:setDaemon\\(\\) is deprecated.*:DeprecationWarning",
     "ignore:.*pkg_resources.*:DeprecationWarning",
+    "ignore:Use setlocale.*instead:DeprecationWarning",
     "error:.*:gevent.monkey.MonkeyPatchWarning"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 license = {text = 'MIT'}
 requires-python = ">=3.8"
 dependencies = [
-    "locust >=2.15.0,<2.16",
+    "locust >=2.16.0,<2.17.0",
     "aenum >3.1.8,<3.1.13",
     "azure-core >=1.24.0,<2.0.0",
     "azure-servicebus >=7.6.0,<7.10.0",
@@ -26,11 +26,11 @@ dependencies = [
     "lxml >=4.8.0,<5.0.0",
     "mypy-extensions >=0.4.3",
     "opencensus-ext-azure >=1.1.1",
-    "paramiko >=3.0.0,<3.1.0",
+    "paramiko >=3.3.1",
     "python-dateutil >=2.8.2,<3.0.0",
     "backports.zoneinfo >=0.2.1;python_version<'3.9'",
-    "pyzmq >=22.3.0,<23.0.0",
-    "PyYAML >=5.3.0,<6.0.0",
+    "pyzmq >=22.2.1,!=23.0.0",
+    "PyYAML >=6.0.1,<7.0.0",
     "setproctitle >=1.2.2",
     "tzdata >=2022.1"
 ]
@@ -91,16 +91,16 @@ ci = [
     "twine >=3.8.0,<4.0.0"
 ]
 docs = [
-    "novella >= 0.2.6",
-    "pydoc-markdown[novella] >= 4.6.1",
-    "docspec == 2.1.2",
-    "docspec-python == 2.1.2",
-    "pytablewriter >= 0.64.1",
+    "novella >=0.2.6",
+    "pydoc-markdown >=4.6.1",
+    "docspec >=2.1.2",
+    "docspec-python >=2.1.2",
+    "pytablewriter >=0.64.1",
     "pip-licenses >=3.5.3,<4.2.0",
-    "requests >= 2.27.1",
-    "mkdocs >= 1.3.0",
-    "mkdocs-material >= 8.3.2",
-    "packaging >= 21.3",
+    "requests >=2.27.1",
+    "mkdocs >=1.3.0",
+    "mkdocs-material >=8.3.2",
+    "packaging >=21.3",
     "grizzly-loadtester-cli"
 ]
 

--- a/script/docs-generate.bash
+++ b/script/docs-generate.bash
@@ -37,7 +37,11 @@ main() {
     esac
 
     >&2 echo "-- installing grizzly-${pypi_suffix}"
-    python -m pip install --no-cache-dir grizzly-loadtester-${pypi_suffix}[dev] &> /dev/null
+    if ! python -m pip install --no-cache-dir grizzly-loadtester-${pypi_suffix}[dev] 2>&1 > /tmp/grizzly-cli-install.log; then
+        cat /tmp/grizzly-cli-install.log
+    fi
+
+    rm -rf /tmp/grizzly-cli-install.log || true
 
     case "${what}" in
         --usage)

--- a/tests/unit/test_grizzly/tasks/clients/test_servicebus.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_servicebus.py
@@ -4,9 +4,9 @@ from typing import Dict, Any
 from json import dumps as jsondumps
 
 import pytest
+import zmq.green as zmq
 
 from _pytest.logging import LogCaptureFixture
-from zmq.sugar.constants import LINGER as ZMQ_LINGER
 from grizzly.tasks.clients import ServiceBusClientTask
 from grizzly.types import RequestDirection
 from grizzly_extras.async_message import AsyncMessageRequest
@@ -257,7 +257,7 @@ class TestServiceBusClientTask:
             'action': 'DISCONNECT',
             'context': state.context,
         })
-        client_mock.setsockopt.assert_called_once_with(ZMQ_LINGER, 0)
+        client_mock.setsockopt.assert_called_once_with(zmq.LINGER, 0)
         client_mock.close.assert_called_once_with()
 
         assert task._state == {}

--- a/tests/unit/test_grizzly/tasks/test_request.py
+++ b/tests/unit/test_grizzly/tasks/test_request.py
@@ -87,7 +87,7 @@ class TestRequestTask:
 
         parent = grizzly_fixture()
 
-        mocker.patch.object(parent.user, 'request', autospec=True)
+        mocker.patch.object(parent.user, 'request')
         request_spy = mocker.spy(parent.user, 'request')
 
         task(parent)

--- a/tests/unit/test_grizzly/test_types.py
+++ b/tests/unit/test_grizzly/test_types.py
@@ -37,11 +37,11 @@ class TestRequestType:
         assert RequestType.from_method(input) == expected
 
     @pytest.mark.parametrize('input,expected', [
-        (e.name, e.value[0],) for e in RequestType
+        (e.name, e.alias,) for e in RequestType
     ] + [
         (e.name, e.name,) for e in RequestMethod if getattr(RequestType, e.name, None) is None
     ] + [
-        (e.value[0], e.value[0],) for e in RequestType
+        (e.alias, e.alias,) for e in RequestType
     ])
     def test_from_string(self, input: str, expected: str) -> None:
         assert RequestType.from_string(input) == expected
@@ -103,7 +103,7 @@ class TestRequestMethod:
 
     def test_direction(self) -> None:
         for method in RequestMethod:
-            assert method.value == method.direction
+            assert method.value.wrapped == method.direction
             assert method in method.direction.methods
 
 

--- a/tests/unit/test_grizzly/testdata/test_communication.py
+++ b/tests/unit/test_grizzly/testdata/test_communication.py
@@ -12,7 +12,6 @@ import gevent
 
 from _pytest.logging import LogCaptureFixture
 from pytest_mock import MockerFixture
-from zmq.sugar.constants import REQ as ZMQ_REQ
 from zmq.error import ZMQError, Again as ZMQAgain
 
 from grizzly.types.locust import StopUser
@@ -110,7 +109,7 @@ class TestTestdataProducer:
             producer_thread.start()
 
             context = zmq.Context()
-            with context.socket(ZMQ_REQ) as socket:
+            with context.socket(zmq.REQ) as socket:
                 socket.connect(address)
 
                 def get_message_from_producer() -> Dict[str, Any]:
@@ -122,7 +121,7 @@ class TestTestdataProducer:
 
                     gevent.sleep(0.1)
 
-                    message = socket.recv_json()
+                    message = cast(Dict[str, Any], socket.recv_json())
                     return message
 
                 message: Dict[str, Any] = get_message_from_producer()
@@ -242,7 +241,7 @@ class TestTestdataProducer:
             producer_thread.start()
 
             context = zmq.Context()
-            with context.socket(ZMQ_REQ) as socket:
+            with context.socket(zmq.REQ) as socket:
                 socket.connect(address)
 
                 def get_message_from_producer() -> Dict[str, Any]:
@@ -254,7 +253,7 @@ class TestTestdataProducer:
 
                     gevent.sleep(0.1)
 
-                    message = socket.recv_json()
+                    message = cast(Dict[str, Any], socket.recv_json())
                     return message
 
                 message: Dict[str, Any] = get_message_from_producer()

--- a/tests/unit/test_grizzly/users/test_servicebus.py
+++ b/tests/unit/test_grizzly/users/test_servicebus.py
@@ -3,10 +3,10 @@ import logging
 from typing import cast
 
 import pytest
+import zmq.green as zmq
 
 from pytest_mock import MockerFixture
 from _pytest.logging import LogCaptureFixture
-from zmq.sugar.constants import REQ as ZMQ_REQ
 from zmq.error import Again as ZMQAgain
 
 from grizzly.users.base import GrizzlyUser, RequestLogger, ResponseHandler
@@ -41,7 +41,7 @@ class TestServiceBusUser:
             assert zmq_client_connect_spy.call_count == 1
             args, _ = zmq_client_connect_spy.call_args_list[0]
             assert args[0] == ServiceBusUser.zmq_url
-            assert user.zmq_client.type == ZMQ_REQ
+            assert user.zmq_client.type == zmq.REQ
             assert say_hello_spy.call_count == 0
 
             scenario = GrizzlyContextScenario(2, behave=behave_fixture.create_scenario('test'))
@@ -90,7 +90,7 @@ class TestServiceBusUser:
             assert zmq_client_disconnect_spy.call_count == 1
             args, _ = zmq_client_disconnect_spy.call_args_list[0]
             assert args[0] == ServiceBusUser.zmq_url
-            assert user.zmq_client.type == ZMQ_REQ
+            assert user.zmq_client.type == zmq.REQ
             assert disconnect_spy.call_count == 0
 
             scenario = GrizzlyContextScenario(2, behave=behave_fixture.create_scenario('test'))

--- a/tests/unit/test_grizzly_extras/async_message/mq/test___init__.py
+++ b/tests/unit/test_grizzly_extras/async_message/mq/test___init__.py
@@ -163,7 +163,7 @@ class TestAsyncMessageQueueHandler:
 
         handler.qmgr = None
 
-        mocker.patch.object(
+        pymqi_connect_with_options_spy = mocker.patch.object(
             pymqi.QueueManager,
             'connect_with_options',
             autospec=True,
@@ -171,7 +171,6 @@ class TestAsyncMessageQueueHandler:
 
         pymqi_sco_spy = mocker.spy(pymqi.SCO, '__init__')
         pymqi_cd_spy = mocker.spy(pymqi.CD, '__init__')
-        pymqi_connect_with_options_spy = mocker.spy(pymqi.QueueManager, 'connect_with_options')
 
         response = handlers[request['action']](handler, request)
 
@@ -201,7 +200,7 @@ class TestAsyncMessageQueueHandler:
 
         pymqi_sco_spy.reset_mock()
         pymqi_cd_spy.reset_mock()
-        pymqi_connect_with_options_spy.reset_mock()  # does not reset call count?!
+        pymqi_connect_with_options_spy.reset_mock()
         pymqi_cd_setitem_spy = mocker.spy(pymqi.CD, '__setitem__')
 
         request['context'].update({
@@ -234,7 +233,7 @@ class TestAsyncMessageQueueHandler:
         assert args[1] == 'SSLCipherSpec'
         assert args[2].decode().strip() == 'ECDHE_RSA_AES_256_GCM_SHA384'
 
-        assert pymqi_connect_with_options_spy.call_count == 2
+        assert pymqi_connect_with_options_spy.call_count == 1
         args, kwargs = pymqi_connect_with_options_spy.call_args_list[-1]
 
         assert args[0] is handler.qmgr
@@ -269,7 +268,7 @@ class TestAsyncMessageQueueHandler:
         assert args[1] == 'SSLCipherSpec'
         assert args[2].decode().strip() == 'rot13'
 
-        assert pymqi_connect_with_options_spy.call_count == 3
+        assert pymqi_connect_with_options_spy.call_count == 1
         args, kwargs = pymqi_connect_with_options_spy.call_args_list[-1]
 
         assert args[0] is handler.qmgr

--- a/tests/unit/test_grizzly_extras/async_message/test___init__.py
+++ b/tests/unit/test_grizzly_extras/async_message/test___init__.py
@@ -4,9 +4,9 @@ from shutil import rmtree
 from platform import node as hostname
 
 import pytest
+import zmq.green as zmq
 
 from zmq.error import Again as ZMQAgain
-from zmq.sugar.constants import NOBLOCK as ZMQ_NOBLOCK
 from pytest_mock import MockerFixture
 from _pytest.tmpdir import TempPathFactory
 from _pytest.capture import CaptureFixture
@@ -207,7 +207,7 @@ def test_async_message_request(mocker: MockerFixture) -> None:
     for i in range(2):
         args, kwargs = client_mock.recv_json.call_args_list[i]
         assert args == ()
-        assert kwargs == {'flags': ZMQ_NOBLOCK}
+        assert kwargs == {'flags': zmq.NOBLOCK}
 
     sleep_mock.reset_mock()
     client_mock.reset_mock()
@@ -222,7 +222,7 @@ def test_async_message_request(mocker: MockerFixture) -> None:
 
     sleep_mock.assert_not_called()
     client_mock.send_json.assert_called_once_with(request)
-    client_mock.recv_json.assert_called_once_with(flags=ZMQ_NOBLOCK)
+    client_mock.recv_json.assert_called_once_with(flags=zmq.NOBLOCK)
 
     # valid response
     client_mock.recv_json.return_value = {'success': True, 'worker': 'foo-bar-baz-foo', 'payload': 'yes'}


### PR DESCRIPTION
updated dependencies, fixed errors related to it and added support for python 3.11.

pyaml < 6.0 is broken due to cython 3.0.0.
pyzmq changed namespace for constants
etc.