### PR TITLE
async-messaged logging refactored

### DIFF
--- a/grizzly/tasks/clients/messagequeue.py
+++ b/grizzly/tasks/clients/messagequeue.py
@@ -84,7 +84,8 @@ from zmq.error import ZMQError
 
 from grizzly.testdata.utils import resolve_variable
 from grizzly.types import GrizzlyResponse, RequestDirection, RequestType
-from grizzly_extras.async_message import AsyncMessageContext, AsyncMessageRequest, AsyncMessageResponse, async_message_request
+from grizzly_extras.async_message import AsyncMessageContext, AsyncMessageRequest, AsyncMessageResponse
+from grizzly_extras.async_message.utils import async_message_request
 
 from . import ClientTask, client, logger
 

--- a/grizzly/users/__init__.py
+++ b/grizzly/users/__init__.py
@@ -87,8 +87,6 @@ class GrizzlyUser(User, metaclass=GrizzlyUserMeta):
     event_hook: GrizzlyEventHook
     grizzly = GrizzlyContext()
 
-    metadata: Dict[str, Any]
-
     def __init__(self, environment: Environment, *args: Any, **kwargs: Any) -> None:
         super().__init__(environment, *args, **kwargs)
 
@@ -98,8 +96,6 @@ class GrizzlyUser(User, metaclass=GrizzlyUserMeta):
         self._scenario = copy(self.__scenario__)
         # these are not copied, and we can share reference
         self._scenario._tasks = self.__scenario__._tasks
-
-        self.metadata = self._context.get('metadata', None) or {}
 
         self.logger = logging.getLogger(f'{self.__class__.__name__}/{id(self)}')
         self.abort = False
@@ -113,6 +109,17 @@ class GrizzlyUser(User, metaclass=GrizzlyUserMeta):
         # if it already has been called with True, do not change it back to False
         if not self.abort:
             self.abort = cast(bool, kwargs.get('abort', False))
+
+    @property
+    def metadata(self) -> Dict[str, Any]:
+        return self._context.get('metadata', None) or {}
+
+    @metadata.setter
+    def metadata(self, value: Dict[str, Any]) -> None:
+        if self._context.get('metadata', None) is None:
+            self._context['metadata'] = {}
+
+        self._context['metadata'].update(value)
 
     @property
     def scenario_state(self) -> Optional[ScenarioState]:

--- a/grizzly/users/messagequeue.py
+++ b/grizzly/users/messagequeue.py
@@ -135,7 +135,8 @@ from grizzly.exceptions import StopScenario
 from grizzly.types import GrizzlyResponse, RequestDirection, RequestType
 from grizzly.utils import merge_dicts
 from grizzly_extras.arguments import get_unsupported_arguments, parse_arguments
-from grizzly_extras.async_message import AsyncMessageContext, AsyncMessageRequest, AsyncMessageResponse, async_message_request
+from grizzly_extras.async_message import AsyncMessageContext, AsyncMessageRequest, AsyncMessageResponse
+from grizzly_extras.async_message.utils import async_message_request
 
 from . import GrizzlyUser, grizzlycontext
 

--- a/grizzly/users/servicebus.py
+++ b/grizzly/users/servicebus.py
@@ -81,7 +81,8 @@ from grizzly.types import GrizzlyResponse, RequestDirection, RequestMethod, Requ
 from grizzly.types.locust import Environment, StopUser
 from grizzly.utils import is_template
 from grizzly_extras.arguments import get_unsupported_arguments, parse_arguments
-from grizzly_extras.async_message import AsyncMessageContext, AsyncMessageRequest, AsyncMessageResponse, async_message_request
+from grizzly_extras.async_message import AsyncMessageContext, AsyncMessageRequest, AsyncMessageResponse
+from grizzly_extras.async_message.utils import async_message_request
 
 from . import GrizzlyUser, grizzlycontext
 

--- a/grizzly/utils.py
+++ b/grizzly/utils.py
@@ -19,12 +19,14 @@ from dateutil.parser import parse as dateparser
 from locust.stats import STATS_NAME_WIDTH
 
 from grizzly.types import T
-from grizzly_extras.async_message import AsyncMessageRequest, AsyncMessageResponse, async_message_request
+from grizzly_extras.async_message.utils import async_message_request
 
 if TYPE_CHECKING:  # pragma: no cover
     from types import FunctionType
 
     import zmq.green as zmq
+
+    from grizzly_extras.async_message import AsyncMessageRequest, AsyncMessageResponse
 
     from .context import GrizzlyContextScenario
     from .scenarios import GrizzlyScenario

