### PR TITLE
handle ENAMETOOLONG when creating a request task with source in context text

### DIFF
--- a/grizzly/steps/_helpers.py
+++ b/grizzly/steps/_helpers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+from errno import ENAMETOOLONG
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Type, cast
 from urllib.parse import urlparse
@@ -69,7 +70,11 @@ def _create_request_task(
                         source = fd.read()
 
                 template = j2env.get_template(source)
-        except j2.exceptions.TemplateNotFound:
+        except (j2.exceptions.TemplateNotFound, OSError) as e:
+            # `TemplateNotFound` inherits `OSError`...
+            if not isinstance(e, j2.exceptions.TemplateNotFound) and e.errno != ENAMETOOLONG:
+                raise
+
             if name is None:
                 name = original_source.replace(''.join(Path(original_source).suffixes), '')
 

--- a/grizzly/users/__init__.py
+++ b/grizzly/users/__init__.py
@@ -5,7 +5,7 @@ These implementations are the basis for how to communicate with the system under
 
 ## Custom
 
-It is possible to implement custom users, the only requirement is that they inherit `grizzly.users.base.GrizzlyUser`. To get them to be executed by `grizzly`
+It is possible to implement custom users, the only requirement is that they inherit `grizzly.users.GrizzlyUser`. To get them to be executed by `grizzly`
 the full namespace has to be specified as `user_class_name` in the scenarios {@pylink grizzly.steps.scenario.user} step.
 
 There are examples of this in the {@link framework.example}.


### PR DESCRIPTION
if request source specified in the step expression [context] text is too long, the check to see if it is a template file failed due to ENAMETOOLONG. this problem was introduced when changing from `os.path` to `pathlib.Path` for handling files.