### PR TITLE
software based TOTP for AAD user authentication

### DIFF
--- a/docs/content/framework/usage/auth/aad.md
+++ b/docs/content/framework/usage/auth/aad.md
@@ -1,0 +1,5 @@
+---
+title: Azure Active Directory
+---
+
+@pydoc grizzly.auth.aad

--- a/grizzly/auth/__init__.py
+++ b/grizzly/auth/__init__.py
@@ -54,6 +54,7 @@ class GrizzlyHttpAuthClient(Generic[P], metaclass=ABCMeta):
             'user': {
                 'username': None,
                 'password': None,
+                'otp_secret': None,
                 'redirect_uri': None,
                 'initialize_uri': None,
             },

--- a/grizzly/auth/aad.py
+++ b/grizzly/auth/aad.py
@@ -1,3 +1,107 @@
+"""
+@anchor pydoc:grizzly.auth.aad Azure Active Directory
+Grizzly provides a way to get tokens via Azure Active Directory (AAD), in the framework this is implemented by {@pylink grizzly.users.restapi}
+load user and {@pylink grizzly.tasks.clients.http} client task, via the `@refresh_token` decorator.
+
+It is possible to use it in custom code as well, by implementing a custom class that inherits `grizzly.auth.GrizzlyHttpAuthClient`.
+
+For information about how to set context variables:
+
+* {@pylink grizzly.steps.background.setup.step_setup_set_global_context_variable}
+
+* {@pylink grizzly.steps.scenario.setup.step_setup_set_context_variable}
+
+Context variable values supports {@link framework.usage.variables.templating}.
+
+There are two ways to get an token, see below.
+
+## Client secret
+
+Using client secret for an app registration.
+
+``` gherkin
+Given a user of type "RestApi" load testing "https://api.example.com"
+And set context variable "auth.provider" to "<provider>"
+And set context variable "auth.client.id" to "<client id>"
+And set context variable "auth.client.secret" to "<client secret>"
+And set context variable "auth.client.resource" to "<resource url/guid>"
+```
+
+## Username and password
+
+Using a username and password, with optional MFA authentication.
+
+`auth.user.redirect_uri` needs to correspond to the endpoint that the client secret is registrered for.
+
+``` gherkin
+Given a user of type "RestApi" load testing "https://api.example.com"
+And set context variable "auth.provider" to "<provider>"
+And set context variable "auth.client.id" to "<client id>"
+And set context variable "auth.user.username" to "alice@example.onmicrosoft.com"
+And set context variable "auth.user.password" to "HemL1gaArn3!"
+And set context variable "auth.user.redirect_uri" to "/app-registrered-redirect-uri"
+```
+
+### MFA / TOTP
+
+If the user is required to have a MFA method, support for software based TOTP tokens are supported. The user **must** first have this method configured.
+
+#### Configure TOTP
+
+1. Login to the accounts [My signins](https://mysignins.microsoft.com/security-info)
+
+2. Click on `Security info`
+
+3. Click on `Add sign-in method`
+
+4. Choose `Authenticator app`
+
+5. Click on `I want to use another authenticator app`
+
+6. Click on `Next`
+
+7. Click on `Can't scan image?`
+
+8. Copy `Secret key` and save it some where safe
+
+9. Click on `Next`
+
+10. Open a terminal and run the following command:
+
+    === "Bash"
+
+        ```bash
+        OTP_SECRET="<secret key from step 8>" grizzly-cli auth
+        ```
+    === "PowerShell"
+
+        ```powershell
+        $Env:OTP_SECRET = "<secret key from step 8>"
+        grizzly-cli auth
+        ```
+
+11. Copy the code generate from above command and click `Next`
+
+12. Finish the wizard
+
+The user now have software based TOTP tokens as MFA method.
+
+
+
+#### Example
+
+In addition to the "Username and password" example, the context variable `auth.user.otp_secret` must also be set.
+
+``` gherkin
+Given a user of type "RestApi" load testing "https://api.example.com"
+And set context variable "auth.provider" to "<provider>"
+And set context variable "auth.client.id" to "<client id>"
+And set context variable "auth.user.username" to "alice@example.onmicrosoft.com"
+And set context variable "auth.user.password" to "HemL1gaArn3!"
+And set context variable "auth.user.redirect_uri" to "/app-registrered-redirect-uri"
+And set context variable "auth.user.otp_secret" to "asdfasdf"  # <-- !!
+```
+"""
 import re
 import json
 import logging

--- a/grizzly/tasks/clients/http.py
+++ b/grizzly/tasks/clients/http.py
@@ -39,6 +39,8 @@ Then get "https://{{ url }}" with name "authenticated-get" and save response pay
 
 This will make any requests towards `www.example.com` to get a token from `http://login.example.com/oauth2` and use it in any
 requests towards `www.example.com`.