--- a/grizzly_extras/async_message/mq/__init__.py
+++ b/grizzly_extras/async_message/mq/__init__.py
@@ -347,7 +347,7 @@ class AsyncMessageQueueHandler(AsyncMessageHandler):
                                 # Message disappeared, retry
                                 do_retry = True
                             elif e.reason == pymqi.CMQC.MQRC_TRUNCATED_MSG_FAILED:
-                                original_length = getattr(e, 'original_length', None)
+                                original_length = getattr(e, 'original_length', -1)
                                 self.logger.warning('got MQRC_TRUNCATED_MSG_FAILED while getting message, retries=%d, original_length=%d', retries, original_length)
                                 if max_message_size is None:
                                     # Concurrency issue, retry

--- a/grizzly_extras/async_message/sb.py
+++ b/grizzly_extras/async_message/sb.py
@@ -413,7 +413,7 @@ class AsyncServiceBusHandler(AsyncMessageHandler):
                 transport_type=TransportType.AmqpOverWebsocket,
             )
 
-        if self.mgmt_client is None and self.logger._logger.level == logging.DEBUG:
+        if self.mgmt_client is None and self.logger.getEffectiveLevel() == logging.DEBUG:
             self.mgmt_client = ServiceBusAdministrationClient.from_connection_string(conn_str=url)
 
         endpoint = context['endpoint']
@@ -612,7 +612,7 @@ class AsyncServiceBusHandler(AsyncMessageHandler):
                             if retry < 3:
                                 self.logger.warning('receiver for %d::%s returned no message without trying, brute-force retry #%d', client, cache_endpoint, retry)
                                 # <!-- useful debugging information, actual message count on message entity
-                                if self.logger._logger.level == logging.DEBUG and self.mgmt_client is not None:
+                                if self.logger.getEffectiveLevel() == logging.DEBUG and self.mgmt_client is not None:
                                     if 'topic' in endpoint_arguments:
                                         topic_properties = self.mgmt_client.get_subscription_runtime_properties(
                                             topic_name=endpoint_arguments['topic'],

--- a/grizzly_extras/async_message/utils.py
+++ b/grizzly_extras/async_message/utils.py
@@ -1,7 +1,16 @@
 """Utilities used by grizzly_extras.async_message."""
 from __future__ import annotations
 
-from typing import Any, Union
+import logging
+from time import perf_counter, sleep
+from typing import Any, Optional, Union, cast
+
+import zmq.green as zmq
+from zmq.error import Again as ZMQAgain
+
+from grizzly_extras.async_message import AsyncMessageAbort, AsyncMessageError, AsyncMessageRequest, AsyncMessageResponse
+
+logger = logging.getLogger(__name__)
 
 
 def tohex(value: Union[int, str, bytes, bytearray, Any]) -> str:
@@ -16,3 +25,37 @@ def tohex(value: Union[int, str, bytes, bytearray, Any]) -> str:
 
     message = f'{value} has an unsupported type {type(value)}'
     raise ValueError(message)
+
+
+def async_message_request(client: zmq.Socket, request: AsyncMessageRequest) -> AsyncMessageResponse:
+    try:
+        client.send_json(request)
+
+        response: Optional[AsyncMessageResponse] = None
+
+        while True:
+            start = perf_counter()
+            try:
+                response = cast(Optional[AsyncMessageResponse], client.recv_json(flags=zmq.NOBLOCK))
+                break
+            except ZMQAgain:
+                sleep(0.1)
+            delta = perf_counter() - start
+            if delta > 1.0:
+                logger.debug('async_message_request::recv_json took %f seconds', delta)
+
+        if response is None:
+            msg = 'no response'
+            raise AsyncMessageError(msg)
+
+        message = response.get('message', None)
+
+        if not response['success']:
+            raise AsyncMessageError(message)
+
+    except Exception as e:
+        if not isinstance(e, (AsyncMessageError, AsyncMessageAbort)):
+            logger.exception('failed to send request=%r', request)
+        raise
+    else:
+        return response

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -38,6 +38,9 @@ def ANY(*cls: Type, message: Optional[str] = None) -> object:  # noqa: N802
     """Compare equal to everything, as long as it is of the same type."""
     class WrappedAny(metaclass=ABCMeta):  # noqa: B024
         def __eq__(self, other: object) -> bool:
+            if len(cls) < 1:
+                return True
+
             return isinstance(other, cls) and (message is None or (message is not None and message in str(other)))
 
         def __ne__(self, other: object) -> bool:
@@ -47,10 +50,13 @@ def ANY(*cls: Type, message: Optional[str] = None) -> object:  # noqa: N802
             return self.__ne__(other)
 
         def __repr__(self) -> str:
-            if message is None:
-                return f'<ANY({cls})>'
+            c = cls[0] if len(cls) == 1 else cls
+            representation: List[str] = [f'<ANY({c})', '>']
 
-            return f"<ANY({cls}, message='{message}')>"
+            if message is not None:
+                representation.insert(-1, f", message='{message}'")
+
+            return ''.join(representation)
 
     for c in cls:
         WrappedAny.register(c)

--- a/tests/unit/test_grizzly/test_utils.py
+++ b/tests/unit/test_grizzly/test_utils.py
@@ -183,7 +183,10 @@ def test_create_user_class_type(behave_fixture: BehaveFixture) -> None:  # noqa:
                 'initialize_uri': None,
             },
         },
