### PR TITLE
add support for sub log directories in `requests/logs`

### DIFF
--- a/grizzly/tasks/clients/__init__.py
+++ b/grizzly/tasks/clients/__init__.py
@@ -153,7 +153,12 @@ class ClientTask(GrizzlyMetaRequestTask):
 
         context_root = environ.get('GRIZZLY_CONTEXT_ROOT', None)
         assert context_root is not None, 'environment variable GRIZZLY_CONTEXT_ROOT is not set!'
+
         self.log_dir = Path(context_root) / 'logs'
+        log_dir = environ.get('GRIZZLY_LOG_DIR', None)
+        if log_dir is not None:
+            self.log_dir /= log_dir
+
         self.log_dir.mkdir(parents=True, exist_ok=True)
         self._scenario = copy(self.__scenario__)
         self._scenario._tasks = self.__scenario__._tasks

--- a/grizzly/users/base/request_logger.py
+++ b/grizzly/users/base/request_logger.py
@@ -60,8 +60,13 @@ class RequestLogger(ResponseEvent):
         self.response_event.add_listener(self.request_logger)
 
         self.log_dir = os.path.join(os.environ.get('GRIZZLY_CONTEXT_ROOT', '.'), 'logs')
+
+        log_dir = os.environ.get('GRIZZLY_LOG_DIR', None)
+        if log_dir is not None:
+            self.log_dir = os.path.join(self.log_dir, log_dir)
+
         if not os.path.exists(self.log_dir):
-            os.mkdir(self.log_dir)
+            os.makedirs(self.log_dir, exist_ok=True)
 
         self._context = merge_dicts(super().context(), RequestLogger._context)
 

--- a/tests/unit/test_grizzly/tasks/clients/test___init__.py
+++ b/tests/unit/test_grizzly/tasks/clients/test___init__.py
@@ -1,5 +1,8 @@
 import logging
 
+from os import environ
+from pathlib import Path
+
 import pytest
 
 from _pytest.logging import LogCaptureFixture
@@ -12,67 +15,83 @@ from grizzly.exceptions import StopUser, RestartScenario
 from tests.fixtures import GrizzlyFixture, MockerFixture
 
 
-def test_task_failing(grizzly_fixture: GrizzlyFixture, mocker: MockerFixture, caplog: LogCaptureFixture) -> None:
+@pytest.mark.parametrize('log_prefix', [False, True,])
+def test_task_failing(grizzly_fixture: GrizzlyFixture, mocker: MockerFixture, caplog: LogCaptureFixture, log_prefix: bool) -> None:
+    try:
+        @client('test')
+        class TestClientTask(ClientTask):
+            __scenario__ = grizzly_fixture.grizzly.scenario
 
-    @client('test')
-    class TestTask(ClientTask):
-        __scenario__ = grizzly_fixture.grizzly.scenario
+            def get(self, parent: GrizzlyScenario) -> GrizzlyResponse:
+                with self.action(parent):
+                    raise RuntimeError('failed get')
 
-        def get(self, parent: GrizzlyScenario) -> GrizzlyResponse:
-            with self.action(parent):
-                raise RuntimeError('failed get')
+            def put(self, parent: GrizzlyScenario) -> GrizzlyResponse:
+                return None, 'put'
 
-        def put(self, parent: GrizzlyScenario) -> GrizzlyResponse:
-            return None, 'put'
+        if log_prefix:
+            environ['GRIZZLY_LOG_DIR'] = 'foobar'
 
-    parent = grizzly_fixture(scenario_type=IteratorScenario)
+        parent = grizzly_fixture(scenario_type=IteratorScenario)
 
-    assert isinstance(parent, IteratorScenario)
+        assert isinstance(parent, IteratorScenario)
 
-    parent.user._context.update({'test': 'was here'})
+        parent.user._context.update({'test': 'was here'})
 
-    task_factory = TestTask(RequestDirection.FROM, 'test://foo.bar', 'dummy-stuff')
+        task_factory = TestClientTask(RequestDirection.FROM, 'test://foo.bar', 'dummy-stuff')
 
-    task = task_factory()
+        assert (Path(environ['GRIZZLY_CONTEXT_ROOT']) / 'logs').exists()
 
