### PR TITLE
change context variables during runtime via `SetVariableTask`

### DIFF
--- a/grizzly/auth/__init__.py
+++ b/grizzly/auth/__init__.py
@@ -8,7 +8,7 @@ from enum import Enum
 from functools import wraps
 from importlib import import_module
 from time import time
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, Generic, Literal, Optional, Tuple, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, Generic, Literal, Optional, Set, Tuple, Type, TypeVar, Union, cast
 from urllib.parse import urlparse
 
 from grizzly.tasks import RequestTask
@@ -64,6 +64,8 @@ class GrizzlyHttpAuthClient(Generic[P], metaclass=ABCMeta):
             },
         },
         'metadata': None,
+        '__cached_auth__': {},
+        '__context_change_history__': set(),
     }
     session_started: Optional[float]
     grizzly: GrizzlyContext
@@ -75,6 +77,14 @@ class GrizzlyHttpAuthClient(Generic[P], metaclass=ABCMeta):
             self._context['metadata'] = {}
 
         cast(dict, self._context['metadata']).update({key: value})
+
+    @property
+    def __context_change_history__(self) -> Set[str]:
+        return cast(Set[str], self._context['__context_change_history__'])
+
+    @property
+    def __cached_auth__(self) -> Dict[str, str]:
+        return cast(Dict[str, str], self._context['__cached_auth__'])
 
 
 AuthenticatableFunc = TypeVar('AuthenticatableFunc', bound=Callable[..., GrizzlyResponse])

