### PR TITLE
bump pymqi version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ async-messaged = "grizzly_extras.async_message.daemon:main"
 
 [project.optional-dependencies]
 mq = [
-    "pymqi ==1.12.0"
+    "pymqi ==1.12.10"
 ]
 dev = [
     "wheel>=0.37.0",


### PR DESCRIPTION
bump pymqi version to be able to use `MQ_FILE_PATH`.