-    assert task_factory._context.get('test', None) is None
-    parent.user._scenario.failure_exception = StopUser
+        if log_prefix:
+            assert (Path(environ['GRIZZLY_CONTEXT_ROOT']) / 'logs' / 'foobar').exists()
+        else:
+            assert not (Path(environ['GRIZZLY_CONTEXT_ROOT']) / 'logs' / 'foobar').exists()
 
-    with pytest.raises(StopUser):
+        task = task_factory()
+
+        assert task_factory._context.get('test', None) is None
+        parent.user._scenario.failure_exception = StopUser
+
+        with pytest.raises(StopUser):
+            task(parent)
+
+        assert task_factory._context.get('test', None) == 'was here'
+
+        parent.user._scenario.failure_exception = RestartScenario
+        parent.user._context.update({'test': 'is here', 'foo': 'bar'})
+
+        assert task_factory._context.get('foo', None) is None
+
+        with pytest.raises(RestartScenario):
+            task(parent)
+
+        assert parent.user._context.get('test', None) == 'is here'
+        assert parent.user._context.get('foo', None) == 'bar'
+
+        parent.user._scenario.failure_exception = None
+
         task(parent)
 
-    assert task_factory._context.get('test', None) == 'was here'
+        log_error_mock = mocker.patch.object(parent.stats, 'log_error')
+        mocker.patch.object(parent, 'on_start', return_value=None)
+        mocker.patch.object(parent, 'wait', side_effect=[NotImplementedError, NotImplementedError])
+        parent.user.environment.catch_exceptions = True
+        parent.user._scenario.failure_exception = RestartScenario
 
-    parent.user._scenario.failure_exception = RestartScenario
-    parent.user._context.update({'test': 'is here', 'foo': 'bar'})
+        parent.tasks.clear()
+        parent._task_queue.clear()
+        parent._task_queue.append(task)
+        parent.task_count = 1
 
-    assert task_factory._context.get('foo', None) is None
+        with pytest.raises(NotImplementedError):
+            with caplog.at_level(logging.INFO):
+                parent.run()
 
-    with pytest.raises(RestartScenario):
-        task(parent)
+        log_error_mock.assert_called_once_with(None)
 
-    assert parent.user._context.get('test', None) == 'is here'
-    assert parent.user._context.get('foo', None) == 'bar'
-
-    parent.user._scenario.failure_exception = None
-
-    task(parent)
-
-    log_error_mock = mocker.patch.object(parent.stats, 'log_error')
-    mocker.patch.object(parent, 'on_start', return_value=None)
-    mocker.patch.object(parent, 'wait', side_effect=[NotImplementedError, NotImplementedError])
-    parent.user.environment.catch_exceptions = True
-    parent.user._scenario.failure_exception = RestartScenario
-
-    parent.tasks.clear()
-    parent._task_queue.clear()
-    parent._task_queue.append(task)
-    parent.task_count = 1
-
-    with pytest.raises(NotImplementedError):
-        with caplog.at_level(logging.INFO):
-            parent.run()
-
-    log_error_mock.assert_called_once_with(None)
-
-    assert 'restarting scenario' in '\n'.join(caplog.messages)
+        assert 'restarting scenario' in '\n'.join(caplog.messages)
+    finally:
+        try:
+            del environ['GRIZZLY_LOG_DIR']
+        except:
+            pass

--- a/tests/unit/test_grizzly/tasks/clients/test_http.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_http.py
@@ -2,6 +2,7 @@ from typing import cast
 from json import dumps as jsondumps, loads as jsonloads
 from unittest.mock import ANY
 from itertools import cycle
+from os import environ
 
 import pytest
 
@@ -46,255 +47,274 @@ class TestHttpClientTask:
         assert task_factory.headers == {'x-grizzly-user': ANY, 'x-test-header': 'foobar'}
         assert task_factory._context.get('test', None) == 'was here'
 
-    def test_get(self, mocker: MockerFixture, grizzly_fixture: GrizzlyFixture) -> None:
-        behave = grizzly_fixture.behave.context
-        grizzly = cast(GrizzlyContext, behave.grizzly)
+    @pytest.mark.parametrize('log_prefix', [False, True,])
+    def test_get(self, mocker: MockerFixture, grizzly_fixture: GrizzlyFixture, log_prefix: bool) -> None:
+        try:
+            if log_prefix:
+                environ['GRIZZLY_LOG_DIR'] = 'foobar'
 
