### PR TITLE
do not fire ResponseEvent for exceptions that are `StopUser` or `RestartScenario`

### DIFF
--- a/tests/e2e/test_failure.py
+++ b/tests/e2e/test_failure.py
@@ -85,3 +85,7 @@ def test_e2e_failure(e2e_fixture: End2EndFixture) -> None:
 
     assert rc == 1
     assert "HOOK-ERROR in after_feature: RuntimeError: locust test failed" in ''.join(output)
+
+    log_files = list((e2e_fixture.root / 'features' / 'logs').glob('*.log'))
+
+    assert len(log_files) == 3


### PR DESCRIPTION
this would result in two request log files, one for the actual request and a more or less empty one for the exception.