+
+For more details, see {@pylink grizzly.auth.aad}.
 '''
 from typing import Optional, Dict, Any
 from json import dumps as jsondumps

--- a/grizzly/users/restapi.py
+++ b/grizzly/users/restapi.py
@@ -117,6 +117,7 @@ class RestApiUser(ResponseHandler, GrizzlyUser, HttpRequests, AsyncRequests, Gri
             'user': {
                 'username': None,
                 'password': None,
+                'otp_secret': None,
                 'redirect_uri': None,
                 'initialize_uri': None,
             },

--- a/grizzly/users/restapi.py
+++ b/grizzly/users/restapi.py
@@ -1,5 +1,7 @@
 # pylint: disable=line-too-long
-'''Communicates with HTTP and HTTPS, with built-in support for Azure authenticated endpoints.
+"""
+@anchor pydoc:grizzly.users.restapi RestAPI
+Communicates with HTTP and HTTPS, with built-in support for Azure authenticated endpoints.
 
 ## Request methods
 
@@ -34,30 +36,9 @@ And set context variable "auth.refresh_time" to "3500"
 
 ### Authentication
 
-#### Client secret
+See {@pylink grizzly.auth.aad}.
 
-``` gherkin
-Given a user of type "RestApi" load testing "https://api.example.com"
-And set context variable "auth.provider" to "<provider>"
-And set context variable "auth.client.id" to "<client id>"
-And set context variable "auth.client.secret" to "<client secret>"
-And set context variable "auth.client.resource" to "<resource url/guid>"
-```
-
-#### Username and password
-
-`auth.user.redirect_uri` needs to correspond to the endpoint that the client secret is registrered for.
-
-``` gherkin
-Given a user of type "RestApi" load testing "https://api.example.com"
-And set context variable "auth.provider" to "<provider>"
-And set context variable "auth.client.id" to "<client id>"
-And set context variable "auth.user.username" to "alice@example.onmicrosoft.com"
-And set context variable "auth.user.password" to "HemL1gaArn3!"
-And set context variable "auth.user.redirect_uri" to "/app-registrered-redirect-uri"
-```
-
-#### Multipart/form-data
+### Multipart/form-data
 
 RestApi supports posting of multipart/form-data content-type, and in that case additional arguments needs to be passed with the request:
 
@@ -70,7 +51,7 @@ Example:
 ``` gherkin
 Then post request "path/my_template.j2.xml" with name "FormPost" to endpoint "example.url.com | content_type=multipart/form-data, multipart_form_data_filename=my_filename, multipart_form_data_name=form_name"
 ```
-'''  # noqa: E501
+"""  # noqa: E501
 import json
 
 from typing import Dict, Optional, Any, Tuple, Union, cast

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
     "pyzmq >=22.2.1,!=23.0.0",
     "PyYAML >=6.0.1,<7.0.0",
     "setproctitle >=1.2.2",
-    "tzdata >=2022.1"
+    "tzdata >=2022.1",
+    "pyotp >=2.9.0,<3.0.0"
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/tests/unit/test_grizzly/auth/test___init__.py
+++ b/tests/unit/test_grizzly/auth/test___init__.py
@@ -212,6 +212,7 @@ def test_refresh_token_user(grizzly_fixture: GrizzlyFixture, mocker: MockerFixtu
         assert auth_context.get('user', None) == {
             'username': 'alice@example.com',
             'password': 'HemligaArne',
+            'otp_secret': None,
             'redirect_uri': '/authenticated',
             'initialize_uri': None,
         }

--- a/tests/unit/test_grizzly/test_utils.py
+++ b/tests/unit/test_grizzly/test_utils.py
@@ -146,6 +146,7 @@ def test_create_user_class_type(behave_fixture: BehaveFixture) -> None:
             'user': {
                 'username': None,
                 'password': None,
+                'otp_secret': None,
                 'redirect_uri': None,
                 'initialize_uri': None,
             },
@@ -173,6 +174,7 @@ def test_create_user_class_type(behave_fixture: BehaveFixture) -> None:
             'user': {
                 'username': None,
                 'password': None,
+                'otp_secret': None,
                 'redirect_uri': None,
                 'initialize_uri': None,
             },
@@ -229,6 +231,7 @@ def test_create_user_class_type(behave_fixture: BehaveFixture) -> None:
             'user': {
                 'username': 'grizzly-user',
                 'password': None,
+                'otp_secret': None,
                 'redirect_uri': None,
                 'initialize_uri': None,
             },
@@ -263,6 +266,7 @@ def test_create_user_class_type(behave_fixture: BehaveFixture) -> None:
             'user': {
                 'username': 'grizzly-user',
                 'password': None,
+                'otp_secret': None,
                 'redirect_uri': None,
                 'initialize_uri': None,
             },
@@ -304,6 +308,7 @@ def test_create_user_class_type(behave_fixture: BehaveFixture) -> None:
             'user': {
                 'username': None,
                 'password': None,
+                'otp_secret': None,
                 'redirect_uri': None,
                 'initialize_uri': None,
             },
@@ -341,6 +346,7 @@ def test_create_user_class_type(behave_fixture: BehaveFixture) -> None:
             'user': {
                 'username': None,
                 'password': None,
+                'otp_secret': None,
                 'redirect_uri': None,
                 'initialize_uri': None,
             },

--- a/tests/unit/test_grizzly/users/test_restapi.py
+++ b/tests/unit/test_grizzly/users/test_restapi.py
@@ -51,6 +51,7 @@ class TestRestApiUser:
                 'user': {
                     'username': None,
                     'password': None,
+                    'otp_secret': None,
                     'redirect_uri': None,
                     'initialize_uri': None,
                 },
@@ -93,6 +94,7 @@ class TestRestApiUser:
                     'user': {
                         'username': '',
                         'password': '',
+                        'otp_secret': None,
                         'redirect_uri': '',
                         'response_mode': '',
                     },


### PR DESCRIPTION
possible to use a (AAD) user that requires MFA (#260). only support software based TOTP method.

Biometria-se/grizzly-cli#80 adds a stateless authenticator app in grizzly-cli to be able to easily configure the (test) users.