-        HttpClientTask.__scenario__ = grizzly.scenario
+            behave = grizzly_fixture.behave.context
+            grizzly = cast(GrizzlyContext, behave.grizzly)
 
-        with pytest.raises(AttributeError) as ae:
-            HttpClientTask(RequestDirection.TO, 'http://example.org', payload_variable='test')
-        assert 'HttpClientTask: variable argument is not applicable for direction TO' in str(ae.value)
+            HttpClientTask.__scenario__ = grizzly.scenario
 
-        with pytest.raises(AttributeError) as ae:
-            HttpClientTask(RequestDirection.FROM, 'http://example.org', source='test')
-        assert 'HttpClientTask: source argument is not applicable for direction FROM' in str(ae.value)
+            with pytest.raises(AttributeError) as ae:
+                HttpClientTask(RequestDirection.TO, 'http://example.org', payload_variable='test')
+            assert 'HttpClientTask: variable argument is not applicable for direction TO' in str(ae.value)
 
-        with pytest.raises(ValueError) as ve:
-            HttpClientTask(RequestDirection.FROM, 'http://example.org', payload_variable='test')
-        assert 'HttpClientTask: variable test has not been initialized' in str(ve)
+            with pytest.raises(AttributeError) as ae:
+                HttpClientTask(RequestDirection.FROM, 'http://example.org', source='test')
+            assert 'HttpClientTask: source argument is not applicable for direction FROM' in str(ae.value)
 
-        with pytest.raises(ValueError) as ve:
-            HttpClientTask(RequestDirection.FROM, 'http://example.org', payload_variable=None, metadata_variable='test')
-        assert 'HttpClientTask: variable test has not been initialized' in str(ve)
+            with pytest.raises(ValueError) as ve:
+                HttpClientTask(RequestDirection.FROM, 'http://example.org', payload_variable='test')
+            assert 'HttpClientTask: variable test has not been initialized' in str(ve)
 
-        response = Response()
-        response.url = 'http://example.org'
-        response._content = jsondumps({'hello': 'world'}).encode()
-        response.status_code = 200
+            with pytest.raises(ValueError) as ve:
+                HttpClientTask(RequestDirection.FROM, 'http://example.org', payload_variable=None, metadata_variable='test')
+            assert 'HttpClientTask: variable test has not been initialized' in str(ve)
 
-        requests_get_spy = mocker.patch(
-            'grizzly.tasks.clients.http.requests.get',
-            side_effect=[response, RuntimeError, RuntimeError, RuntimeError, RuntimeError, response, response, response, response]
-        )
+            response = Response()
+            response.url = 'http://example.org'
+            response._content = jsondumps({'hello': 'world'}).encode()
+            response.status_code = 200
 
-        grizzly.state.variables.update({'test': 'none'})
+            requests_get_spy = mocker.patch(
+                'grizzly.tasks.clients.http.requests.get',
+                side_effect=[response, RuntimeError, RuntimeError, RuntimeError, RuntimeError, response, response, response, response]
+            )
 
-        with pytest.raises(ValueError) as ve:
-            HttpClientTask(RequestDirection.FROM, 'http://example.org', payload_variable=None, metadata_variable='test')
-        assert 'HttpClientTask: payload variable is not set, but metadata variable is set' in str(ve)
+            grizzly.state.variables.update({'test': 'none'})
 
-        parent = grizzly_fixture()
-        parent.user._context.update({'test': 'was here'})
+            with pytest.raises(ValueError) as ve:
+                HttpClientTask(RequestDirection.FROM, 'http://example.org', payload_variable=None, metadata_variable='test')
+            assert 'HttpClientTask: payload variable is not set, but metadata variable is set' in str(ve)
 
-        request_fire_spy = mocker.spy(parent.user.environment.events.request, 'fire')
+            parent = grizzly_fixture()
+            parent.user._context.update({'test': 'was here'})
 
-        grizzly.state.variables.update({'test_payload': 'none', 'test_metadata': 'none'})
+            request_fire_spy = mocker.spy(parent.user.environment.events.request, 'fire')
 