-        'metadata': None,
+        'metadata': {
+            'Content-Type': 'application/json',
+            'x-grizzly-user': 'grizzly.users.RestApiUser_001',
+        },
     }
     assert user_type_1.__scenario__ is scenario
 
@@ -279,6 +282,7 @@ def test_create_user_class_type(behave_fixture: BehaveFixture) -> None:  # noqa:
         'metadata': {
             'Content-Type': 'application/xml',
             'Foo-Bar': 'hello world',
+            'x-grizzly-user': 'RestApiUser_001',
         },
     }
     assert user_type_2.__scenario__ is scenario

--- a/tests/unit/test_grizzly/users/test_restapi.py
+++ b/tests/unit/test_grizzly/users/test_restapi.py
@@ -55,7 +55,10 @@ class TestRestApiUser:
                     'initialize_uri': None,
                 },
             },
-            'metadata': None,
+            'metadata': {
+                'Content-Type': 'application/json',
+                'x-grizzly-user': parent.user.__class__.__name__,
+            },
         }
         assert parent.user.metadata == {
             'Content-Type': 'application/json',

--- a/tests/unit/test_grizzly_extras/async_message/test_utils.py
+++ b/tests/unit/test_grizzly_extras/async_message/test_utils.py
@@ -1,9 +1,17 @@
 """Unit tests of grizzly_extras.async_message.utils."""
 from __future__ import annotations
 
-import pytest
+from typing import TYPE_CHECKING
 
-from grizzly_extras.async_message.utils import tohex
+import pytest
+import zmq.green as zmq
+from zmq.error import Again as ZMQAgain
+
+from grizzly_extras.async_message import AsyncMessageError, AsyncMessageRequest
+from grizzly_extras.async_message.utils import async_message_request, tohex
+
+if TYPE_CHECKING:  # pragma: no cover
+    from tests.fixtures import MockerFixture
 
 
 class Test_tohex:
@@ -22,3 +30,47 @@ class Test_tohex:
 
     def test_bytearray(self) -> None:
         assert tohex(bytearray(b'\xde\xad\xbe\xef')) == 'deadbeef'
+
+
+def test_async_message_request(mocker: MockerFixture) -> None:
+    client_mock = mocker.MagicMock()
+    sleep_mock = mocker.patch('grizzly_extras.async_message.utils.sleep', return_value=None)
+
+    # no valid response
+    client_mock.recv_json.side_effect = [ZMQAgain, None]
+
+    request: AsyncMessageRequest = {
+        'worker': None,
+        'action': 'HELLO',
+    }
+
+    with pytest.raises(AsyncMessageError, match='no response'):
+        async_message_request(client_mock, request)
+
+    sleep_mock.assert_called_once_with(0.1)
+    client_mock.send_json.assert_called_once_with(request)
+
+    assert client_mock.recv_json.call_count == 2
+    for i in range(2):
+        args, kwargs = client_mock.recv_json.call_args_list[i]
+        assert args == ()
+        assert kwargs == {'flags': zmq.NOBLOCK}
+
+    sleep_mock.reset_mock()
+    client_mock.reset_mock()
+
+    # unsuccessful response
+    client_mock.recv_json.side_effect = None
+    client_mock.recv_json.return_value = {'success': False, 'message': 'error! error! error!'}
+
+    with pytest.raises(AsyncMessageError, match='error! error! error!'):
+        async_message_request(client_mock, request)
+
+    sleep_mock.assert_not_called()
+    client_mock.send_json.assert_called_once_with(request)
+    client_mock.recv_json.assert_called_once_with(flags=zmq.NOBLOCK)
+
+    # valid response
+    client_mock.recv_json.return_value = {'success': True, 'worker': 'foo-bar-baz-foo', 'payload': 'yes'}
+
+    assert async_message_request(client_mock, request) == {'success': True, 'worker': 'foo-bar-baz-foo', 'payload': 'yes'}


### PR DESCRIPTION
removed `ThreadLogger` class while implementing the fix for #283. that class was created as a possible work-around where tests running distributed would fail at after a while. turned out it was due to a buffer becoming full (since it wasn't read), but this logger wrapper was never removed.

metadata should not be it's own instance variable, it should read `self._context['metadata']`, so removed the instance variable and created property getter/setter that wraps around `_context` instead.