--- a/grizzly/auth/aad.py
+++ b/grizzly/auth/aad.py
@@ -752,7 +752,7 @@ class AAD(RefreshToken):
             request_meta = {
                 'request_type': 'AUTH',
                 'response_time': int((time_perf_counter() - start_time) * 1000),
-                'name': f'{scenario_index} {cls.__name__} OAuth2 user token {version}',
+                'name': f'{scenario_index} {cls.__name__} OAuth2 user token {version}: {username_lowercase}',
                 'context': client._context,
                 'response': None,
                 'exception': exception,
@@ -872,7 +872,7 @@ class AAD(RefreshToken):
             request_meta = {
                 'request_type': 'AUTH',
                 'response_time': int((time_perf_counter() - start_time) * 1000),
-                'name': f'{scenario_index} {cls.__name__} OAuth2 user token {version}',
+                'name': f'{scenario_index} {cls.__name__} OAuth2 client token {version}: {auth_client_context["id"]}',
                 'context': client._context,
                 'response': None,
                 'exception': exception,

--- a/grizzly/steps/setup.py
+++ b/grizzly/steps/setup.py
@@ -10,6 +10,7 @@ from grizzly.context import GrizzlyContext
 from grizzly.tasks import SetVariableTask
 from grizzly.testdata import GrizzlyVariables
 from grizzly.testdata.utils import resolve_variable
+from grizzly.types import VariableType
 from grizzly.types.behave import Context, given, then
 from grizzly.utils import is_template
 
@@ -118,4 +119,4 @@ def step_setup_variable_value(context: Context, name: str, value: str) -> None:
         except Exception as e:
             raise AssertionError(e) from e
     else:
-        grizzly.scenario.tasks.add(SetVariableTask(name, value))
+        grizzly.scenario.tasks.add(SetVariableTask(name, value, VariableType.VARIABLES))

--- a/grizzly/tasks/set_variable.py
+++ b/grizzly/tasks/set_variable.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, MutableMapping, Optional, Type, cast
 
 from grizzly.testdata import GrizzlyVariables
+from grizzly.testdata.utils import create_context_variable
+from grizzly.types import VariableType
 from grizzly.utils import is_template
 
 from . import GrizzlyTask, grizzlytask, template
@@ -33,25 +35,30 @@ if TYPE_CHECKING:  # pragma: no cover
 class SetVariableTask(GrizzlyTask):
     variable: str
     value: str
+    variable_type: VariableType
 
     _variable_instance: Optional[MutableMapping[str, Any]] = None
     _variable_instance_type: Optional[Type[AtomicVariable]] = None
     _variable_key: str
 
-    def __init__(self, variable: str, value: str) -> None:
+    def __init__(self, variable: str, value: str, variable_type: VariableType) -> None:
         super().__init__()
 
         self.variable = variable
         self.value = value
+        self.variable_type = variable_type
 
-        module_name, variable_type, variable, sub_variable = GrizzlyVariables.get_variable_spec(self.variable)
+        if variable_type == VariableType.VARIABLES:
+            module_name, variable_type_name, variable, sub_variable = GrizzlyVariables.get_variable_spec(self.variable)
 
-        if not (module_name is None or variable_type is None):
-            self._variable_instance_type = GrizzlyVariables.load_variable(module_name, variable_type)
+            if not (module_name is None or variable_type_name is None):
+                self._variable_instance_type = GrizzlyVariables.load_variable(module_name, variable_type_name)
 
-            if not getattr(self._variable_instance_type, '__settable__', False):
-                message = f'{module_name}.{variable_type} is not settable'
-                raise AttributeError(message)
+                if not getattr(self._variable_instance_type, '__settable__', False):
+                    message = f'{module_name}.{variable_type_name} is not settable'
+                    raise AttributeError(message)
+        else:
+            sub_variable = None
 
         if sub_variable is not None:
             self._variable_key = f'{variable}.{sub_variable}'
@@ -69,15 +76,19 @@ class SetVariableTask(GrizzlyTask):
     def __call__(self) -> grizzlytask:
         @grizzlytask
         def task(parent: GrizzlyScenario) -> Any:
-            if self._variable_instance is None and self._variable_instance_type is not None:
-                self._variable_instance = cast(MutableMapping[str, Any], self._variable_instance_type.get())
-
             value = parent.render(self.value)
 
-            if self._variable_instance is not None:
-                self._variable_instance[self._variable_key] = value
+            if self.variable_type == VariableType.VARIABLES:
+                if self._variable_instance is None and self._variable_instance_type is not None:
+                    self._variable_instance = cast(MutableMapping[str, Any], self._variable_instance_type.get())
 
-            # always update user context with new value
-            parent.user._context['variables'][self.variable] = value
+
+                if self._variable_instance is not None:
+                    self._variable_instance[self._variable_key] = value
+
+                # always update user context with new value
+                parent.user._context['variables'][self.variable] = value
+            else:
+                parent.user.add_context(create_context_variable(self.grizzly, self.variable, value))
 
         return task

--- a/grizzly/tasks/set_variable.py
+++ b/grizzly/tasks/set_variable.py
@@ -68,7 +68,7 @@ class SetVariableTask(GrizzlyTask):
     @property
     def variable_template(self) -> str:
         """Create a dummy template for the variable, used so we will not complain that this variable isn't used anywhere."""
-        if not is_template(self.variable):
+        if not is_template(self.variable) and self.variable_type == VariableType.VARIABLES:
             return f'{{{{ {self.variable} }}}}'
 
         return self.variable

--- a/grizzly/testdata/utils.py
+++ b/grizzly/testdata/utils.py
@@ -15,7 +15,7 @@ from jinja2.meta import find_undeclared_variables
 from grizzly.testdata.ast import get_template_variables
 from grizzly.types import GrizzlyVariableType, RequestType, TestdataType
 from grizzly.types.locust import MessageHandler, StopUser
-from grizzly.utils import is_template, merge_dicts
+from grizzly.utils import is_template, merge_dicts, unflatten
 
 from . import GrizzlyVariables
 
@@ -118,12 +118,7 @@ def transform(grizzly: GrizzlyContext, data: Dict[str, Any], scenario: Optional[
 
             paths: List[str] = key.split('.')
             variable = paths.pop(0)
-            path = paths.pop()
-            struct = {path: value}
-            paths.reverse()
-
-            for path in paths:
-                struct = {path: {**struct}}
+            struct = unflatten('.'.join(paths), value)
 
             if variable in testdata:
                 testdata[variable] = merge_dicts(testdata[variable], struct)

--- a/grizzly/types/__init__.py
+++ b/grizzly/types/__init__.py
@@ -1,7 +1,7 @@
 """Grizzly types."""
 from __future__ import annotations
 
-from enum import Enum
+from enum import Enum, auto
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union, cast
 
 from locust.rpc.protocol import Message
@@ -33,6 +33,11 @@ __all__ = [
     'ZoneInfoNotFoundError',
     'pymqi',
 ]
+
+
+class VariableType(Enum):
+    VARIABLES = auto()
+    CONTEXT = auto()
 
 
 class MessageDirection(PermutationEnum):

--- a/grizzly/utils.py
+++ b/grizzly/utils.py
@@ -318,6 +318,21 @@ def flatten(node: Dict[str, Any], parents: Optional[List[str]] = None) -> Dict[s
 
     return flat
 
+def unflatten(key: str, value: Any) -> Dict[str, Any]:
+    paths: List[str] = key.split('.')
+
+    # last node should have the value
+    path = paths.pop()
+    struct = {path: value}
+
+    # build the struct from the inside out
+    paths.reverse()
+
+    for path in paths:
+        struct = {path: {**struct}}
+
+    return struct
+
 
 def normalize(value: str) -> str:
     """Normalize a string to make it more non-human friendly."""

--- a/tests/e2e/test_auth.py
+++ b/tests/e2e/test_auth.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from tests.fixtures import End2EndFixture
 
 
-def test_e2e_auth(e2e_fixture: End2EndFixture) -> None:
+def test_e2e_auth_user_token(e2e_fixture: End2EndFixture) -> None:
     if e2e_fixture._distributed:
         pytest.skip('telling the webserver what to expected auth-wise is not as simple when running dist, compare to running local')
 
@@ -27,14 +27,14 @@ def test_e2e_auth(e2e_fixture: End2EndFixture) -> None:
         stats = grizzly.state.locust.environment.stats
 
         expectations = [
-            ('001 AAD OAuth2 user token v1.0', 'AUTH', 0, 1),
-            ('001 RestApi auth', 'SCEN', 0, 1),
-            ('001 RestApi auth', 'TSTD', 0, 1),
-            ('001 restapi-echo', 'GET', 0, 1),
-            ('002 AAD OAuth2 user token v1.0', 'AUTH', 0, 1),
-            ('002 HttpClientTask auth', 'SCEN', 0, 1),
-            ('002 HttpClientTask auth', 'TSTD', 0, 1),
-            ('002 httpclient-echo', 'CLTSK', 0, 1),
+            ('001 AAD OAuth2 client token v1.0: dummy-client-id', 'AUTH', 0, 1),
+            ('001 RestApi auth', 'SCEN', 0, 2),
+            ('001 RestApi auth', 'TSTD', 0, 2),
+            ('001 restapi-echo', 'GET', 0, 2),
+            ('002 AAD OAuth2 client token v1.0: dummy-client-id', 'AUTH', 0, 1),
+            ('002 HttpClientTask auth', 'SCEN', 0, 2),
+            ('002 HttpClientTask auth', 'TSTD', 0, 2),
+            ('002 httpclient-echo', 'CLTSK', 0, 2),
         ]
 
         for name, method, expected_num_failures, expected_num_requests in expectations:
@@ -77,7 +77,7 @@ def test_e2e_auth(e2e_fixture: End2EndFixture) -> None:
             And set context variable "auth.client.id" to "{e2e_fixture.webserver.auth['client']['id']}"
             And set context variable "auth.client.secret" to "{e2e_fixture.webserver.auth['client']['secret']}"
             {add_metadata()}
-            And repeat for "1" iterations
+            And repeat for "2" iterations
             Then get request with name "restapi-echo" from endpoint "/api/echo"
 
         Scenario: HttpClientTask auth
@@ -86,7 +86,7 @@ def test_e2e_auth(e2e_fixture: End2EndFixture) -> None:
             And set context variable "{e2e_fixture.host}/auth.provider" to "http://{e2e_fixture.host}{e2e_fixture.webserver.auth_provider_uri}"
             And set context variable "{e2e_fixture.host}/auth.client.id" to "{e2e_fixture.webserver.auth['client']['id']}"
             And set context variable "{e2e_fixture.host}/auth.client.secret" to "{e2e_fixture.webserver.auth['client']['secret']}"
-            And repeat for "1" iterations
+            And repeat for "2" iterations
             Then get "http://{e2e_fixture.host}/api/echo" with name "httpclient-echo" and save response payload in "foobar"
             {add_metadata()}
         """))

--- a/tests/unit/test_grizzly/auth/test___init__.py
+++ b/tests/unit/test_grizzly/auth/test___init__.py
@@ -209,13 +209,13 @@ def test_refresh_token_user(grizzly_fixture: GrizzlyFixture, mocker: MockerFixtu
     get_token_mock.assert_called_once_with(parent.user, AuthMethod.USER)
     get_token_mock.reset_mock()
 
-    parent.user.add_context({'auth': {'user': {'username': 'alice@example.com'}}})
+    parent.user.add_context({'auth': {'user': {'username': 'alice@example.com', 'password': 'foobar'}}})
     assert 'Authorization' not in parent.user.metadata
     auth_context = parent.user._context.get('auth', None)
     assert auth_context is not None
     assert auth_context.get('user', None) == {
         'username': 'alice@example.com',
-        'password': 'HemligaArne',
+        'password': 'foobar',
         'otp_secret': None,
         'redirect_uri': '/authenticated',
         'initialize_uri': None,

--- a/tests/unit/test_grizzly/auth/test_aad.py
+++ b/tests/unit/test_grizzly/auth/test_aad.py
@@ -514,7 +514,7 @@ class TestAAD:
             fire_spy.assert_called_once_with(
                 request_type='AUTH',
                 response_time=0,
-                name=f'001 AAD OAuth2 user token {version}',
+                name=f'001 AAD OAuth2 user token {version}: test-user@example.com',
                 context=parent.user._context,
                 response_length=0,
                 response=None,
@@ -530,7 +530,7 @@ class TestAAD:
             fire_spy.assert_called_once_with(
                 request_type='AUTH',
                 response_time=0,
-                name=f'001 AAD OAuth2 user token {version}',
+                name=f'001 AAD OAuth2 user token {version}: test-user@example.com',
                 context=parent.user._context,
                 response_length=0,
                 response=None,
@@ -546,7 +546,7 @@ class TestAAD:
             fire_spy.assert_called_once_with(
                 request_type='AUTH',
                 response_time=0,
-                name=f'001 AAD OAuth2 user token {version}',
+                name=f'001 AAD OAuth2 user token {version}: test-user@example.com',
                 context=parent.user._context,
                 response_length=0,
                 response=None,
@@ -562,7 +562,7 @@ class TestAAD:
             fire_spy.assert_called_once_with(
                 request_type='AUTH',
                 response_time=0,
-                name=f'001 AAD OAuth2 user token {version}',
+                name=f'001 AAD OAuth2 user token {version}: test-user@example.com',
                 context=parent.user._context,
                 response_length=0,
                 response=None,
@@ -583,7 +583,7 @@ class TestAAD:
             fire_spy.assert_called_once_with(
                 request_type='AUTH',
                 response_time=0,
-                name=f'001 AAD OAuth2 user token {version}',
+                name=f'001 AAD OAuth2 user token {version}: test-user@example.com',
                 context=parent.user._context,
                 response_length=0,
                 response=None,
@@ -604,7 +604,7 @@ class TestAAD:
             fire_spy.assert_called_once_with(
                 request_type='AUTH',
                 response_time=0,
-                name=f'001 AAD OAuth2 user token {version}',
+                name=f'001 AAD OAuth2 user token {version}: test-user@example.com',
                 context=parent.user._context,
                 response_length=0,
                 response=None,
@@ -628,7 +628,7 @@ class TestAAD:
             fire_spy.assert_called_once_with(
                 request_type='AUTH',
                 response_time=0,
-                name=f'001 AAD OAuth2 user token {version}',
+                name=f'001 AAD OAuth2 user token {version}: test-user@example.com',
                 context=parent.user._context,
                 response_length=0,
                 response=None,
@@ -646,7 +646,7 @@ class TestAAD:
             fire_spy.assert_called_once_with(
                 request_type='AUTH',
                 response_time=0,
-                name=f'001 AAD OAuth2 user token {version}',
+                name=f'001 AAD OAuth2 user token {version}: test-user@example.com',
                 context=parent.user._context,
                 response_length=0,
                 response=None,
@@ -662,7 +662,7 @@ class TestAAD:
             fire_spy.assert_called_once_with(
                 request_type='AUTH',
                 response_time=0,
-                name=f'001 AAD OAuth2 user token {version}',
+                name=f'001 AAD OAuth2 user token {version}: test-user@example.com',
                 context=parent.user._context,
                 response_length=0,
                 response=None,
@@ -677,7 +677,7 @@ class TestAAD:
             fire_spy.assert_called_once_with(
                 request_type='AUTH',
                 response_time=0,
-                name=f'001 AAD OAuth2 user token {version}',
+                name=f'001 AAD OAuth2 user token {version}: test-user@example.com',
                 context=parent.user._context,
                 response_length=0,
                 response=None,
@@ -692,7 +692,7 @@ class TestAAD:
             fire_spy.assert_called_once_with(
                 request_type='AUTH',
                 response_time=0,
-                name=f'001 AAD OAuth2 user token {version}',
+                name=f'001 AAD OAuth2 user token {version}: test-user@example.com',
                 context=parent.user._context,
                 response_length=0,
                 response=None,
@@ -707,7 +707,7 @@ class TestAAD:
             fire_spy.assert_called_once_with(
                 request_type='AUTH',
                 response_time=0,
-                name=f'001 AAD OAuth2 user token {version}',
+                name=f'001 AAD OAuth2 user token {version}: test-user@example.com',
                 context=parent.user._context,
                 response_length=0,
                 response=None,
@@ -734,7 +734,7 @@ class TestAAD:
             fire_spy.assert_called_once_with(
                 request_type='AUTH',
                 response_time=0,
-                name=f'001 AAD OAuth2 user token {version}',
+                name=f'001 AAD OAuth2 user token {version}: test-user@example.com',
                 context=parent.user._context,
                 response_length=0,
                 response=None,
@@ -752,7 +752,7 @@ class TestAAD:
             fire_spy.assert_called_once_with(
                 request_type='AUTH',
                 response_time=0,
-                name=f'001 AAD OAuth2 user token {version}',
+                name=f'001 AAD OAuth2 user token {version}: test-user@example.com',
                 context=parent.user._context,
                 response_length=0,
                 response=None,
@@ -768,7 +768,7 @@ class TestAAD:
                 fire_spy.assert_called_once_with(
                     request_type='AUTH',
                     response_time=0,
-                    name=f'001 AAD OAuth2 user token {version}',
+                    name=f'001 AAD OAuth2 user token {version}: test-user@example.com',
                     context=parent.user._context,
                     response_length=0,
                     response=None,
@@ -783,7 +783,7 @@ class TestAAD:
                 fire_spy.assert_called_once_with(
                     request_type='AUTH',
                     response_time=0,
-                    name=f'001 AAD OAuth2 user token {version}',
+                    name=f'001 AAD OAuth2 user token {version}: test-user@example.com',
                     context=parent.user._context,
                     response_length=0,
                     response=None,
@@ -809,7 +809,7 @@ class TestAAD:
             fire_spy.assert_called_once_with(
                 request_type='AUTH',
                 response_time=0,
-                name=f'001 AAD OAuth2 user token {version}',
+                name=f'001 AAD OAuth2 user token {version}: test-user@example.com',
                 context=parent.user._context,
                 response_length=0,
                 response=None,
@@ -829,7 +829,7 @@ class TestAAD:
             fire_spy.assert_called_once_with(
                 request_type='AUTH',
                 response_time=0,
-                name=f'001 AAD OAuth2 user token {version}',
+                name=f'001 AAD OAuth2 user token {version}: test-user@example.com',
                 context=parent.user._context,
                 response_length=0,
                 response=None,
@@ -848,7 +848,7 @@ class TestAAD:
             fire_spy.assert_called_once_with(
                 request_type='AUTH',
                 response_time=0,
-                name=f'001 AAD OAuth2 user token {version}',
+                name=f'001 AAD OAuth2 user token {version}: test-user@example.com',
                 context=parent.user._context,
                 response_length=0,
                 response=None,
@@ -868,7 +868,7 @@ class TestAAD:
             fire_spy.assert_called_once_with(
                 request_type='AUTH',
                 response_time=0,
-                name=f'001 AAD OAuth2 user token {version}',
+                name=f'001 AAD OAuth2 user token {version}: test-user@example.com',
                 context=parent.user._context,
                 response_length=0,
                 response=None,
@@ -887,7 +887,7 @@ class TestAAD:
             fire_spy.assert_called_once_with(
                 request_type='AUTH',
                 response_time=0,
-                name=f'001 AAD OAuth2 user token {version}',
+                name=f'001 AAD OAuth2 user token {version}: test-user@example.com',
                 context=parent.user._context,
                 response_length=0,
                 response=None,
@@ -907,7 +907,7 @@ class TestAAD:
             fire_spy.assert_called_once_with(
                 request_type='AUTH',
                 response_time=0,
-                name=f'001 AAD OAuth2 user token {version}',
+                name=f'001 AAD OAuth2 user token {version}: test-user@example.com',
                 context=parent.user._context,
                 response_length=0,
                 response=None,
@@ -926,7 +926,7 @@ class TestAAD:
             fire_spy.assert_called_once_with(
                 request_type='AUTH',
                 response_time=0,
-                name=f'001 AAD OAuth2 user token {version}',
+                name=f'001 AAD OAuth2 user token {version}: test-user@example.com',
                 context=parent.user._context,
                 response_length=0,
                 response=None,
@@ -951,7 +951,7 @@ class TestAAD:
             fire_spy.assert_called_once_with(
                 request_type='AUTH',
                 response_time=0,
-                name=f'001 AAD OAuth2 user token {version}',
+                name=f'001 AAD OAuth2 user token {version}: test-user@example.com',
                 context=parent.user._context,
                 response_length=0,
                 response=None,
@@ -1074,7 +1074,7 @@ class TestAAD:
                 fire_spy.assert_called_once_with(
                     request_type='AUTH',
                     response_time=ANY(int),
-                    name=f'001 AAD OAuth2 user token {version}.0',
+                    name=f'001 AAD OAuth2 client token {version}.0: asdf',
                     context=parent.user._context,
                     response=None,
                     exception=ANY(RuntimeError, message='fake error message'),

--- a/tests/unit/test_grizzly/steps/scenario/test_setup.py
+++ b/tests/unit/test_grizzly/steps/scenario/test_setup.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from contextlib import suppress
+from hashlib import sha256
 from os import environ
 from typing import TYPE_CHECKING, cast
 
@@ -14,6 +15,7 @@ from grizzly.tasks.clients import HttpClientTask
 from grizzly.testdata import GrizzlyVariables, GrizzlyVariableType
 from grizzly.types import RequestDirection, RequestMethod
 from grizzly.users import RestApiUser
+from tests.helpers import SOME
 
 if TYPE_CHECKING:  # pragma: no cover
     from pytest_mock import MockerFixture
@@ -47,13 +49,19 @@ def test_step_setup_set_context_variable_runtime(grizzly_fixture: GrizzlyFixture
     task = grizzly.scenario.tasks.pop()
 
     assert len(grizzly.scenario.tasks) == 0
+    assert parent.user.__cached_auth__ == {}
 
     step_setup_set_context_variable(behave, 'auth.user.username', 'bob')
+    step_setup_set_context_variable(behave, 'auth.user.password', 'foobar')
 
     assert grizzly.scenario.context == {
         'host': '',
-        'auth': {'user': {'username': 'bob'},
+        'auth': {'user': {'username': 'bob', 'password': 'foobar'},
     }}
+    assert parent.user.__cached_auth__ == {}
+    assert parent.user.__context_change_history__ == set()
+
+    parent.user._context = merge_dicts(parent.user._context, grizzly.scenario.context)
 
     assert len(grizzly.scenario.tasks()) == 0
 
@@ -62,27 +70,70 @@ def test_step_setup_set_context_variable_runtime(grizzly_fixture: GrizzlyFixture
     step_setup_set_context_variable(behave, 'auth.user.username', 'alice')
 
     assert len(grizzly.scenario.tasks()) == 2
+    assert parent.user.__context_change_history__ == set()
 
     task_factory = grizzly.scenario.tasks().pop()
 
     assert isinstance(task_factory, SetVariableTask)
     assert task_factory.variable_type == VariableType.CONTEXT
 
-    parent.user._context['metadata'].update({'Authorization': 'Bearer f00bar=='})
+    parent.user.metadata.update({'Authorization': 'Bearer f00bar=='})
     assert parent.user.metadata == {
         'Content-Type': 'application/json',
         'x-grizzly-user': 'RestApiUser_001',
         'Authorization': 'Bearer f00bar==',
     }
-    assert parent.user._context.get('auth', {}).get('user', {}).get('username', '') is None
+    assert parent.user._context.get('auth', {}).get('user', {}) == SOME(dict, username='bob', password='foobar')  # noqa: S106
 
     task_factory()(parent)
 
-    assert parent.user._context.get('auth', {}).get('user', {}).get('username', None) == 'alice'
+    assert parent.user._context.get('auth', {}).get('user', {}) == SOME(dict, username='alice', password='foobar')  # noqa: S106
+    assert parent.user.metadata == {
+        'Content-Type': 'application/json',
+        'x-grizzly-user': 'RestApiUser_001',
+        'Authorization': 'Bearer f00bar==',
+    }
+
+    expected_cache_key = sha256(b'bob:foobar').hexdigest()
+
+    assert parent.user.__context_change_history__ == {'auth.user.username'}
+    assert parent.user.__cached_auth__ == {expected_cache_key: 'Bearer f00bar=='}
+
+    step_setup_set_context_variable(behave, 'auth.user.password', 'hello world')
+
+    assert len(grizzly.scenario.tasks()) == 2
+
+    task_factory = grizzly.scenario.tasks().pop()
+
+    assert isinstance(task_factory, SetVariableTask)
+    assert task_factory.variable_type == VariableType.CONTEXT
+
+    task_factory()(parent)
+
+    assert parent.user._context.get('auth', {}).get('user', {}) == SOME(dict, username='alice', password='hello world')  # noqa: S106
     assert parent.user.metadata == {
         'Content-Type': 'application/json',
         'x-grizzly-user': 'RestApiUser_001',
     }
+
+    assert parent.user.__context_change_history__ == set()
+    assert parent.user.__cached_auth__ == {expected_cache_key: 'Bearer f00bar=='}
+
+    step_setup_set_context_variable(behave, 'auth.user.username', 'bob')
+    task_factory = grizzly.scenario.tasks().pop()
+    task_factory()(parent)
+
+    step_setup_set_context_variable(behave, 'auth.user.password', 'foobar')
+    task_factory = grizzly.scenario.tasks().pop()
+    task_factory()(parent)
+
+    assert parent.user._context.get('auth', {}).get('user', {}) == SOME(dict, username='bob', password='foobar')  # noqa: S106
+    assert parent.user.metadata == {
+        'Content-Type': 'application/json',
+        'x-grizzly-user': 'RestApiUser_001',
+        'Authorization': 'Bearer f00bar==',
+    }
+    assert parent.user.__context_change_history__ == set()
 
 def test_step_setup_set_context_variable_init(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context

--- a/tests/unit/test_grizzly/steps/test_setup.py
+++ b/tests/unit/test_grizzly/steps/test_setup.py
@@ -9,6 +9,7 @@ import pytest
 from grizzly.context import GrizzlyContext
 from grizzly.steps import *
 from grizzly.tasks import SetVariableTask
+from grizzly.types import VariableType
 
 if TYPE_CHECKING:  # pragma: no cover
     from tests.fixtures import BehaveFixture, MockerFixture
@@ -121,4 +122,4 @@ def test_step_setup_variable_value(behave_fixture: BehaveFixture, mocker: Mocker
 
     step_setup_variable_value(behave, 'custom.variable.AtomicFooBar.value.foo', 'hello')
 
-    set_variable_task_mock.assert_called_once_with('custom.variable.AtomicFooBar.value.foo', 'hello')
+    set_variable_task_mock.assert_called_once_with('custom.variable.AtomicFooBar.value.foo', 'hello', VariableType.VARIABLES)

--- a/tests/unit/test_grizzly/test_utils.py
+++ b/tests/unit/test_grizzly/test_utils.py
@@ -157,6 +157,8 @@ def test_create_user_class_type(behave_fixture: BehaveFixture) -> None:  # noqa:
             },
         },
         'metadata': None,
+        '__cached_auth__': {},
+        '__context_change_history__': set(),
     }
     user_type_1 = user_class_type_1(behave_fixture.locust.environment)
 
@@ -189,6 +191,8 @@ def test_create_user_class_type(behave_fixture: BehaveFixture) -> None:  # noqa:
             'Content-Type': 'application/json',
             'x-grizzly-user': 'grizzly.users.RestApiUser_001',
         },
+        '__cached_auth__': {},
+        '__context_change_history__': set(),
     }
     assert user_type_1.__scenario__ is scenario
 
@@ -250,6 +254,8 @@ def test_create_user_class_type(behave_fixture: BehaveFixture) -> None:  # noqa:
             'Content-Type': 'application/xml',
             'Foo-Bar': 'hello world',
         },
+        '__cached_auth__': {},
+        '__context_change_history__': set(),
     }
 
     user_type_2 = user_class_type_2(behave_fixture.locust.environment)
@@ -286,6 +292,8 @@ def test_create_user_class_type(behave_fixture: BehaveFixture) -> None:  # noqa:
             'Foo-Bar': 'hello world',
             'x-grizzly-user': 'RestApiUser_001',
         },
+        '__cached_auth__': {},
+        '__context_change_history__': set(),
     }
     assert user_type_2.__scenario__ is scenario
 
@@ -327,6 +335,8 @@ def test_create_user_class_type(behave_fixture: BehaveFixture) -> None:  # noqa:
             },
         },
         'metadata': None,
+        '__cached_auth__': {},
+        '__context_change_history__': set(),
     }
 
     assert user_class_type_1.host is not user_class_type_2.host
@@ -367,6 +377,8 @@ def test_create_user_class_type(behave_fixture: BehaveFixture) -> None:  # noqa:
             },
         },
         'metadata': None,
+        '__cached_auth__': {},
+        '__context_change_history__': set(),
     }
 
     scenario = GrizzlyContextScenario(1, behave=behave_fixture.create_scenario('A scenario description'))

--- a/tests/unit/test_grizzly/test_utils.py
+++ b/tests/unit/test_grizzly/test_utils.py
@@ -22,11 +22,13 @@ from grizzly.utils import (
     create_scenario_class_type,
     create_user_class_type,
     fail_direct,
+    flatten,
     in_correct_section,
     is_template,
     normalize,
     parse_timespan,
     safe_del,
+    unflatten,
 )
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -695,3 +697,21 @@ def test_normalize() -> None:
     assert normalize('test') == 'test'
     assert normalize('Hello World!') == 'Hello-World'
     assert normalize('[does]this-look* <strange>!') == 'doesthis-look-strange'
+
+
+def test_flatten() -> None:
+    assert flatten({
+        'hello': {'world': {'foo': {'bar': 'foobar'}}},
+        'foo': {'bar': 'hello world!'},
+    }) == {
+        'hello.world.foo.bar': 'foobar',
+        'foo.bar': 'hello world!',
+    }
+
+
+def test_unflatten() -> None:
+    assert unflatten('hello.world.foo.bar', 'foobar') == {
+        'hello': {'world': {'foo': {'bar': 'foobar'}}},
+    }
+
+    assert unflatten('foo.bar', 'hello world!') == {'foo': {'bar': 'hello world!'}}


### PR DESCRIPTION
possible if changing the user context is needed in a scenario, e.g. using a different user to perform requests.