-        task_factory = HttpClientTask(RequestDirection.FROM, 'http://example.org', payload_variable='test_payload', metadata_variable='test_metadata')
-        assert task_factory.arguments == {}
-        assert task_factory.__template_attributes__ == {'endpoint', 'destination', 'source', 'name', 'variable_template'}
+            grizzly.state.variables.update({'test_payload': 'none', 'test_metadata': 'none'})
 
-        task = task_factory()
+            task_factory = HttpClientTask(RequestDirection.FROM, 'http://example.org', payload_variable='test_payload', metadata_variable='test_metadata')
+            assert task_factory.arguments == {}
+            assert task_factory.__template_attributes__ == {'endpoint', 'destination', 'source', 'name', 'variable_template'}
 
-        assert callable(task)
+            task = task_factory()
 
-        assert parent.user._context['variables'].get('test_payload', None) is None
-        assert parent.user._context['variables'].get('test_metadata', None) is None
-        assert task_factory._context.get('test', None) is None
+            assert callable(task)
 
-        task_factory.name = 'test-1'
-        response.status_code = 400
-        response.headers = CaseInsensitiveDict({'x-foo-bar': 'test'})
+            assert parent.user._context['variables'].get('test_payload', None) is None
+            assert parent.user._context['variables'].get('test_metadata', None) is None
+            assert task_factory._context.get('test', None) is None
 
-        task(parent)
+            task_factory.name = 'test-1'
+            response.status_code = 400
+            response.headers = CaseInsensitiveDict({'x-foo-bar': 'test'})
 
-        assert task_factory._context.get('test', None) == 'was here'
-        assert parent.user._context['variables'].get('test_payload', None) is None
-        assert parent.user._context['variables'].get('test_metadata', None) is None
-        assert requests_get_spy.call_count == 1
-        args, kwargs = requests_get_spy.call_args_list[-1]
-        assert args[0] == 'http://example.org'
-        assert len(kwargs) == 2
-        assert kwargs.get('headers', {}).get('x-grizzly-user', None).startswith('HttpClientTask::')
-        assert kwargs.get('cookies', None) == {}
-
-        assert request_fire_spy.call_count == 1
-        _, kwargs = request_fire_spy.call_args_list[-1]
-        assert kwargs.get('request_type', None) == 'CLTSK'
-        assert kwargs.get('name', None) == f'{parent.user._scenario.identifier} test-1'
-        assert kwargs.get('response_time', None) >= 0.0
-        assert kwargs.get('response_length') == len(jsondumps({'hello': 'world'}))
-        assert kwargs.get('context', None) is parent.user._context
-        exception = kwargs.get('exception', None)
-        assert isinstance(exception, CatchResponseError)
-        assert str(exception) == '400 not in [200]: {"hello": "world"}'
-
-        request_logs = list(task_factory.log_dir.rglob('**/*'))
-        assert len(request_logs) == 1
-        request_log = request_logs[-1]
-        log_entry = jsonloads(request_log.read_text())
-        assert log_entry.get('request', {}).get('time', None) >= 0.0
-        assert log_entry.get('request', {}).get('url', None) == 'http://example.org'
-        assert log_entry.get('request', {}).get('metadata', None) is not None
-        assert log_entry.get('request', {}).get('payload', '') is None
-        assert log_entry.get('response', {}).get('url', None) == 'http://example.org'
-        assert log_entry.get('response', {}).get('metadata', None) == {'x-foo-bar': 'test'}
-        assert log_entry.get('response', {}).get('payload', None) is not None
-        assert log_entry.get('response', {}).get('status', None) == 400
-
-        parent.user._context['variables']['test'] = None
-        response.status_code = 200
-        task_factory.name = 'test-2'
-
-        task(parent)
-
-        assert parent.user._context['variables'].get('test', '') is None  # not set
-        assert requests_get_spy.call_count == 2
-        args, kwargs = requests_get_spy.call_args_list[-1]
-        assert args[0] == 'http://example.org'
-        assert len(kwargs) == 2
-        assert kwargs.get('headers', {}).get('x-grizzly-user', None).startswith('HttpClientTask::')
-        assert kwargs.get('cookies', None) == {}
-
-        assert request_fire_spy.call_count == 2
-        _, kwargs = request_fire_spy.call_args_list[-1]
-        assert kwargs.get('request_type', None) == 'CLTSK'
-        assert kwargs.get('name', None) == f'{parent.user._scenario.identifier} test-2'
-        assert kwargs.get('response_time', None) >= 0.0
-        assert kwargs.get('response_length') == 0
-        assert kwargs.get('context', None) is parent.user._context
-        assert isinstance(kwargs.get('exception', None), RuntimeError)
-        assert len(list(task_factory.log_dir.rglob('**/*'))) == 2
-
-        parent.user._scenario.failure_exception = StopUser
-        task_factory.name = 'test-3'
-
-        with pytest.raises(StopUser):
             task(parent)
 
