### PR TITLE
set variable task resolve file value

### DIFF
--- a/grizzly/steps/utils.py
+++ b/grizzly/steps/utils.py
@@ -4,8 +4,9 @@ feature file, but should not be included in a finished, testable, feature.
 """
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
+from grizzly.context import GrizzlyContext
 from grizzly.types.behave import Context, then
 
 
@@ -14,9 +15,36 @@ def step_utils_fail(context: Context, *_args: Any, **_kwargs: Any) -> None:  # n
     """Force a failed scenario. Can be useful when writing a new scenario. The scenario will fail before `locust` has started, so only when
     the scenario is setup.
 
+    Example:
     ```gherkin
     Then fail
     ```
+
     """
     message = 'manually failed'
     raise AssertionError(message)
+
+
+@then('add orphan template "{template}"')
+def step_utils_add_orphan_template(context: Context, template: str) -> None:
+    """Add arbitrary templats to fool grizzly that a variable is being used.
+
+    This step should be avoided at all costs, escpecially if you do not know what you are doing.
+    There are cases that grizzly will complain that a variable is declared, but not found in any templates, with this step it is possible to
+    "fool" that logic, by adding a template containing that variable.
+
+    When adding this step in a feature-file, you should also write an [bug issue](https://github.com/Biometria-se/grizzly/issues/new?assignees=&labels=bug&projects=&template=bug_report.md&title=)
+    detailing why it was necessary to use it, so the root cause can be fixed.
+
+    Example:
+    ```gherkin
+    Then add orphan template "{{ hello world foobar }}"
+    ```
+
+    Args:
+        template (str): templating string with jinja2 template containing variable names
+
+    """
+    grizzly = cast(GrizzlyContext, context.grizzly)
+
+    grizzly.scenario.orphan_templates.append(template)

--- a/grizzly/tasks/set_variable.py
+++ b/grizzly/tasks/set_variable.py
@@ -20,9 +20,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, MutableMapping, Optional, Type, cast
 
 from grizzly.testdata import GrizzlyVariables
-from grizzly.testdata.utils import create_context_variable
+from grizzly.testdata.utils import create_context_variable, read_file
 from grizzly.types import VariableType
-from grizzly.utils import has_template
+from grizzly.utils import has_template, is_file
 
 from . import GrizzlyTask, grizzlytask, template
 
@@ -77,6 +77,9 @@ class SetVariableTask(GrizzlyTask):
         @grizzlytask
         def task(parent: GrizzlyScenario) -> Any:
             value = parent.render(self.value)
+
+            if is_file(value):
+                value = parent.render(read_file(value))
 
             if self.variable_type == VariableType.VARIABLES:
                 if self._variable_instance is None and self._variable_instance_type is not None:

--- a/tests/unit/test_grizzly/steps/test_utils.py
+++ b/tests/unit/test_grizzly/steps/test_utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from grizzly.steps.utils import step_utils_fail
+from grizzly.steps.utils import step_utils_add_orphan_template, step_utils_fail
 from tests.helpers import ANY
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -17,3 +17,14 @@ def test_step_utils_fail(behave_fixture: BehaveFixture) -> None:
     step_utils_fail(behave)
 
     assert behave.exceptions == {behave.scenario.name: [ANY(AssertionError, message='manually failed')]}
+
+def test_step_utils_add_orphan_template(behave_fixture: BehaveFixture) -> None:
+    behave = behave_fixture.context
+    grizzly = behave_fixture.grizzly
+    grizzly.scenarios.create(behave_fixture.create_scenario('test'))
+
+    assert grizzly.scenario.orphan_templates == []
+
+    step_utils_add_orphan_template(behave, '{{ hello world }}')
+
+    assert grizzly.scenario.orphan_templates == ['{{ hello world }}']

--- a/tests/unit/test_grizzly/tasks/test_set_variable.py
+++ b/tests/unit/test_grizzly/tasks/test_set_variable.py
@@ -92,5 +92,19 @@ class TestSetVariableTask:
 
             set_value_mock.assert_called_once_with('output', 'hello, world!')
             assert 'AtomicCsvWriter.output.foo' not in parent.user._context['variables']
+
+            # set value from file runtime, and render file contents
+            test_file = grizzly_fixture.test_context / 'requests' / 'test' / 'hello.foo.txt'
+            test_file.parent.mkdir(exist_ok=True, parents=True)
+            test_file.write_text('{{ value }}')
+
+            grizzly_fixture.grizzly.state.variables.update({'bar': 'foo'})
+            parent.user._context['variables'].update({'bar': 'foo'})
+            task_factory = SetVariableTask('foobar', 'test/hello.{{ bar }}.txt', VariableType.VARIABLES)
+            task = task_factory()
+
+            task(parent)
+
+            assert parent.user._context['variables']['foobar'] == 'hello, world!'
         finally:
             cleanup()


### PR DESCRIPTION
checks if rendered variable value is a a file, and if so reads the file and renders the template inside it before setting it as the variable value. just as the initialization done before runtime does.

new debugging utility step to add orphan templates in the scenario.