### PR TITLE
keystore -- share testdata between scenarios

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -142,6 +142,15 @@ jobs:
       with:
         version: '2.20.3'
 
+    - name: pre docker debug
+      id: pre-docker-debug
+      if: matrix.run_mode == 'dist'
+      run: |
+        docker version || true
+        docker container ls -a || true
+        ls -l /var/run/docker.sock || true
+        docker compose || true
+
     - name: ssh agent
       id: ssh-agent
       run: |
@@ -152,6 +161,15 @@ jobs:
       env:
         SSH_AUTH_SOCK: /tmp/ssh_auth_sock
       run: python -m pytest tests/e2e
+
+    - name: post docker debug
+      id: post-docker-debug
+      if: matrix.run_mode == 'dist' && always()
+      run: |
+        docker version || true
+        docker container ls -a || true
+        ls -l /var/run/docker.sock || true
+        docker compose || true
 
   pre-documentation-scripts:
     name: 'documentation / script inventory'

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+opensource@biometria.se.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/grizzly/gevent.py
+++ b/grizzly/gevent.py
@@ -21,14 +21,21 @@ class GreenletWithExceptionCatching(Greenlet):
                 return func(*args, **kwargs)
             except Exception as exception:
                 self.wrap_exceptions(self.handle_exception)(exception)
-                return exception
+                return exception  # pragma: no cover
 
         return exception_handler
 