-        parent.user._scenario.failure_exception = RestartScenario
-        task_factory.name = 'test-4'
+            assert task_factory._context.get('test', None) == 'was here'
+            assert parent.user._context['variables'].get('test_payload', None) is None
+            assert parent.user._context['variables'].get('test_metadata', None) is None
+            assert requests_get_spy.call_count == 1
+            args, kwargs = requests_get_spy.call_args_list[-1]
+            assert args[0] == 'http://example.org'
+            assert len(kwargs) == 2
+            assert kwargs.get('headers', {}).get('x-grizzly-user', None).startswith('HttpClientTask::')
+            assert kwargs.get('cookies', None) == {}
 
-        with pytest.raises(RestartScenario):
+            assert request_fire_spy.call_count == 1
+            _, kwargs = request_fire_spy.call_args_list[-1]
+            assert kwargs.get('request_type', None) == 'CLTSK'
+            assert kwargs.get('name', None) == f'{parent.user._scenario.identifier} test-1'
+            assert kwargs.get('response_time', None) >= 0.0
+            assert kwargs.get('response_length') == len(jsondumps({'hello': 'world'}))
+            assert kwargs.get('context', None) is parent.user._context
+            exception = kwargs.get('exception', None)
+            assert isinstance(exception, CatchResponseError)
+            assert str(exception) == '400 not in [200]: {"hello": "world"}'
+
+            request_logs = list(task_factory.log_dir.rglob('**/*'))
+            assert len(request_logs) == 1
+            request_log = request_logs[-1]
+            parent_name = 'foobar' if log_prefix else 'logs'
+            assert request_log.parent.name == parent_name
+
+            log_entry = jsonloads(request_log.read_text())
+            assert log_entry.get('request', {}).get('time', None) >= 0.0
+            assert log_entry.get('request', {}).get('url', None) == 'http://example.org'
+            assert log_entry.get('request', {}).get('metadata', None) is not None
+            assert log_entry.get('request', {}).get('payload', '') is None
+            assert log_entry.get('response', {}).get('url', None) == 'http://example.org'
+            assert log_entry.get('response', {}).get('metadata', None) == {'x-foo-bar': 'test'}
+            assert log_entry.get('response', {}).get('payload', None) is not None
+            assert log_entry.get('response', {}).get('status', None) == 400
+
+            parent.user._context['variables']['test'] = None
+            response.status_code = 200
+            task_factory.name = 'test-2'
+
             task(parent)
 
-        assert parent.user._context['variables'].get('test', '') is None  # not set
-        assert requests_get_spy.call_count == 4
-        args, kwargs = requests_get_spy.call_args_list[-1]
-        assert args[0] == 'http://example.org'
-        assert len(kwargs) == 2
-        assert kwargs.get('headers', {}).get('x-grizzly-user', None).startswith('HttpClientTask::')
-        assert kwargs.get('cookies', None) == {}
+            assert parent.user._context['variables'].get('test', '') is None  # not set
+            assert requests_get_spy.call_count == 2
+            args, kwargs = requests_get_spy.call_args_list[-1]
+            assert args[0] == 'http://example.org'
+            assert len(kwargs) == 2
+            assert kwargs.get('headers', {}).get('x-grizzly-user', None).startswith('HttpClientTask::')
+            assert kwargs.get('cookies', None) == {}
 
