### PR TITLE
service bus client unquote bug

### DIFF
--- a/grizzly/scenarios/__init__.py
+++ b/grizzly/scenarios/__init__.py
@@ -79,7 +79,7 @@ class GrizzlyScenario(SequentialTaskSet):
 
         for task in self.tasks:
             if isinstance(task, grizzlytask):
-                task.on_start(self)
+                task.on_start(self)  # type: ignore[unreachable]
 
     def on_stop(self) -> None:
         """
@@ -88,7 +88,7 @@ class GrizzlyScenario(SequentialTaskSet):
         """
         for task in self.tasks:
             if isinstance(task, grizzlytask):
-                try:
+                try:  # type: ignore[unreachable]
                     task.on_stop(self)
                 except Exception as e:
                     self.logger.error(f'on_stop: {str(e)}', exc_info=True)

--- a/grizzly/tasks/clients/servicebus.py
+++ b/grizzly/tasks/clients/servicebus.py
@@ -204,7 +204,6 @@ class ServiceBusClientTask(ClientTask):
                 endpoint_arguments['subscription'] = f'{quote}{subscription}_{id(parent.user)}{quote}'
                 context['endpoint'] = ', '.join([f'{key}:{value}' for key, value in endpoint_arguments.items()])
 
-
             state = State(
                 parent=parent,
                 client=cast(zmq.Socket, self._zmq_context.socket(zmq.REQ)),

--- a/grizzly/tasks/clients/servicebus.py
+++ b/grizzly/tasks/clients/servicebus.py
@@ -193,11 +193,17 @@ class ServiceBusClientTask(ClientTask):
         if state is None:
             context = self.context.copy()
             # add id of user as suffix to subscription name, to make it unique
-            endpoint_arguments = parse_arguments(context['endpoint'], separator=':')
+            endpoint_arguments = parse_arguments(context['endpoint'], separator=':', unquote=False)
 
             if 'subscription' in endpoint_arguments:
-                endpoint_arguments['subscription'] = f'{endpoint_arguments["subscription"]}_{id(parent.user)}'
+                subscription = endpoint_arguments['subscription']
+                quote = ''
+                if subscription[0] in ['"', "'"] and subscription[-1] == subscription[0]:
+                    quote = subscription[0]
+                    subscription = subscription[1:-1]
+                endpoint_arguments['subscription'] = f'{quote}{subscription}_{id(parent.user)}{quote}'
                 context['endpoint'] = ', '.join([f'{key}:{value}' for key, value in endpoint_arguments.items()])
+
 
             state = State(
                 parent=parent,

--- a/tests/unit/test_grizzly/scenarios/test_iterator.py
+++ b/tests/unit/test_grizzly/scenarios/test_iterator.py
@@ -898,7 +898,7 @@ class TestIterationScenario:
             task_2 = scenario.tasks[-2]
 
             assert isinstance(task_1, grizzlytask)
-            assert isinstance(task_2, grizzlytask)
+            assert isinstance(task_2, grizzlytask)  # type: ignore[unreachable]
             assert task_1 is not task_2
             assert task_1._on_stop is None
             assert task_2._on_stop is None
@@ -962,7 +962,7 @@ class TestIterationScenario:
             task_2 = scenario.tasks[-2]
 
             assert isinstance(task_1, grizzlytask)
-            assert isinstance(task_2, grizzlytask)
+            assert isinstance(task_2, grizzlytask)  # type: ignore[unreachable]
             assert task_1 is not task_2
 
             task_1_on_stop_spy = mocker.spy(task_1, '_on_stop')

--- a/tests/unit/test_grizzly/tasks/clients/test_servicebus.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_servicebus.py
@@ -65,7 +65,7 @@ class TestServiceBusClientTask:
         task = ServiceBusClientTask(
             RequestDirection.FROM,
             (
-                'sb://$conf::sbns.host$/topic:my-topic/subscription:my-subscription-{{ id }}/expression:$.hello.world'
+                'sb://$conf::sbns.host$/topic:my-topic/subscription:"my-subscription-{{ id }}"/expression:$.hello.world'
                 ';SharedAccessKeyName=$conf::sbns.key.name$;SharedAccessKey=$conf::sbns.key.secret$#Consume=True&MessageWait=300&ContentType=json'
             ),
             'test',
@@ -77,7 +77,7 @@ class TestServiceBusClientTask:
         assert task.context == {
             'url': task.endpoint,
             'connection': 'receiver',
-            'endpoint': 'topic:my-topic, subscription:my-subscription-{{ id }}, expression:$.hello.world',
+            'endpoint': 'topic:my-topic, subscription:"my-subscription-{{ id }}", expression:$.hello.world',
             'consume': True,
             'message_wait': 300,
             'content_type': 'JSON'
@@ -87,7 +87,7 @@ class TestServiceBusClientTask:
         assert task.metadata_variable is None
         assert task.source is None
         assert task._state == {}
-        assert sorted(task.get_templates()) == sorted(['topic:my-topic, subscription:my-subscription-{{ id }}, expression:$.hello.world', '{{ foobar }}'])
+        assert sorted(task.get_templates()) == sorted(['topic:my-topic, subscription:"my-subscription-{{ id }}", expression:$.hello.world', '{{ foobar }}'])
         context_mock.assert_called_once_with()
         context_mock.reset_mock()
 
@@ -96,7 +96,7 @@ class TestServiceBusClientTask:
         task = ServiceBusClientTask(
             RequestDirection.FROM,
             (
-                'sb://$conf::sbns.host$/topic:my-topic/subscription:my-subscription-{{ id }}/expression:$.hello.world'
+                'sb://$conf::sbns.host$/topic:my-topic/subscription:"my-subscription-{{ id }}"/expression:$.hello.world'
                 ';SharedAccessKeyName=$conf::sbns.key.name$;SharedAccessKey=$conf::sbns.key.secret$#Consume=True&MessageWait=300&ContentType=json'
             ),
             'test',
@@ -109,7 +109,7 @@ class TestServiceBusClientTask:
         assert task.context == {
             'url': task.endpoint,
             'connection': 'receiver',
-            'endpoint': 'topic:my-topic, subscription:my-subscription-{{ id }}, expression:$.hello.world',
+            'endpoint': 'topic:my-topic, subscription:"my-subscription-{{ id }}", expression:$.hello.world',
             'consume': True,
             'message_wait': 300,
             'content_type': 'JSON'
@@ -119,7 +119,7 @@ class TestServiceBusClientTask:
         assert task.metadata_variable == 'barfoo'
         assert task.source is None
         assert task._state == {}
-        assert sorted(task.get_templates()) == sorted(['topic:my-topic, subscription:my-subscription-{{ id }}, expression:$.hello.world', '{{ foobar }} {{ barfoo }}'])
+        assert sorted(task.get_templates()) == sorted(['topic:my-topic, subscription:"my-subscription-{{ id }}", expression:$.hello.world', '{{ foobar }} {{ barfoo }}'])
         context_mock.assert_called_once_with()
         context_mock.reset_mock()
 
@@ -296,6 +296,45 @@ class TestServiceBusClientTask:
             'action': 'SUBSCRIBE',
             'context': expected_context,
             'payload': '1=2'
+        })
+
+        async_message_request_mock.reset_mock()
+        caplog.clear()
+
+        task = ServiceBusClientTask(
+            RequestDirection.FROM,
+            (
+                "sb://my-sbns.servicebus.windows.net/topic:my-topic/subscription:'my-subscription-{{ id }}'/"
+                "expression:'$.`this`[?bar='foo' & bar='foo']';SharedAccessKeyName=AccessKey;SharedAccessKey=37aabb777f454324="
+            ),  # noqa: Q003
+            'test',
+        )
+        task._text = '1=1'
+
+        state = task.get_state(parent)
+
+        state.worker = 'foo-bar-baz'
+        state.client = client_mock
+
+        expected_context = state.context.copy()
+        expected_context['endpoint'] = expected_context['endpoint'].replace('{{ id }}', 'baz-bar-foo')
+
+        with caplog.at_level(logging.INFO):
+            task.subscribe(parent)
+
+        assert caplog.messages == ['foobar!']
+        async_message_request_mock.assert_called_once_with(client_mock, {
+            'worker': 'foo-bar-baz',
+            'client': state.parent_id,
+            'action': 'SUBSCRIBE',
+            'context': {
+                'url': expected_context['url'],
+                'connection': 'receiver',
+                'endpoint': f"topic:my-topic, subscription:'my-subscription-baz-bar-foo_{id(parent.user)}', expression:'$.`this`[?bar='foo' & bar='foo']'",
+                'message_wait': None,
+                'consume': False,
+            },
+            'payload': '1=1',
         })
 
     def test_unsubscribe(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture, caplog: LogCaptureFixture) -> None:

--- a/tests/unit/test_grizzly_extras/test_arguments.py
+++ b/tests/unit/test_grizzly_extras/test_arguments.py
@@ -147,3 +147,10 @@ def test_parse_arguments(separator: str) -> None:
         'value2': '=',
         'value3': '%',
     }
+
+    arguments = parse_arguments(f"expression{separator}'$.`this`[?hello='world' & world=2]', foo{separator}bar", separator, unquote=False)
+
+    assert arguments == {
+        'expression': "'$.`this`[?hello='world' & world=2]'",
+        'foo': 'bar',
+    }


### PR DESCRIPTION
do not unquote endpoint arguments when making subscription name unique, otherwise the value will be incorrect when it comes to async-messaged.