-    def spawn(self, func: Callable, *args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> Greenlet:
-        func_wrap = self.wrap_exceptions(func)
-        return super().spawn(func_wrap, *args, **kwargs)
+    def spawn(self, func: Callable, *args: Any, **kwargs: Any) -> Greenlet:
+        return super().spawn(
+            self.wrap_exceptions(func),
+            *args,
+            **kwargs,
+        )
 
-    def spawn_later(self, seconds: int, func: Callable, *args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> Greenlet:
-        func_wrap = self.wrap_exceptions(func)
-        return super().spawn_later(seconds, func_wrap, *args, **kwargs)
+    def spawn_later(self, seconds: int, func: Callable, *args: Any, **kwargs: Any) -> Greenlet:
+        return super().spawn_later(
+            seconds,
+            self.wrap_exceptions(func),
+            *args,
+            **kwargs,
+        )

--- a/grizzly/scenarios/iterator.py
+++ b/grizzly/scenarios/iterator.py
@@ -147,6 +147,8 @@ class IteratorScenario(GrizzlyScenario):
                         self.logger.error('on_stop failed', exc_info=True)
 
                     # to avoid spawning of a new user, we should wait until spawning is complete
+                    # if we abort too soon, locust will see that there are too few users, and spawn
+                    # another one
                     if has_error:
                         count = 0
                         while not self.grizzly.state.spawning_complete:

--- a/grizzly/scenarios/iterator.py
+++ b/grizzly/scenarios/iterator.py
@@ -222,7 +222,7 @@ class IteratorScenario(GrizzlyScenario):
         # scenario timer
         self.start = perf_counter()
 
-        remote_context = self.consumer.request(self.__class__.__name__)
+        remote_context = self.consumer.testdata(self.__class__.__name__)
 
         if remote_context is None:
             self.logger.debug('no iteration data available, stop scenario')

--- a/grizzly/steps/scenario/tasks.py
+++ b/grizzly/steps/scenario/tasks.py
@@ -3,6 +3,7 @@ This module contains step implementations that creates requests executed by the 
 in the scenario.
 """
 from typing import cast
+from json import loads as jsonloads, JSONDecodeError
 
 from grizzly.types import RequestDirection, RequestMethod
 from grizzly.types.behave import Context, register_type, then, given, when
@@ -19,6 +20,7 @@ from grizzly.tasks import (
     TaskWaitTask,
     LoopTask,
     ConditionalTask,
+    KeystoreTask,
 )
 
 from grizzly_extras.transformer import TransformerContentType
@@ -865,3 +867,68 @@ def step_task_loop_end(context: Context) -> None:
     loop = grizzly.scenario.tasks.tmp.loop
     grizzly.scenario.tasks.tmp.loop = None
     grizzly.scenario.tasks.add(loop)
+
+
+@then(u'get "{key}" from keystore and save in variable "{variable}", with default value "{default_value}"')
+def step_task_keystore_get_default(context: Context, key: str, variable: str, default_value: str) -> None:
+    """
+    Get a value for `key` using the {@pylink grizzly.tasks}, if `key` does not exist in the keystore `default_value` will be used and will be set in the keystore to next
+    iteration. `default_value` must be JSON serializable (string values must be single-quoted).
+
+    See {@pylink grizzly.tasks.keystore} task documentation for more information.
+
+    Example:
+
+    ``` gherkin
+    And value for variable "foobar" is "none"
+    Then get "foobar" from keystore and save in variable "foobar", with default value "{'hello': 'world'}"
+    """
+    grizzly = cast(GrizzlyContext, context.grizzly)
+    if "'" in default_value:
+        default_value = default_value.replace("'", '"')
+
+    try:
+        grizzly.scenario.tasks.add(KeystoreTask(key, 'get', variable, jsonloads(default_value)))
+    except JSONDecodeError:
+        raise AssertionError(f'"{default_value}" is not valid JSON')
+
+
+@then(u'get "{key}" from keystore and save in variable "{variable}"')
+def step_task_keystore_get(context: Context, key: str, variable: str) -> None:
+    """
+    Get a value for `key` using the {@pylink grizzly.tasks.keystore} task.
+
+    See {@pylink grizzly.tasks.keystore} task documentation for more information.
+
+    Example:
+
+    ``` gherkin
+    And value for variable "foobar" is "none"
+    Then get "foobar" from keystore and save in variable "foobar"
+    """
+    grizzly = cast(GrizzlyContext, context.grizzly)
+    grizzly.scenario.tasks.add(KeystoreTask(key, 'get', variable))
+
+
+@then(u'set "{key}" in keystore with value "{value}"')
+def step_task_keystore_set(context: Context, key: str, value: str) -> None:
+    """
+    Set a value for `key` using the {@pylink grizzly.tasks.keystore} task. `value` must be JSON serializable (string values must be single-quoted).
+
+    See {@pylink grizzly.tasks.keystore} task documentation for more information.
+
+    Example:
+
+    ``` gherkin
+    And value for variable "foobar" is "{'hello': 'world'}"
+    Then set "foobar" in keystore with value "{{ foobar }}"
+    ```
+    """
+    grizzly = cast(GrizzlyContext, context.grizzly)
+    if "'" in value:
+        value = value.replace("'", '"')
+
+    try:
+        grizzly.scenario.tasks.add(KeystoreTask(key, 'set', jsonloads(value)))
+    except JSONDecodeError:
+        raise AssertionError(f'"{value}" is not valid JSON')

--- a/grizzly/tasks/__init__.py
+++ b/grizzly/tasks/__init__.py
@@ -58,6 +58,8 @@ from inspect import getmro
 
 from grizzly_extras.transformer import TransformerContentType
 
+from grizzly.context import GrizzlyContext
+
 if TYPE_CHECKING:  # pragma: no cover
     from grizzly.types import GrizzlyResponse
     from grizzly.scenarios import GrizzlyScenario
@@ -140,9 +142,11 @@ class GrizzlyTask(ABC):
     _context_root: str
 
     step: str
+    grizzly: GrizzlyContext
 
     def __init__(self) -> None:
         self._context_root = environ.get('GRIZZLY_CONTEXT_ROOT', '.')
+        self.grizzly = GrizzlyContext()
 
     @abstractmethod
     def __call__(self) -> grizzlytask:
@@ -255,6 +259,7 @@ from .task_wait import TaskWaitTask
 from .conditional import ConditionalTask
 from .loop import LoopTask
 from .set_variable import SetVariableTask
+from .keystore import KeystoreTask
 
 
 __all__ = [
@@ -272,4 +277,5 @@ __all__ = [
     'ConditionalTask',
     'LoopTask',
     'SetVariableTask',
+    'KeystoreTask',
 ]

--- a/grizzly/tasks/clients/__init__.py
+++ b/grizzly/tasks/clients/__init__.py
@@ -86,8 +86,6 @@ class ClientTask(GrizzlyMetaRequestTask):
     ) -> None:
         super().__init__()
 
-        self.grizzly = GrizzlyContext()
-
         if text is not None:
             self.text = text
         else:

--- a/grizzly/tasks/keystore.py
+++ b/grizzly/tasks/keystore.py
@@ -1,23 +1,39 @@
 """
 @anchor pydoc:grizzly.tasks.keystore Keystore task
-This tasks sets and gets values from a distributed keystore.
+This tasks sets and gets values from a distributed keystore. This makes is possible to share values between scenarios.
+
+Retreived (get) values are rendered before setting the variable.
+Stored (set) values are not rendered, so it is possible to store templates.
+
+The whole keystore is persistent, so anything stored will be loaded the next time the scenario runs.
 
 ## Step implementations
 
-@TODO
+* {@pylink grizzly.steps.scenario.tasks.step_task_keystore_get}
+
+* {@pylink grizzly.steps.scenario.tasks.step_task_keystore_get_default}
+
+* {@pylink grizzly.steps.scenario.tasks.step_task_keystore_set}
 
 ## Statistics
 
-This task does not have any request statistics entries.
+This task only has request statistics entry, of type `KEYS`, if a key (without `default_value`) that does not have a value set is retrieved.
 
 ## Arguments
 
-*
+* `key` _str_: name of key in keystore
+
+* `action` _Action_: literal `set` or `get`
+
+* `action_context` _str | Any_: when `action` is `get` it must be a `str` (variable name), for `set` any goes (as long as it is json serializable and not `None`)
+
+* `default_value` _Any (Optional)_: used when `action` is `get` and `key` does not exist in the keystore
 """
 from __future__ import annotations
-from typing import Any, Literal, TYPE_CHECKING
+from typing import Any, Literal, Optional, Union, TYPE_CHECKING, cast
+from json import loads as jsonloads, dumps as jsondumps
 
-from . import GrizzlyTask, grizzlytask
+from . import GrizzlyTask, grizzlytask, template
 
 if TYPE_CHECKING:  # pragma: no cover
     from grizzly.scenarios import GrizzlyScenario
@@ -25,21 +41,61 @@ if TYPE_CHECKING:  # pragma: no cover
 Action = Literal['get', 'set']
 
 
+@template('action_context')
 class KeystoreTask(GrizzlyTask):
     key: str
-    variable: str
     action: Action
+    action_context: Union[str, Optional[Any]]
+    default_value: Optional[Any]
 
-    def __init__(self, key: str, variable: str, action: Action) -> None:
+    def __init__(self, key: str, action: Action, action_context: Union[str, Any], default_value: Optional[Any] = None) -> None:
         super().__init__()
 
         self.key = key
-        self.variable = variable
         self.action = action
+        self.action_context = action_context
+        self.default_value = default_value
+
+        if self.action == 'get':
+            assert isinstance(self.action_context, str), 'action context for get must be a string'
+            assert action_context in self.grizzly.state.variables, f'{action_context} has not been initialized'
+        elif self.action == 'set':
+            assert self.action_context is not None, 'action context for set cannot be None'
+        else:
+            raise AssertionError(f'{self.action} is not a valid action')
 
     def __call__(self) -> grizzlytask:
         @grizzlytask
         def task(parent: GrizzlyScenario) -> Any:
-            return None
+            try:
+                if self.action == 'get':
+                    value = parent.consumer.keystore_get(self.key)
+
+                    if value is None and self.default_value is not None:
+                        parent.consumer.keystore_set(self.key, self.default_value)
+                        value = cast(Any, self.default_value)
+
+                    if value is not None:
+                        parent.user._context['variables'][self.action_context] = jsonloads(parent.render(jsondumps(value)))
+                    else:
+                        raise RuntimeError(f'key {self.key} does not exist in keystore')
+                elif self.action == 'set':
+                    # do not render set values, might want it to be a template
+                    parent.consumer.keystore_set(self.key, self.action_context)
+                else:  # pragma: no cover
+                    pass
+            except Exception as e:
+                parent.user.logger.error(str(e))
+                parent.user.environment.events.request.fire(
+                    request_type='KEYS',
+                    name=f'{parent.user._scenario.identifier} {self.key}',
+                    response_time=0,
+                    response_length=1,
+                    context=parent.user._context,
+                    exception=e,
+                )
+
+                if parent.user._scenario.failure_exception is not None:
+                    raise parent.user._scenario.failure_exception()
 
         return task

--- a/grizzly/tasks/keystore.py
+++ b/grizzly/tasks/keystore.py
@@ -1,0 +1,45 @@
+"""
+@anchor pydoc:grizzly.tasks.keystore Keystore task
+This tasks sets and gets values from a distributed keystore.
+
+## Step implementations
+
+@TODO
+
+## Statistics
+
+This task does not have any request statistics entries.
+
+## Arguments
+
+*
+"""
+from __future__ import annotations
+from typing import Any, Literal, TYPE_CHECKING
+
+from . import GrizzlyTask, grizzlytask
+
+if TYPE_CHECKING:  # pragma: no cover
+    from grizzly.scenarios import GrizzlyScenario
+
+Action = Literal['get', 'set']
+
+
+class KeystoreTask(GrizzlyTask):
+    key: str
+    variable: str
+    action: Action
+
+    def __init__(self, key: str, variable: str, action: Action) -> None:
+        super().__init__()
+
+        self.key = key
+        self.variable = variable
+        self.action = action
+
+    def __call__(self) -> grizzlytask:
+        @grizzlytask
+        def task(parent: GrizzlyScenario) -> Any:
+            return None
+
+        return task

--- a/grizzly/tasks/request.py
+++ b/grizzly/tasks/request.py
@@ -64,7 +64,6 @@ from grizzly_extras.transformer import TransformerContentType
 from grizzly_extras.arguments import parse_arguments, split_value, unquote
 
 from grizzly.types import GrizzlyResponse, RequestMethod
-from grizzly.context import GrizzlyContext
 
 from . import GrizzlyMetaRequestTask, template, grizzlytask  # pylint: disable=unused-import
 
@@ -118,7 +117,6 @@ class RequestTask(GrizzlyMetaRequestTask):
     _source: Optional[str]
     arguments: Optional[Dict[str, str]]
     metadata: Optional[Dict[str, str]]
-    grizzly = GrizzlyContext()
     async_request: bool
 
     response: RequestTaskResponse

--- a/grizzly/testdata/communication.py
+++ b/grizzly/testdata/communication.py
@@ -1,6 +1,6 @@
 import logging
 
-from typing import TYPE_CHECKING, Dict, Optional, Any, cast
+from typing import TYPE_CHECKING, Dict, Optional, Any, Union, cast
 from os import environ
 from pathlib import Path
 from json import dumps as jsondumps, loads as jsonloads
@@ -186,7 +186,7 @@ class TestdataProducer:
 
         if self._persist_file.exists():
             persist_content = jsonloads(self._persist_file.read_text())
-            self.keystore = jsonloads(persist_content.get('grizzly::keystore', {}))
+            self.keystore = persist_content.get('grizzly::keystore', {})
         else:
             self.keystore = {}
 
@@ -202,7 +202,7 @@ class TestdataProducer:
             return
 
         try:
-            variable_state: Dict[str, str] = {}
+            variable_state: Dict[str, Union[str, Dict[str, Any]]] = {}
 
             for testdata in self.testdata.values():
                 for key, variable in testdata.items():
@@ -218,7 +218,7 @@ class TestdataProducer:
                         continue
 
             if len(self.keystore) > 0:
-                variable_state.update({'grizzly::keystore': jsondumps(self.keystore)})
+                variable_state.update({'grizzly::keystore': self.keystore})
 
             # only write file if we actually have something to write
             if len(variable_state.keys()) > 0 and len(list(chain(*variable_state.values()))) > 0:

--- a/grizzly/testdata/communication.py
+++ b/grizzly/testdata/communication.py
@@ -3,7 +3,7 @@ import logging
 from typing import TYPE_CHECKING, Dict, Optional, Any, cast
 from os import environ
 from pathlib import Path
-from json import dumps as jsondumps
+from json import dumps as jsondumps, loads as jsonloads
 from itertools import chain
 
 from zmq.error import ZMQError, Again as ZMQAgain
@@ -60,34 +60,28 @@ class TestdataConsumer:
             self.stopped = True
             gsleep(0.1)
 
-    def request(self, scenario: str) -> Optional[Dict[str, Any]]:
-        self.logger.debug('available')
-        self.socket.send_json({
-            'message': 'available',
+    def testdata(self, scenario: str) -> Optional[Dict[str, Any]]:
+        request = {
+            'message': 'testdata',
             'identifier': self.identifier,
             'scenario': scenario,
-        })
+        }
 
-        self.logger.debug('waiting for response from producer')
-        message: Dict[str, Any]
+        response = self._request(request)
 
-        # loop and NOBLOCK needed when running in local mode, to let other gevent threads get time
-        while True:
-            try:
-                message = cast(Dict[str, Any], self.socket.recv_json(flags=zmq.NOBLOCK))
-                break
-            except ZMQAgain:
-                gsleep(0.1)  # let other greenlets execute
+        if response is None:
+            self.logger.error('no testdata received')
+            return None
 
-        if message['action'] == 'stop':
+        if response['action'] == 'stop':
             self.logger.debug('received stop command')
             return None
 
-        if not message['action'] == 'consume':
-            self.logger.error(f'unknown action "{message["action"]}" received, stopping user')
+        if not response['action'] == 'consume':
+            self.logger.error(f'unknown action "{response["action"]}" received, stopping user')
             raise StopUser()
 
-        data = message['data']
+        data = response['data']
 
         self.logger.debug(f'received: {data}')
 
@@ -103,12 +97,56 @@ class TestdataConsumer:
 
         return cast(Dict[str, Any], data)
 
+    def keystore_get(self, key: str) -> Optional[Any]:
+        request = {
+            'action': 'get',
+            'key': key,
+        }
+
+        response = self._keystore_request(request)
+
+        return (response or {}).get('data', None)
+
+    def keystore_set(self, key: str, value: Any) -> None:
+        request = {
+            'action': 'set',
+            'key': key,
+            'data': value,
+        }
+
+        self._keystore_request(request)
+
+    def _keystore_request(self, request: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        request.update({
+            'message': 'keystore',
+            'identifier': self.identifier,
+        })
+
+        return self._request(request)
+
+    def _request(self, request: Dict[str, str]) -> Optional[Dict[str, Any]]:
+        self.socket.send_json(request)
+
+        self.logger.debug('waiting for response from producer')
+        message: Dict[str, Any]
+
+        # loop and NOBLOCK needed when running in local mode, to let other gevent threads get time
+        while True:
+            try:
+                message = cast(Dict[str, Any], self.socket.recv_json(flags=zmq.NOBLOCK))
+                break
+            except ZMQAgain:
+                gsleep(0.1)  # let other greenlets execute
+
+        return message
+
 
 class TestdataProducer:
     # need so pytest doesn't raise PytestCollectionWarning
     __test__: bool = False
 
     _stopping: bool
+    _persist_file: Path
 
     logger: logging.Logger
     semaphore = Semaphore()
@@ -117,6 +155,7 @@ class TestdataProducer:
     testdata: TestdataType
     environment: Environment
     has_persisted: bool
+    keystore: Dict[str, Any]
 
     def __init__(self, grizzly: 'GrizzlyContext', testdata: TestdataType, address: str = 'tcp://127.0.0.1:5555') -> None:
         self.grizzly = grizzly
@@ -137,25 +176,32 @@ class TestdataProducer:
 
         self.logger.debug(f'serving:\n{self.testdata}')
 
+        feature_file = environ.get('GRIZZLY_FEATURE_FILE', None)
+        context_root = environ.get('GRIZZLY_CONTEXT_ROOT', None)
+        assert feature_file is not None
+        assert context_root is not None
+
+        persist_root = Path(context_root) / 'persistent'
+        self._persist_file = persist_root / f'{Path(feature_file).stem}.json'
+
+        if self._persist_file.exists():
+            persist_content = jsonloads(self._persist_file.read_text())
+            self.keystore = jsonloads(persist_content.get('grizzly::keystore', {}))
+        else:
+            self.keystore = {}
+
     def on_test_stop(self) -> None:
         self.logger.debug('test stopping')
         with self.semaphore:
-            self.persist_testdata()
+            self.persist_data()
             for scenario_name in self.scenarios_iteration.keys():
                 self.scenarios_iteration[scenario_name] = 0
 
-    def persist_testdata(self) -> None:
+    def persist_data(self) -> None:
         if self.has_persisted:
             return
 
         try:
-            feature_file = environ.get('GRIZZLY_FEATURE_FILE', None)
-            context_root = environ.get('GRIZZLY_CONTEXT_ROOT', None)
-
-            assert feature_file is not None
-            assert context_root is not None
-
-            persist_root = Path(context_root) / 'persistent'
             variable_state: Dict[str, str] = {}
 
             for testdata in self.testdata.values():
@@ -171,15 +217,17 @@ class TestdataProducer:
                     except:
                         continue
 
+            if len(self.keystore) > 0:
+                variable_state.update({'grizzly::keystore': jsondumps(self.keystore)})
+
             # only write file if we actually have something to write
             if len(variable_state.keys()) > 0 and len(list(chain(*variable_state.values()))) > 0:
-                persist_root.mkdir(exist_ok=True, parents=True)
-                persist_file = persist_root / f'{Path(feature_file).stem}.json'
-                persist_file.write_text(jsondumps(variable_state, indent=2))
-                self.logger.info(f'wrote variables next initial values for {feature_file} to {persist_file}')
+                self._persist_file.parent.mkdir(exist_ok=True, parents=True)
+                self._persist_file.write_text(jsondumps(variable_state, indent=2))
+                self.logger.info(f'feature file data persisted in {self._persist_file}')
                 self.has_persisted = True
         except:
-            self.logger.error('failed do persist variables next initial values', exc_info=True)
+            self.logger.error('failed do persist feature file data', exc_info=True)
 
     def stop(self) -> None:
         self._stopping = True
@@ -193,7 +241,7 @@ class TestdataProducer:
             gsleep(0.1)
             self.context.term()
 
-            self.persist_testdata()
+            self.persist_data()
 
     def run(self) -> None:
         self.logger.debug('start producing...')
@@ -203,14 +251,26 @@ class TestdataProducer:
                     recv = cast(Dict[str, Any], self.socket.recv_json(flags=zmq.NOBLOCK))
                     consumer_identifier = recv.get('identifier', '')
                     self.logger.debug(f'got request from consumer {consumer_identifier}')
+                    response: Dict[str, Any]
 
-                    if recv['message'] == 'available':
-                        message: Dict[str, Any] = {
-                            'action': 'stop',
-                        }
+                    with self.semaphore:
+                        if recv['message'] == 'keystore':
+                            if recv['action'] == 'get':
+                                recv['data'] = self.keystore.get(recv['key'], None)
+                                response = recv
+                            elif recv['action'] == 'set':
+                                key = recv.get('key', None)
+                                value = recv.get('data', None)
 
-                        try:
-                            with self.semaphore:
+                                if key is not None:
+                                    self.keystore.update({key: value})
+                                response = recv
+                        elif recv['message'] == 'testdata':
+                            response = {
+                                'action': 'stop',
+                            }
+
+                            try:
                                 scenario_name = recv['scenario']
                                 scenario = self.grizzly.scenarios.find_by_class_name(scenario_name)
 
@@ -223,7 +283,7 @@ class TestdataProducer:
                                         and self.scenarios_iteration[scenario_name] < scenario.iterations
                                     ) or scenario_name not in self.scenarios_iteration:
                                         testdata = self.testdata.get(scenario_name, {})
-                                        message['action'] = 'consume'
+                                        response['action'] = 'consume'
                                         data: Dict[str, Any] = {'variables': {}}
                                         loaded_variable_datatypes: Dict[str, Any] = {}
 
@@ -253,7 +313,7 @@ class TestdataProducer:
                                                 value = variable
 
                                             if value is None and scenario_name not in self.scenarios_iteration:
-                                                message['action'] = 'stop'
+                                                response['action'] = 'stop'
                                                 self.logger.warning(f'{key} does not have a value and iterations is not set for {scenario_name}, stop test')
                                                 data = {}
                                                 break
@@ -264,21 +324,22 @@ class TestdataProducer:
                                                     key = self.grizzly.state.alias[key]
                                                     data[key] = value
 
-                                        message['data'] = data
+                                        response['data'] = data
 
                                     if scenario_name in self.scenarios_iteration:
                                         self.scenarios_iteration[scenario_name] += 1
                                         self.logger.debug(f'{consumer_identifier}/{scenario_name}: iteration={self.scenarios_iteration[scenario_name]}')
-                        except TypeError:
-                            message = {
-                                'action': 'stop',
-                            }
-                            self.logger.error(f'test data error, stop consumer {consumer_identifier}', exc_info=True)
+                            except TypeError:
+                                response = {
+                                    'action': 'stop',
+                                }
+                                self.logger.error(f'test data error, stop consumer {consumer_identifier}', exc_info=True)
+                        else:
+                            self.logger.error(f'received unknown message "{recv["messsage"]}"')
+                            continue
 
-                        self.logger.debug(f'producing {message} for consumer {consumer_identifier}')
-                        self.socket.send_json(message)
-                    else:
-                        self.logger.error(f'received unknown message "{recv["messsage"]}"')
+                        self.logger.debug(f'producing {response} for consumer {consumer_identifier}')
+                        self.socket.send_json(response)
 
                     gsleep(0)
                 except ZMQAgain:

--- a/tests/e2e/test_keystore.py
+++ b/tests/e2e/test_keystore.py
@@ -1,0 +1,68 @@
+from textwrap import dedent
+
+from grizzly.types.behave import Context, Feature
+
+from tests.fixtures import End2EndFixture
+
+
+def test_e2e_keystore(e2e_fixture: End2EndFixture) -> None:
+    def after_feature(context: Context, feature: Feature) -> None:
+        from pathlib import Path
+        from json import loads as jsonloads
+        from grizzly.locust import on_worker
+
+        if on_worker(context):
+            return
+
+        persist_file = Path(context.config.base_dir) / 'persistent' / f'{Path(feature.filename).stem}.json'
+
+        assert persist_file.exists()
+
+        persistance = jsonloads(persist_file.read_text())
+
+        assert persistance == {
+            'grizzly::keystore': {
+                'foobar::set': 'hello',
+                'foobar::get::default': {'hello': 'world'},
+            }
+        }
+
+    e2e_fixture.add_after_feature(after_feature)
+
+    if e2e_fixture._distributed:
+        start_webserver_step = f'Then start webserver on master port "{e2e_fixture.webserver.port}"\n'
+    else:
+        start_webserver_step = ''
+
+    feature_file = e2e_fixture.create_feature(dedent(f'''Feature: test persistence
+    Background: common configuration
+        Given "2" users
+        And spawn rate is "2" user per second
+        {start_webserver_step}
+    Scenario: first
+        Given a user of type "Dummy" load testing "dummy://test"
+        And repeat for "1" iterations
+        And value for variable "key_holder_1" is "none"
+        And wait "0" seconds between tasks
+        Then set "foobar::set" in keystore with value "'hello'"
+        Then get "foobar::get::default" from keystore and save in variable "key_holder_1", with default value "{{'hello': 'world'}}"
+        Then log message "key_holder_1={{{{ key_holder_1 }}}}"
+    Scenario: second
+        Given a user of type "Dummy" load testing "dummy://test"
+        And repeat for "1" iterations
+        And value for variable "key_holder_2" is "none"
+        And value for variable "key_holder_3" is "none"
+        And wait "0.9" seconds between tasks
+        Then get "foobar::set" from keystore and save in variable "key_holder_2"
+        Then get "foobar::get::default" from keystore and save in variable "key_holder_3"
+        Then log message "key_holder_2={{{{ key_holder_2 }}}}, key_holder_3={{{{ key_holder_3 }}}}"
+    '''))
+
+    rc, output = e2e_fixture.execute(feature_file)
+
+    assert rc == 0
+
+    result = ''.join(output)
+
+    assert "key_holder_1={'hello': 'world'}" in result
+    assert "key_holder_2=hello, key_holder_3={'hello': 'world'}" in result

--- a/tests/unit/test_grizzly/scenarios/test_iterator.py
+++ b/tests/unit/test_grizzly/scenarios/test_iterator.py
@@ -204,7 +204,7 @@ class TestIterationScenario:
         parent.consumer = TestdataConsumer(parent, identifier='test')
 
         def mock_request(data: Optional[Dict[str, Any]]) -> None:
-            def request(self: 'TestdataConsumer', scenario: str) -> Optional[Dict[str, Any]]:
+            def testdata_request(self: 'TestdataConsumer', scenario: str) -> Optional[Dict[str, Any]]:
                 if data is None or data == {}:
                     return None
 
@@ -214,8 +214,8 @@ class TestIterationScenario:
                 return data
 
             mocker.patch(
-                'grizzly.testdata.communication.TestdataConsumer.request',
-                request,
+                'grizzly.testdata.communication.TestdataConsumer.testdata',
+                testdata_request,
             )
 
         mock_request(None)
@@ -788,7 +788,7 @@ class TestIterationScenario:
             scenario.on_start()  # create scenario.consumer, so we can patch request below
 
             # same as 1 iteration
-            mocker.patch.object(scenario.consumer, 'request', side_effect=[
+            mocker.patch.object(scenario.consumer, 'testdata', side_effect=[
                 {'variables': {'hello': 'world'}},
                 {'variables': {'foo': 'bar'}},
                 None,

--- a/tests/unit/test_grizzly/tasks/test_keystore.py
+++ b/tests/unit/test_grizzly/tasks/test_keystore.py
@@ -1,0 +1,133 @@
+from typing import cast
+from unittest.mock import ANY
+
+import pytest
+
+from grizzly.tasks import KeystoreTask
+from grizzly.context import GrizzlyContext
+from grizzly.exceptions import RestartScenario
+
+from tests.fixtures import GrizzlyFixture, MockerFixture
+
+
+class TestKeystoreTask:
+    def test___init__(self, grizzly_fixture: GrizzlyFixture) -> None:
+        with pytest.raises(AssertionError) as ae:
+            KeystoreTask('foobar', 'get', None)
+        assert str(ae.value) == 'action context for get must be a string'
+
+        with pytest.raises(AssertionError) as ae:
+            KeystoreTask('foobar', 'get', 'foobar')
+        assert str(ae.value) == 'foobar has not been initialized'
+
+        grizzly_fixture.grizzly.state.variables.update({'foobar': 'none'})
+
+        task = KeystoreTask('foobar', 'get', 'foobar')
+
+        assert task.key == 'foobar'
+        assert task.action == 'get'
+        assert task.action_context == 'foobar'
+        assert task.default_value is None
+
+        task = KeystoreTask('foobar', 'get', 'foobar', ['hello', 'world'])
+
+        assert task.key == 'foobar'
+        assert task.action == 'get'
+        assert task.action_context == 'foobar'
+        assert task.default_value == ['hello', 'world']
+
+        with pytest.raises(AssertionError) as ae:
+            KeystoreTask('foobar', 'set', None)
+        assert str(ae.value) == 'action context for set cannot be None'
+
+        task = KeystoreTask('foobar', 'set', {'hello': 'world'})
+
+        assert task.key == 'foobar'
+        assert task.action == 'set'
+        assert task.action_context == {'hello': 'world'}
+        assert task.default_value is None
+
+        with pytest.raises(AssertionError) as ae:
+            KeystoreTask('foobar', 'unknown', None)  # type: ignore
+        assert str(ae.value) == 'unknown is not a valid action'
+
+    def test___call___get(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
+        behave = grizzly_fixture.behave.context
+        grizzly = cast(GrizzlyContext, behave.grizzly)
+
+        parent = grizzly_fixture()
+
+        assert parent is not None
+
+        consumer_mock = mocker.MagicMock()
+        setattr(parent, 'consumer', consumer_mock)
+
+        grizzly.state.variables.update({'foobar': 'none'})
+
+        # key does not exist in keystore
+        setattr(parent.consumer.keystore_get, 'return_value', None)
+        request_spy = mocker.spy(parent.user.environment.events.request, 'fire')
+
+        task_factory = KeystoreTask('foobar', 'get', 'foobar')
+        task = task_factory()
+
+        parent.user._scenario.failure_exception = RestartScenario
+
+        with pytest.raises(RestartScenario):
+            task(parent)
+
+        assert parent.user._context['variables'].get('foobar', None) is None
+
+        request_spy.assert_called_once_with(
+            request_type='KEYS',
+            name='001 foobar',
+            response_time=0,
+            response_length=1,
+            context=parent.user._context,
+            exception=ANY,
+        )
+
+        _, kwargs = request_spy.call_args_list[-1]
+        actual_exception = kwargs.get('exception', None)
+        assert isinstance(actual_exception, RuntimeError)
+        assert str(actual_exception) == 'key foobar does not exist in keystore'
+
+        request_spy.reset_mock()
+
+        # key exist in keystore
+        setattr(parent.consumer.keystore_get, 'return_value', ['hello', 'world'])
+
+        task(parent)
+
+        request_spy.assert_not_called()
+
+        assert parent.user._context['variables'].get('foobar', None) == ['hello', 'world']
+
+        # key does not exist in keystore, but has a default value
+        setattr(parent.consumer.keystore_get, 'return_value', None)
+
+        task_factory = KeystoreTask('foobar', 'get', 'foobar', {'hello': 'world'})
+        assert task_factory.default_value is not None
+        task = task_factory()
+
+        task(parent)
+
+        request_spy.assert_not_called()
+        consumer_mock.keystore_set.assert_called_with('foobar', {'hello': 'world'})
+        assert parent.user._context['variables'].get('foobar', None) == {'hello': 'world'}
+
+    def test___call___set(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
+        parent = grizzly_fixture()
+
+        assert parent is not None
+
+        consumer_mock = mocker.MagicMock()
+        setattr(parent, 'consumer', consumer_mock)
+
+        task_factory = KeystoreTask('foobar', 'set', {'hello': '{{ world }}'})
+        task = task_factory()
+
+        task(parent)
+
+        consumer_mock.keystore_set.assert_called_once_with('foobar', {'hello': '{{ world }}'})
+        consumer_mock.reset_mock()

--- a/tests/unit/test_grizzly/test_gevent.py
+++ b/tests/unit/test_grizzly/test_gevent.py
@@ -1,0 +1,52 @@
+from gevent import Greenlet, getcurrent
+
+import pytest
+
+from grizzly.gevent import GreenletWithExceptionCatching
+
+from tests.fixtures import MockerFixture
+
+
+def func(a: str, i: int) -> None:
+    raise RuntimeError(f'func error, {a=}, {i=}')
+
+
+class TestGreenletWithExceptionCatching:
+    def test___init__(self) -> None:
+        g = GreenletWithExceptionCatching()
+
+        assert g.started_from == getcurrent()
+        assert isinstance(g, Greenlet)
+
+    def test_handle_exception(self) -> None:
+        g = GreenletWithExceptionCatching()
+
+        with pytest.raises(RuntimeError) as re:
+            g.handle_exception(RuntimeError('error'))
+        assert str(re.value) == 'error'
+
+    def test_spawn(self, mocker: MockerFixture) -> None:
+        g = GreenletWithExceptionCatching()
+        wrap_exceptions_spy = mocker.spy(g, 'wrap_exceptions')
+
+        with pytest.raises(RuntimeError) as re:
+            func_g = g.spawn(func, 'hello', i=1)
+            wrap_exceptions_spy.assert_called_once_with(func)
+            wrap_exceptions_spy.reset_mock()
+            func_g.join()
+        assert str(re.value) == "func error, a='hello', i=1"
+
+        wrap_exceptions_spy.assert_called_once_with(g.handle_exception)
+
+    def test_spawn_later(self, mocker: MockerFixture) -> None:
+        g = GreenletWithExceptionCatching()
+        wrap_exceptions_spy = mocker.spy(g, 'wrap_exceptions')
+
+        with pytest.raises(RuntimeError) as re:
+            func_g = g.spawn_later(1, func, 'foobar', i=1337)
+            wrap_exceptions_spy.assert_called_once_with(func)
+            wrap_exceptions_spy.reset_mock()
+            func_g.join()
+        assert str(re.value) == "func error, a='foobar', i=1337"
+
+        wrap_exceptions_spy.assert_called_once_with(g.handle_exception)

--- a/tests/unit/test_grizzly/testdata/test_communication.py
+++ b/tests/unit/test_grizzly/testdata/test_communication.py
@@ -218,7 +218,7 @@ class TestTestdataProducer:
                     actual_initial_values = json.loads(persist_file.read_text())
                     assert actual_initial_values == {
                         'AtomicIntegerIncrementer.value': '11 | step=5, persist=True',
-                        'grizzly::keystore': json.dumps({'foobar': {'hello': 'world'}}),
+                        'grizzly::keystore': {'foobar': {'hello': 'world'}},
                     }
 
             if context is not None:
@@ -358,7 +358,7 @@ class TestTestdataProducer:
                 producer.keystore.update(actual_keystore)
                 producer.stop()
 
-            assert caplog.messages[-1] == f'wrote variables next initial values for features/test_run_with_variable_none.feature to {persistent_file}'
+            assert caplog.messages[-1] == f'feature file data persisted in {persistent_file}'
             assert caplog.messages[-2] == 'failed to stop'
 
             assert persistent_file.exists()
@@ -366,7 +366,7 @@ class TestTestdataProducer:
             actual_persist_values = json.loads(persistent_file.read_text())
             assert actual_persist_values == {
                 'AtomicIntegerIncrementer.foobar': '3 | step=1, persist=True',
-                'grizzly::keystore': json.dumps(actual_keystore),
+                'grizzly::keystore': actual_keystore,
 
             }
 
@@ -377,7 +377,7 @@ class TestTestdataProducer:
                 del producer.keystore['bar']
                 producer.stop()
 
-            assert caplog.messages[-1] == f'wrote variables next initial values for features/test_run_with_variable_none.feature to {persistent_file}'
+            assert caplog.messages[-1] == f'feature file data persisted in {persistent_file}'
             assert caplog.messages[-2] == 'failed to stop'
 
             assert persistent_file.exists()
@@ -387,7 +387,7 @@ class TestTestdataProducer:
             actual_persist_values = json.loads(persistent_file.read_text())
             assert actual_persist_values == {
                 'AtomicIntegerIncrementer.foobar': '5 | step=1, persist=True',
-                'grizzly::keystore': json.dumps(actual_keystore),
+                'grizzly::keystore': actual_keystore,
             }
         finally:
             cleanup()

--- a/tests/unit/test_grizzly_extras/async_message/test_utils.py
+++ b/tests/unit/test_grizzly_extras/async_message/test_utils.py
@@ -1,0 +1,22 @@
+import pytest
+
+from grizzly_extras.async_message.utils import tohex
+
+
+class Test_tohex:
+    def test_unsupported(self) -> None:
+        with pytest.raises(ValueError) as ve:
+            tohex(['deadbeef'])  # type:ignore
+        assert str(ve.value) == "['deadbeef'] has an unsupported type <class 'list'>"
+
+    def test_int(self) -> None:
+        assert tohex(3735928559) == 'deadbeef'
+
+    def test_str(self) -> None:
+        assert tohex('Þ­¾ï') == 'deadbeef'
+
+    def test_bytes(self) -> None:
+        assert tohex(b'\xde\xad\xbe\xef') == 'deadbeef'
+
+    def test_bytearray(self) -> None:
+        assert tohex(bytearray(b'\xde\xad\xbe\xef')) == 'deadbeef'


### PR DESCRIPTION
implementation of a keystore in `TestdataProducer`, which `TestdataConsumer` can interact with, via the `KeystoreTask`.

makes it possible to share testdata between scenarios, even when running distributed.