-        assert request_fire_spy.call_count == 4
-        _, kwargs = request_fire_spy.call_args_list[-1]
-        assert kwargs.get('request_type', None) == 'CLTSK'
-        assert kwargs.get('name', None) == f'{parent.user._scenario.identifier} test-4'
-        assert kwargs.get('response_time', None) >= 0.0
-        assert kwargs.get('response_length') == 0
-        assert kwargs.get('context', None) is parent.user._context
-        assert isinstance(kwargs.get('exception', None), RuntimeError)
-        assert len(list(task_factory.log_dir.rglob('**/*'))) == 4
+            assert request_fire_spy.call_count == 2
+            _, kwargs = request_fire_spy.call_args_list[-1]
+            assert kwargs.get('request_type', None) == 'CLTSK'
+            assert kwargs.get('name', None) == f'{parent.user._scenario.identifier} test-2'
+            assert kwargs.get('response_time', None) >= 0.0
+            assert kwargs.get('response_length') == 0
+            assert kwargs.get('context', None) is parent.user._context
+            assert isinstance(kwargs.get('exception', None), RuntimeError)
+            assert len(list(task_factory.log_dir.rglob('**/*'))) == 2
 
-        parent.user._scenario.failure_exception = None
+            parent.user._scenario.failure_exception = StopUser
+            task_factory.name = 'test-3'
 
-        task_factory = HttpClientTask(RequestDirection.FROM, 'http://example.org', 'http-get', payload_variable='test')
-        task = task_factory()
-        assert task_factory.arguments == {}
-        assert task_factory.content_type == TransformerContentType.UNDEFINED
+            with pytest.raises(StopUser):
+                task(parent)
 
-        task(parent)
+            parent.user._scenario.failure_exception = RestartScenario
+            task_factory.name = 'test-4'
 
-        assert parent.user._context['variables'].get('test', '') is None  # not set
-        assert requests_get_spy.call_count == 5
-        args, kwargs = requests_get_spy.call_args_list[-1]
-        assert args[0] == 'http://example.org'
-        assert len(kwargs) == 2
-        assert kwargs.get('headers', {}).get('x-grizzly-user', None).startswith('HttpClientTask::')
-        assert kwargs.get('cookies', None) == {}
+            with pytest.raises(RestartScenario):
+                task(parent)
 
-        assert request_fire_spy.call_count == 5
-        _, kwargs = request_fire_spy.call_args_list[-1]
-        assert kwargs.get('request_type', None) == 'CLTSK'
-        assert kwargs.get('name', None) == f'{parent.user._scenario.identifier} http-get'
-        assert kwargs.get('response_time', None) >= 0.0
-        assert kwargs.get('response_length') == 0
-        assert kwargs.get('context', None) is parent.user._context
-        assert isinstance(kwargs.get('exception', None), RuntimeError)
-        assert len(list(task_factory.log_dir.rglob('**/*'))) == 5
+            assert parent.user._context['variables'].get('test', '') is None  # not set
+            assert requests_get_spy.call_count == 4
+            args, kwargs = requests_get_spy.call_args_list[-1]
+            assert args[0] == 'http://example.org'
+            assert len(kwargs) == 2
+            assert kwargs.get('headers', {}).get('x-grizzly-user', None).startswith('HttpClientTask::')
+            assert kwargs.get('cookies', None) == {}
 
-        grizzly.state.configuration['test.host'] = 'https://example.org'
+            assert request_fire_spy.call_count == 4
+            _, kwargs = request_fire_spy.call_args_list[-1]
+            assert kwargs.get('request_type', None) == 'CLTSK'
+            assert kwargs.get('name', None) == f'{parent.user._scenario.identifier} test-4'
+            assert kwargs.get('response_time', None) >= 0.0
+            assert kwargs.get('response_length') == 0
+            assert kwargs.get('context', None) is parent.user._context
+            assert isinstance(kwargs.get('exception', None), RuntimeError)
+            assert len(list(task_factory.log_dir.rglob('**/*'))) == 4
 
-        task_factory = HttpClientTask(RequestDirection.FROM, 'https://$conf::test.host$/api/test', 'http-env-get', payload_variable='test')
-        assert task_factory.arguments == {'verify': True}
-        assert task_factory.content_type == TransformerContentType.UNDEFINED
-        task = task_factory()
-        response.url = 'https://example.org/api/test'
-        requests_get_spy.side_effect = cycle([response])
+            parent.user._scenario.failure_exception = None
 
