### PR TITLE
execute python script step improvements

### DIFF
--- a/grizzly/steps/scenario/setup.py
+++ b/grizzly/steps/scenario/setup.py
@@ -3,7 +3,6 @@ This module contains step implementations that setup the load test scenario with
 """
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any, Optional, cast
 
 import parse
@@ -11,11 +10,10 @@ import parse
 from grizzly.auth import GrizzlyHttpAuthClient
 from grizzly.context import GrizzlyContext
 from grizzly.exceptions import RestartScenario
-from grizzly.locust import on_worker
 from grizzly.tasks import GrizzlyTask, RequestTask, SetVariableTask
 from grizzly.testdata.utils import create_context_variable, resolve_variable
 from grizzly.types import VariableType
-from grizzly.types.behave import Context, Feature, given, register_type, then
+from grizzly.types.behave import Context, given, register_type, then
 from grizzly.types.locust import StopUser
 from grizzly.utils import has_template, merge_dicts
 from grizzly_extras.text import permutation
@@ -258,55 +256,3 @@ def step_setup_metadata(context: Context, key: str, value: str) -> None:
             grizzly.scenario.context['metadata'] = {}
 
         grizzly.scenario.context['metadata'].update({key: casted_value})
-
-
-def _execute_python_script(context: Context, source: str) -> None:
-    if on_worker(context):
-        return
-
-    exec(source)  # noqa: S102
-
-@then('execute python script "{script_path}"')
-def step_setup_execute_python_script(context: Context, script_path: str) -> None:
-    """Execute python script located in specified path.
-
-    The script will not execute on workers, only on master (distributed mode) or local (local mode), and
-    it will only execute once before the test starts.
-
-    This can be useful for generating test data files.
-
-    Example:
-    ```gherkin
-    Then execute python script "../bin/generate-testdata.py"
-    ```
-
-    """
-    script_file = Path(script_path)
-    if not script_file.exists():
-        feature = cast(Feature, context.feature)
-        base_path = Path(feature.filename).parent if feature.filename not in [None, '<string>'] else Path.cwd()
-        script_file = (base_path / script_path).resolve()
-
-    assert script_file.exists(), f'script {script_path} does not exist'
-
-    _execute_python_script(context, script_file.read_text())
-
-@then('execute python script')
-def step_setup_execute_python_script_inline(context: Context) -> None:
-    """Execute inline python script specified in the step text.
-
-    The script will not execute on workers, only on master (distributed mode) or local (local mode), and
-    it will only execute once before the test starts.
-
-    This can be useful for generating test data files.
-
-    Example:
-    ```gherkin
-    Then execute python script
-      \"\"\"
-      print('foobar script')
-      \"\"\"
-    ```
-
-    """
-    _execute_python_script(context, context.text)

--- a/grizzly/steps/setup.py
+++ b/grizzly/steps/setup.py
@@ -4,14 +4,16 @@ This module contains steps that can be in both `Background:` and `Scenario:` sec
 from __future__ import annotations
 
 from os import environ
+from pathlib import Path
 from typing import cast
 
 from grizzly.context import GrizzlyContext
+from grizzly.locust import on_worker
 from grizzly.tasks import SetVariableTask
 from grizzly.testdata import GrizzlyVariables
 from grizzly.testdata.utils import resolve_variable
 from grizzly.types import VariableType
-from grizzly.types.behave import Context, given, then
+from grizzly.types.behave import Context, Feature, given, then
 from grizzly.utils import has_template
 
 
@@ -131,3 +133,55 @@ def step_setup_variable_value(context: Context, name: str, value: str) -> None:
             raise AssertionError(e) from e  # noqa: TRY004
 
         raise
+
+
+def _execute_python_script(context: Context, source: str) -> None:
+    if on_worker(context):
+        return
+
+    exec(source, globals(), globals())  # noqa: S102
+
+@then('execute python script "{script_path}"')
+def step_setup_execute_python_script(context: Context, script_path: str) -> None:
+    """Execute python script located in specified path.
+
+    The script will not execute on workers, only on master (distributed mode) or local (local mode), and
+    it will only execute once before the test starts.
+
+    This can be useful for generating test data files.
+
+    Example:
+    ```gherkin
+    Then execute python script "../bin/generate-testdata.py"
+    ```
+
+    """
+    script_file = Path(script_path)
+    if not script_file.exists():
+        feature = cast(Feature, context.feature)
+        base_path = Path(feature.filename).parent if feature.filename not in [None, '<string>'] else Path.cwd()
+        script_file = (base_path / script_path).resolve()
+
+    assert script_file.exists(), f'script {script_path} does not exist'
+
+    _execute_python_script(context, script_file.read_text())
+
+@then('execute python script')
+def step_setup_execute_python_script_inline(context: Context) -> None:
+    """Execute inline python script specified in the step text.
+
+    The script will not execute on workers, only on master (distributed mode) or local (local mode), and
+    it will only execute once before the test starts.
+
+    This can be useful for generating test data files.
+
+    Example:
+    ```gherkin
+    Then execute python script
+      \"\"\"
+      print('foobar script')
+      \"\"\"
+    ```
+
+    """
+    _execute_python_script(context, context.text)

--- a/grizzly/steps/setup.py
+++ b/grizzly/steps/setup.py
@@ -139,14 +139,17 @@ def _execute_python_script(context: Context, source: str) -> None:
     if on_worker(context):
         return
 
-    exec(source, globals(), globals())  # noqa: S102
+    scope = globals()
+    scope.update({'context': context})
+
+    exec(source, scope, scope)  # noqa: S102
 
 @then('execute python script "{script_path}"')
 def step_setup_execute_python_script(context: Context, script_path: str) -> None:
     """Execute python script located in specified path.
 
     The script will not execute on workers, only on master (distributed mode) or local (local mode), and