-        task(parent)
+            task_factory = HttpClientTask(RequestDirection.FROM, 'http://example.org', 'http-get', payload_variable='test')
+            task = task_factory()
+            assert task_factory.arguments == {}
+            assert task_factory.content_type == TransformerContentType.UNDEFINED
 
-        assert requests_get_spy.call_count == 6
-        args, kwargs = requests_get_spy.call_args_list[-1]
-        assert args[0] == 'https://example.org/api/test'
-        assert len(kwargs) == 3
-        assert kwargs.get('verify', None)
-        assert kwargs.get('headers', {}).get('x-grizzly-user', None).startswith('HttpClientTask::')
-        assert kwargs.get('cookies', None) == {}
+            task(parent)
 
-        print(list(task_factory.log_dir.rglob('**/*')))
+            assert parent.user._context['variables'].get('test', '') is None  # not set
+            assert requests_get_spy.call_count == 5
+            args, kwargs = requests_get_spy.call_args_list[-1]
+            assert args[0] == 'http://example.org'
+            assert len(kwargs) == 2
+            assert kwargs.get('headers', {}).get('x-grizzly-user', None).startswith('HttpClientTask::')
+            assert kwargs.get('cookies', None) == {}
 
-        assert len(list(task_factory.log_dir.rglob('**/*'))) == 5
+            assert request_fire_spy.call_count == 5
+            _, kwargs = request_fire_spy.call_args_list[-1]
+            assert kwargs.get('request_type', None) == 'CLTSK'
+            assert kwargs.get('name', None) == f'{parent.user._scenario.identifier} http-get'
+            assert kwargs.get('response_time', None) >= 0.0
+            assert kwargs.get('response_length') == 0
+            assert kwargs.get('context', None) is parent.user._context
+            assert isinstance(kwargs.get('exception', None), RuntimeError)
+            assert len(list(task_factory.log_dir.rglob('**/*'))) == 5
 
-        task_factory = HttpClientTask(RequestDirection.FROM, 'https://$conf::test.host$/api/test | verify=False, content_type=json', 'http-env-get-1', payload_variable='test')
-        task = task_factory()
-        assert task_factory.arguments == {'verify': False}
-        assert task_factory.content_type == TransformerContentType.JSON
-        assert len(list(task_factory.log_dir.rglob('**/*'))) == 5
+            grizzly.state.configuration['test.host'] = 'https://example.org'
 
-        task(parent)
+            task_factory = HttpClientTask(RequestDirection.FROM, 'https://$conf::test.host$/api/test', 'http-env-get', payload_variable='test')
+            assert task_factory.arguments == {'verify': True}
+            assert task_factory.content_type == TransformerContentType.UNDEFINED
+            task = task_factory()
+            response.url = 'https://example.org/api/test'
+            requests_get_spy.side_effect = cycle([response])
 
-        assert requests_get_spy.call_count == 7
-        args, kwargs = requests_get_spy.call_args_list[-1]
-        assert args[0] == 'https://example.org/api/test'
-        assert len(kwargs) == 3
-        assert not kwargs.get('verify', None)
-        assert kwargs.get('headers', {}).get('x-grizzly-user', None).startswith('HttpClientTask::')
-        assert kwargs.get('cookies', None) == {}
-        assert request_fire_spy.call_count == 7
-        assert len(list(task_factory.log_dir.rglob('**/*'))) == 5
+            task(parent)
 
-        task_factory = HttpClientTask(RequestDirection.FROM, 'https://$conf::test.host$/api/test | verify=True, content_type=json', 'http-env-get-2', payload_variable='test')
-        task = task_factory()
-        assert task_factory.arguments == {'verify': True}
-        assert task_factory.content_type == TransformerContentType.JSON
+            assert requests_get_spy.call_count == 6
+            args, kwargs = requests_get_spy.call_args_list[-1]
+            assert args[0] == 'https://example.org/api/test'
+            assert len(kwargs) == 3
+            assert kwargs.get('verify', None)
+            assert kwargs.get('headers', {}).get('x-grizzly-user', None).startswith('HttpClientTask::')
+            assert kwargs.get('cookies', None) == {}
 
-        parent.user._scenario.context['log_all_requests'] = True
-        task_factory._context['metadata'] = {'x-test-header': 'foobar'}
+            print(list(task_factory.log_dir.rglob('**/*')))
 
-        task.on_start(parent)
+            assert len(list(task_factory.log_dir.rglob('**/*'))) == 5
 
-        assert task_factory.headers.get('x-test-header', None) == 'foobar'
+            task_factory = HttpClientTask(RequestDirection.FROM, 'https://$conf::test.host$/api/test | verify=False, content_type=json', 'http-env-get-1', payload_variable='test')
+            task = task_factory()
+            assert task_factory.arguments == {'verify': False}
+            assert task_factory.content_type == TransformerContentType.JSON
+            assert len(list(task_factory.log_dir.rglob('**/*'))) == 5
 
-        task(parent)
+            task(parent)
 
-        assert requests_get_spy.call_count == 8
-        args, kwargs = requests_get_spy.call_args_list[-1]
-        assert args[0] == 'https://example.org/api/test'
-        assert len(kwargs) == 3
-        assert kwargs.get('verify', None)
-        headers = kwargs.get('headers', {})
-        assert headers.get('x-grizzly-user', None).startswith('HttpClientTask::')
-        assert headers.get('x-test-header', None) == 'foobar'
-        assert kwargs.get('cookies', None) == {}
-        assert request_fire_spy.call_count == 8
-        args, kwargs = request_fire_spy.call_args_list[-1]
-        assert len(list(task_factory.log_dir.rglob('**/*'))) == 6
+            assert requests_get_spy.call_count == 7
+            args, kwargs = requests_get_spy.call_args_list[-1]
+            assert args[0] == 'https://example.org/api/test'
+            assert len(kwargs) == 3
+            assert not kwargs.get('verify', None)
+            assert kwargs.get('headers', {}).get('x-grizzly-user', None).startswith('HttpClientTask::')
+            assert kwargs.get('cookies', None) == {}
+            assert request_fire_spy.call_count == 7
+            assert len(list(task_factory.log_dir.rglob('**/*'))) == 5
 
-        with pytest.raises(NotImplementedError) as nie:
-            HttpClientTask(RequestDirection.FROM, 'https://$conf::test.host$/api/test | verify=True, content_type=json', 'http-env-get-2', payload_variable='test', text='foobar')
-        assert str(nie.value) == 'HttpClientTask has not implemented support for step text'
+            task_factory = HttpClientTask(RequestDirection.FROM, 'https://$conf::test.host$/api/test | verify=True, content_type=json', 'http-env-get-2', payload_variable='test')
+            task = task_factory()
+            assert task_factory.arguments == {'verify': True}
+            assert task_factory.content_type == TransformerContentType.JSON
+
+            parent.user._scenario.context['log_all_requests'] = True
+            task_factory._context['metadata'] = {'x-test-header': 'foobar'}
+
+            task.on_start(parent)
+
+            assert task_factory.headers.get('x-test-header', None) == 'foobar'
+
+            task(parent)
+
+            assert requests_get_spy.call_count == 8
+            args, kwargs = requests_get_spy.call_args_list[-1]
+            assert args[0] == 'https://example.org/api/test'
+            assert len(kwargs) == 3
+            assert kwargs.get('verify', None)
+            headers = kwargs.get('headers', {})
+            assert headers.get('x-grizzly-user', None).startswith('HttpClientTask::')
+            assert headers.get('x-test-header', None) == 'foobar'
+            assert kwargs.get('cookies', None) == {}
+            assert request_fire_spy.call_count == 8
+            args, kwargs = request_fire_spy.call_args_list[-1]
+            assert len(list(task_factory.log_dir.rglob('**/*'))) == 6
+
+            with pytest.raises(NotImplementedError) as nie:
+                HttpClientTask(
+                    RequestDirection.FROM,
+                    'https://$conf::test.host$/api/test | verify=True, content_type=json',
+                    'http-env-get-2',
+                    payload_variable='test',
+                    text='foobar',
+                )
+            assert str(nie.value) == 'HttpClientTask has not implemented support for step text'
+        finally:
+            try:
+                del environ['GRIZZLY_LOG_DIR']
+            except:
+                pass
 
     def test_put(self, grizzly_fixture: GrizzlyFixture) -> None:
         HttpClientTask.__scenario__ = grizzly_fixture.grizzly.scenario


### PR DESCRIPTION
grizzly implementation of #248.