-    it will only execute once before the test starts.
+    it will only execute once before the test starts. Available in the scope is the current `context` object.
 
     This can be useful for generating test data files.
 
@@ -171,7 +174,7 @@ def step_setup_execute_python_script_inline(context: Context) -> None:
     """Execute inline python script specified in the step text.
 
     The script will not execute on workers, only on master (distributed mode) or local (local mode), and
-    it will only execute once before the test starts.
+    it will only execute once before the test starts. Available in the scope is the current `context` object.
 
     This can be useful for generating test data files.
 

--- a/grizzly/tasks/transformer.py
+++ b/grizzly/tasks/transformer.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from grizzly.scenarios import GrizzlyScenario
 
 
-@template('content')
+@template('content', 'expression')
 class TransformerTask(GrizzlyTask):
     expression: str
     variable: str

--- a/grizzly/types/__init__.py
+++ b/grizzly/types/__init__.py
@@ -5,7 +5,9 @@ from enum import Enum, auto
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union, cast
 
 from locust.rpc.protocol import Message
-from mypy_extensions import Arg, KwArg
+from typing_extensions import Concatenate, ParamSpec
+
+P = ParamSpec('P')
 
 from grizzly_extras.text import PermutationEnum
 
@@ -236,7 +238,7 @@ HandlerContextType = Union[Dict[str, Any], Optional[Any]]
 
 GrizzlyVariableType = Union[str, float, int, bool]
 
-MessageCallback = Callable[[Arg(Environment, 'environment'), Arg(Message, 'msg'), KwArg(Any)], None]
+MessageCallback = Callable[Concatenate[Environment, Message, P], None]
 
 WrappedFunc = TypeVar('WrappedFunc', bound=Callable[..., Any])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=60.10.0", "wheel>=0.37.0", "setuptools-scm>=7.0.3"]
+requires = ["setuptools ==69.2.0", "wheel ==0.43.0", "setuptools-scm ==8.0.4"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -14,24 +14,23 @@ license = {text = 'MIT'}
 requires-python = ">=3.8"
 dependencies = [
     "locust >=2.24.0,<2.25.0",
-    "azure-core >=1.24.0,<2.0.0",
-    "azure-servicebus >=7.6.0,<7.10.0",
-    "azure-storage-blob >=12.9.0,<13.0.0",
-    "azure-iot-device >=2.12.0,<3.0.0",
-    "behave >=1.2.6,<2.0.0",
-    "influxdb >=5.3.1,<6.0.0",
-    "Jinja2 >=3.0.3,<4.0.0",
-    "jsonpath-ng >=1.5.3,<2.0.0",
-    "lxml >=4.8.0,<5.0.0",
-    "mypy-extensions >=0.4.3",
-    "opencensus-ext-azure >=1.1.1",
-    "python-dateutil >=2.8.2,<3.0.0",
-    "backports.zoneinfo >=0.2.1;python_version<'3.9'",
-    "pyzmq >=22.2.1,!=23.0.0",
-    "PyYAML >=6.0.1,<7.0.0",
-    "setproctitle >=1.2.2",
-    "tzdata >=2022.1",
-    "pyotp >=2.9.0,<3.0.0"
+    "azure-core ==1.30.1",
+    "azure-servicebus ==7.9.0",
+    "azure-storage-blob ==12.19.1",
+    "azure-iot-device ==2.13.0",
+    "behave ==1.2.6",
+    "influxdb ==5.3.1",
+    "Jinja2 ==3.1.3",
+    "jsonpath-ng ==1.6.1",
+    "lxml ==5.1.0",
+    "opencensus-ext-azure ==1.1.13",
+    "python-dateutil ==2.9.0.post0",
+    "backports.zoneinfo ==0.2.1;python_version<'3.9'",
+    "pyzmq ==25.1.2",
+    "PyYAML ==6.0.1",
+    "setproctitle ==1.3.3",
+    "pyotp ==2.9.0",
+    "tzdata >=2022.1"
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -73,44 +72,43 @@ mq = [
     "pymqi ==1.12.10"
 ]
 dev = [
-    "wheel>=0.37.0",
-    "astunparse >=1.6.3",
-    "mypy >=1.3.0",
-    "pytest >=7.0.0",
-    "coverage[toml] >=6.4.4",
-    "pytest-cov >=3.0.0",
-    "pytest-mock >=3.7.0",
-    "pytest-timeout >=2.1.0",
-    "atomicwrites >= 1.4.0",
+    "wheel ==0.43.0",
+    "astunparse ==1.6.3",
+    "mypy ==1.9.0",
+    "pytest ==8.1.1",
+    "coverage[toml] ==6.4.4",
+    "pytest-cov ==5.0.0",
+    "pytest-mock ==3.14.0",
+    "pytest-timeout ==2.3.1",
+    "atomicwrites ==1.4.1",
+    "snakeviz ==2.2.0",
+    "ruff ==0.3.4",
+    "parameterized ==0.9.0",
+    "line-profiler ==4.1.2",
     "types-paramiko >=2.8.13",
     "types-python-dateutil >=2.8.9",
     "types-PyYAML <6.0.0,>=5.3.0",
     "types-requests >=2.27.0",
     "types-Jinja2 >=2.0.0",
-    "types-backports >=0.1.3",
-    "snakeviz",
-    "ruff <1.0.0",
-    "parameterized >=0.9.0,<1.0.0",
-    "line-profiler ==4.1.2"
+    "types-backports >=0.1.3"
 ]
 ci = [
-    "build >=0.7.0",
-    "twine >=3.8.0,<4.0.0"
+    "build ==1.1.1",
+    "twine ==5.0.0"
 ]
 docs = [
-    "novella >=0.2.6",
-    "pydoc-markdown >=4.6.1",
-    "docspec >=2.1.2",
-    "docspec-python >=2.1.2",
-    "pytablewriter >=0.64.1",
-    "pip-licenses >=3.5.3,<4.2.0",
-    "requests >=2.27.1",
-    "mkdocs >=1.3.0",
-    "mkdocs-material >=8.3.2",
-    "packaging >=21.3",
-    "grizzly-loadtester-cli",
-    "python-frontmatter",
-    "mistune >=3.0.2"
+    "novella ==0.2.6",
+    "pydoc-markdown ==4.8.2",
+    "databind ==4.4.2",
+    "pytablewriter ==1.2.0",
+    "pip-licenses ==4.3.4",
+    "requests ==2.31.0",
+    "mkdocs ==1.5.3",
+    "mkdocs-material ==9.5.15",
+    "packaging ==24.0",
+    "mistune ==3.0.2",
+    "python-frontmatter ==1.1.0",
+    "grizzly-loadtester-cli"
 ]
 
 [tool.setuptools_scm]

--- a/script/docs-generate-licenses.py
+++ b/script/docs-generate-licenses.py
@@ -34,6 +34,9 @@ def generate_license_table() -> List[str]:
     args.allow_only = None
     args.with_system = False
     args.filter_strings = False
+    args.with_maintainers = False
+    args.no_version = False
+    args.python = sys.executable
 
     licenses = jsonloads(create_output_string(args))
     headers = ['Name', 'Version', 'License']

--- a/tests/unit/test_grizzly/listeners/test___init__.py
+++ b/tests/unit/test_grizzly/listeners/test___init__.py
@@ -92,7 +92,7 @@ def test_init_master(caplog: LogCaptureFixture, grizzly_fixture: GrizzlyFixture)
         runner = MasterRunner(grizzly_fixture.behave.locust.environment, '0.0.0.0', 5555)
         grizzly.state.locust = runner
 
-        init_function = init(grizzly, {})
+        init_function: Callable[..., None] = init(grizzly, {})
         assert callable(init_function)
 
         init_function(runner)
@@ -110,10 +110,10 @@ def test_init_master(caplog: LogCaptureFixture, grizzly_fixture: GrizzlyFixture)
             init_function(runner)
         assert 'there is no test data' in caplog.text
 
-        def callback(environment: Environment, msg: Message, **_kwargs: Any) -> None:  # noqa: ARG001
+        def callback(environment: Environment, msg: Message, *_args: Any, **_kwargs: Any) -> None:  # noqa: ARG001
             pass
 
-        def callback_ack(environment: Environment, msg: Message, **_kwargs: Any) -> None:  # noqa: ARG001
+        def callback_ack(environment: Environment, msg: Message, *_args: Any, **_kwargs: Any) -> None:  # noqa: ARG001
             pass
 
         grizzly.setup.locust.messages.register(MessageDirection.CLIENT_SERVER, 'test_message', callback)
@@ -139,7 +139,7 @@ def test_init_worker(grizzly_fixture: GrizzlyFixture) -> None:
     try:
         grizzly = grizzly_fixture.grizzly
 
-        init_function = init(grizzly)
+        init_function: Callable[..., None] = init(grizzly)
         assert callable(init_function)
 
         runner = WorkerRunner(grizzly_fixture.behave.locust.environment, 'localhost', 5555)
@@ -153,10 +153,10 @@ def test_init_worker(grizzly_fixture: GrizzlyFixture) -> None:
             'grizzly_worker_quit': grizzly_worker_quit,
         })
 
-        def callback(environment: Environment, msg: Message, **_kwargs: Any) -> None:  # noqa: ARG001
+        def callback(environment: Environment, msg: Message, *_args: Any, **_kwargs: Any) -> None:  # noqa: ARG001
             pass
 
-        def callback_ack(environment: Environment, msg: Message, **_kwargs: Any) -> None:  # noqa: ARG001
+        def callback_ack(environment: Environment, msg: Message, *_args: Any, **_kwargs: Any) -> None:  # noqa: ARG001
             pass
 
         grizzly.state.locust.custom_messages.clear()
@@ -188,7 +188,7 @@ def test_init_local(grizzly_fixture: GrizzlyFixture) -> None:
         runner = LocalRunner(grizzly_fixture.behave.locust.environment)
         grizzly.state.locust = runner
 
-        init_function = init(grizzly, {})
+        init_function: Callable[..., None] = init(grizzly, {})
         assert callable(init_function)
 
         init_function(runner)
@@ -201,10 +201,10 @@ def test_init_local(grizzly_fixture: GrizzlyFixture) -> None:
 
         assert environ.get('TESTDATA_PRODUCER_ADDRESS', None) == 'tcp://127.0.0.1:5555'
 
-        def callback(environment: Environment, msg: Message, **_kwargs: Any) -> None:  # noqa: ARG001
+        def callback(environment: Environment, msg: Message, *_args: Any, **_kwargs: Any) -> None:  # noqa: ARG001
             pass
 
-        def callback_ack(environment: Environment, msg: Message, **_kwargs: Any) -> None:  # noqa: ARG001
+        def callback_ack(environment: Environment, msg: Message, *_args: Any, **_kwargs: Any) -> None:  # noqa: ARG001
             pass
 
         grizzly.setup.locust.messages.register(MessageDirection.CLIENT_SERVER, 'test_message', callback)
@@ -353,7 +353,7 @@ def test_quitting(mocker: MockerFixture, grizzly_fixture: GrizzlyFixture) -> Non
         with pytest.raises(Running):
             init_testdata()
 
-        init_function = init(grizzly, {})
+        init_function: Callable[..., None] = init(grizzly, {})
         assert callable(init_function)
 
         init_function(runner)
@@ -411,7 +411,7 @@ def test_validate_result(mocker: MockerFixture, caplog: LogCaptureFixture, grizz
 
     environment.stats.total.total_response_time = 2000
 
-    validate_result_wrapper = validate_result(grizzly)
+    validate_result_wrapper: Callable[..., None] = validate_result(grizzly)
     assert callable(validate_result_wrapper)
 
     # environment has statistics, but can't find a matching scenario

--- a/tests/unit/test_grizzly/steps/test_setup.py
+++ b/tests/unit/test_grizzly/steps/test_setup.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, cast
 
 from grizzly.context import GrizzlyContext
 from grizzly.steps import *
-from grizzly.steps.scenario.setup import _execute_python_script
+from grizzly.steps.setup import _execute_python_script
 from grizzly.tasks import SetVariableTask
 from grizzly.types import VariableType
 from tests.helpers import ANY
@@ -205,7 +205,7 @@ def test_step_setup_variable_value(behave_fixture: BehaveFixture, mocker: Mocker
 
 
 def test_step_setup_execute_python_script(grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
-    execute_script_mock = mocker.patch('grizzly.steps.scenario.setup._execute_python_script', return_value=None)
+    execute_script_mock = mocker.patch('grizzly.steps.setup._execute_python_script', return_value=None)
     context = grizzly_fixture.behave.context
 
     original_cwd = Path.cwd()
@@ -240,7 +240,7 @@ def test_step_setup_execute_python_script(grizzly_fixture: GrizzlyFixture, mocke
 
 
 def test_step_setup_execute_python_script_inline(grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
-    execute_script_mock = mocker.patch('grizzly.steps.scenario.setup._execute_python_script', return_value=None)
+    execute_script_mock = mocker.patch('grizzly.steps.setup._execute_python_script', return_value=None)
     context = grizzly_fixture.behave.context
     context.text = "print('foobar')"
 
@@ -260,7 +260,7 @@ def test_step_setup_execute_python_script_inline(grizzly_fixture: GrizzlyFixture
 
 def test__execute_python_script(behave_fixture: BehaveFixture, mocker: MockerFixture) -> None:
     context = behave_fixture.context
-    on_worker_mock = mocker.patch('grizzly.steps.scenario.setup.on_worker', return_value=True)
+    on_worker_mock = mocker.patch('grizzly.steps.setup.on_worker', return_value=True)
     exec_mock = mocker.patch('builtins.exec')
 
     # do not execute, since we're on a worker
@@ -278,5 +278,5 @@ def test__execute_python_script(behave_fixture: BehaveFixture, mocker: MockerFix
     _execute_python_script(context, "print('foobar')")
 
     on_worker_mock.assert_called_once_with(context)
-    exec_mock.assert_called_once_with("print('foobar')")
+    exec_mock.assert_called_once_with("print('foobar')", ANY(dict), ANY(dict))
 

--- a/tests/unit/test_grizzly/tasks/test_transformer.py
+++ b/tests/unit/test_grizzly/tasks/test_transformer.py
@@ -51,7 +51,7 @@ class TestTransformerTask:
             variable='test_variable', expression='$.result.value', content_type=TransformerContentType.JSON, content='',
         )
 
-        assert task_factory.__template_attributes__ == {'content'}
+        assert task_factory.__template_attributes__ == {'content', 'expression'}
 
         task = task_factory()
 

--- a/tests/unit/test_grizzly_extras/test_transformer.py
+++ b/tests/unit/test_grizzly_extras/test_transformer.py
@@ -86,6 +86,12 @@ class Testtransformer:
                 return super().parser(expression)
 
         transform_spy = mocker.spy(DummyTransformer, 'transform')
+
+        # restore some method metadata
+        DummyTransformer.transform.__name__ = 'transform'
+        DummyTransformer.transform.__qualname__ = 'DummyTransformer.transform'
+        DummyTransformer.transform.__annotations__ = {'_raw': str, 'return': Any}
+
         transform_spy.side_effect = [None, None, None, (TransformerContentType.JSON, {'test': 'value'}), (TransformerContentType.UNDEFINED, {'test': 'value'})]
 
         original_transformers = transformer.available.copy()


### PR DESCRIPTION
steps moved from `grizzly.steps.scenario.setup` to `grizzly.steps.setup`, making it possible to place them in the `Background`-section in the `Feature`.

inject behave `context` object to `exec` scope, making it available for any scripts, so they can base logic on behaves current context (which also includes `GrizzlyContext` instance).

add transformer task `expression` as containing templates, so variables only used in expressions doesn't have to appear in any other templates (defined not used).