### PR TITLE
dry run

### DIFF
--- a/grizzly/auth/aad.py
+++ b/grizzly/auth/aad.py
@@ -79,7 +79,7 @@ If the user is required to have a MFA method, support for software based TOTP to
         grizzly-cli auth
         ```
 
-11. Copy the code generate from above command and click `Next`
+11. Copy the code generate from above command, go back to the browser and paste it into the text field and click `Next`
 
 12. Finish the wizard
 
@@ -96,7 +96,7 @@ And set context variable "auth.client.id" to "<client id>"
 And set context variable "auth.user.username" to "alice@example.onmicrosoft.com"
 And set context variable "auth.user.password" to "HemL1gaArn3!"
 And set context variable "auth.user.redirect_uri" to "/app-registrered-redirect-uri"
-And set context variable "auth.user.otp_secret" to "asdfasdf"  # <-- !!
+And set context variable "auth.user.otp_secret" to "asdfasdf"  # <-- `Secret key` from Step 8 in "Configure TOTP"
 ```
 """
 from __future__ import annotations

--- a/grizzly/context.py
+++ b/grizzly/context.py
@@ -252,6 +252,7 @@ class GrizzlyContextTasks(List['GrizzlyTask']):
 @dataclass(unsafe_hash=True)
 class GrizzlyContextScenario:
     _name: str = field(init=False, hash=True)
+    class_type: str = field(init=False, hash=True, default='IteratorScenario')
     description: str = field(init=False, hash=False)
     user: GrizzlyContextScenarioUser = field(init=False, hash=False, compare=False, default_factory=GrizzlyContextScenarioUser)
     index: int = field(init=True)
@@ -281,9 +282,6 @@ class GrizzlyContextScenario:
 
     @property
     def name(self) -> str:
-        if self._name.endswith(f'_{self.identifier}'):
-            return self._name.replace(f'_{self.identifier}', '')
-
         return self._name
 
     @name.setter
@@ -296,10 +294,7 @@ class GrizzlyContextScenario:
 
     @property
     def class_name(self) -> str:
-        if not self.name.endswith(f'_{self.identifier}'):
-            return f'{self.name}_{self.identifier}'
-
-        return self.name
+        return f'{self.class_type}_{self.identifier}'
 
     def should_validate(self) -> bool:
         return (

--- a/grizzly/exceptions.py
+++ b/grizzly/exceptions.py
@@ -76,8 +76,8 @@ class ScenarioError(AssertionError):
         return f'    ! {self.error!s}'
 
 
-class FeatureError(AssertionError):
-    def __init__(self, error: AssertionError) -> None:
+class FeatureError(Exception):
+    def __init__(self, error: Exception) -> None:
         self.error = error
 
     def __str__(self) -> str:

--- a/grizzly/listeners/__init__.py
+++ b/grizzly/listeners/__init__.py
@@ -206,7 +206,7 @@ def validate_result(grizzly: GrizzlyContext) -> Callable[Concatenate[Environment
                 actual = stats.total.fail_ratio
                 if actual > expected:
                     error_message = f'failure ration {int(actual*100)}% > {int(expected*100)}%'
-                    logger.error('scenario %s (%s) failed due to %s', scenario.name, prefix, error_message)
+                    logger.error('scenario "%s" (%s) failed due to %s', scenario.name, prefix, error_message)
                     environment.stats.log_error(
                         RequestType.SCENARIO(),
                         scenario.locust_name,

--- a/grizzly/locust.py
+++ b/grizzly/locust.py
@@ -16,7 +16,6 @@ from time import perf_counter
 from typing import TYPE_CHECKING, Any, Callable, Dict, Generator, Iterator, List, NoReturn, Optional, Set, SupportsIndex, Tuple, Type, TypeVar, cast
 
 import gevent
-from jinja2.exceptions import TemplateError
 from locust import events
 from locust import stats as lstats
 from locust.dispatch import UsersDispatcher
@@ -31,7 +30,7 @@ from .listeners import init, init_statistics_listener, locust_test_start, locust
 from .testdata.utils import initialize_testdata
 from .types import RequestType, TestdataType
 from .types.behave import Context, Status
-from .types.locust import Environment, LocustRunner, MasterRunner, Message, MessageHandler, WorkerRunner
+from .types.locust import Environment, LocustRunner, MasterRunner, Message, WorkerRunner
 from .users import GrizzlyUser
 from .utils import create_scenario_class_type, create_user_class_type
 
@@ -661,7 +660,7 @@ def setup_locust_scenarios(grizzly: GrizzlyContext) -> Tuple[List[Type[GrizzlyUs
         total_weight = sum([scenario.user.weight for scenario in scenarios])
         for scenario in scenarios:
             scenario_user_count = ceil(user_count * (scenario.user.weight / total_weight))
-            distribution[scenario.name] = scenario_user_count
+            distribution[scenario.class_name] = scenario_user_count
 
         total_user_count = sum(distribution.values())
         user_overflow = total_user_count - user_count
@@ -675,11 +674,11 @@ def setup_locust_scenarios(grizzly: GrizzlyContext) -> Tuple[List[Type[GrizzlyUs
             logger.warning('there should be %d users, but there will only be %d users spawned', user_count, total_user_count)
 
         while user_overflow > 0:
-            for scenario_name in dict(sorted(distribution.items(), key=lambda d: d[1], reverse=True)):
-                if distribution[scenario_name] <= 1:
+            for scenario_class_name in dict(sorted(distribution.items(), key=lambda d: d[1], reverse=True)):
+                if distribution[scenario_class_name] <= 1:
                     continue
 
-                distribution[scenario_name] -= 1
+                distribution[scenario_class_name] -= 1
                 user_overflow -= 1
 
                 if user_overflow < 1:
@@ -687,10 +686,10 @@ def setup_locust_scenarios(grizzly: GrizzlyContext) -> Tuple[List[Type[GrizzlyUs
 
     for scenario in scenarios:
         # Given a user of type "" load testing ""
-        assert 'host' in scenario.context, f'variable "host" is not found in the context for {scenario.name}'
-        assert len(scenario.tasks) > 0, f'no tasks has been added to {scenario.name}'
+        assert 'host' in scenario.context, f'variable "host" is not found in the context for scenario "{scenario.name}"'
+        assert len(scenario.tasks) > 0, f'no tasks has been added to scenario "{scenario.name}"'
 
-        fixed_count = distribution.get(scenario.name, None)
+        fixed_count = distribution.get(scenario.class_name, None)
         user_class_type = create_user_class_type(scenario, grizzly.setup.global_context, fixed_count=fixed_count)
         user_class_type.host = scenario.context['host']
 
@@ -698,7 +697,7 @@ def setup_locust_scenarios(grizzly: GrizzlyContext) -> Tuple[List[Type[GrizzlyUs
 
         # @TODO: how do we specify other type of grizzly.scenarios?
         scenario_type = create_scenario_class_type('IteratorScenario', scenario)
-        scenario.name = scenario_type.__name__
+
         for task in scenario.tasks:
             scenario_type.populate(task)
 
@@ -741,7 +740,7 @@ def setup_resource_limits(context: Context) -> None:
             )
 
 
-def setup_environment_listeners(context: Context) -> Tuple[Set[str], Dict[str, MessageHandler]]:
+def setup_environment_listeners(context: Context, *, testdata: Optional[TestdataType]) -> None:
     grizzly = cast(GrizzlyContext, context.grizzly)
 
     environment = grizzly.state.locust.environment
@@ -753,18 +752,6 @@ def setup_environment_listeners(context: Context) -> Tuple[Set[str], Dict[str, M
     environment.events.quitting._handlers = []
 
     # add standard listeners
-    testdata: Optional[TestdataType] = None
-    external_dependencies: Set[str] = set()
-    message_handlers: Dict[str, MessageHandler] = {}
-
-    # initialize testdata
-    try:
-        testdata, external_dependencies, message_handlers = initialize_testdata(grizzly)
-    except TemplateError as e:
-        message = f'error parsing request payload: {e}'
-        logger.exception(message)
-        raise AssertionError(message) from e
-
     if not on_worker(context):
         validate_results = False
 
@@ -791,8 +778,6 @@ def setup_environment_listeners(context: Context) -> Tuple[Set[str], Dict[str, M
     # And save statistics to "..."
     if grizzly.setup.statistics_url is not None:
         environment.events.init.add_listener(init_statistics_listener(grizzly.setup.statistics_url))
-
-    return external_dependencies, message_handlers
 
 
 def print_scenario_summary(grizzly: GrizzlyContext) -> None:
@@ -907,17 +892,24 @@ def run(context: Context) -> int:  # noqa: C901, PLR0915, PLR0912
     setup_logging(log_level, None)
 
     # make sure the user hasn't screwed up
-    if on_master(context) and on_worker(context):
-        logger.error('seems to be a problem with "behave" arguments, cannot be both master and worker')
+    is_both_master_and_worker = on_master(context) and on_worker(context)
+    is_spawn_rate_not_set = grizzly.setup.spawn_rate is None
+    is_user_count_not_set = grizzly.setup.dispatcher_class in [UsersDispatcher, None] and (grizzly.setup.user_count is None or grizzly.setup.user_count < 1)
+
+    if is_both_master_and_worker or is_spawn_rate_not_set or is_user_count_not_set:
+        if is_both_master_and_worker:
+            logger.error('seems to be a problem with "behave" arguments, cannot be both master and worker')
+
+        if is_spawn_rate_not_set:
+            logger.error('spawn rate is not set')
+
+        if is_user_count_not_set:
+            logger.error("step 'Given \"user_count\" users' is not in the feature file")
+
         return 254
 
-    if grizzly.setup.spawn_rate is None:
-        logger.error('spawn rate is not set')
-        return 254
-
-    if grizzly.setup.dispatcher_class in [UsersDispatcher, None] and (grizzly.setup.user_count is None or grizzly.setup.user_count < 1):
-        logger.error("step 'Given \"user_count\" users' is not in the feature file")
-        return 254
+    # initialize testdata
+    testdata, external_dependencies, message_handlers = initialize_testdata(grizzly)
 
     greenlet_exception_handler = greenlet_exception_logger(logger)
 
@@ -925,7 +917,8 @@ def run(context: Context) -> int:  # noqa: C901, PLR0915, PLR0912
 
     external_processes: Dict[str, subprocess.Popen] = {}
 
-    user_classes, external_dependencies = setup_locust_scenarios(grizzly)
+    user_classes, variable_dependencies = setup_locust_scenarios(grizzly)
+    external_dependencies.update(variable_dependencies)
 
     assert len(user_classes) > 0, 'no users specified in feature'
 
@@ -971,8 +964,11 @@ def run(context: Context) -> int:  # noqa: C901, PLR0915, PLR0912
 
         grizzly.state.locust = runner
 
-        variable_dependencies, message_handlers = setup_environment_listeners(context)
-        external_dependencies.update(variable_dependencies)
+        setup_environment_listeners(context, testdata=testdata)
+
+        if environ.get('GRIZZLY_DRY_RUN', 'false').lower() == 'true':
+            runner.quit()
+            return 0
 
         environment.events.init.fire(environment=environment, runner=runner, web_ui=None)
 
@@ -1041,6 +1037,7 @@ def run(context: Context) -> int:  # noqa: C901, PLR0915, PLR0912
                 return 1
 
         stats_printer_greenlet: Optional[gevent.Greenlet] = None
+        spawn_rate = cast(float, grizzly.setup.spawn_rate)
 
         @dataclass
         class LocustOption:
@@ -1054,7 +1051,7 @@ def run(context: Context) -> int:  # noqa: C901, PLR0915, PLR0912
         environment.parsed_options = LocustOption(
             headless=True,
             num_users=grizzly.setup.user_count or 0,
-            spawn_rate=grizzly.setup.spawn_rate,
+            spawn_rate=spawn_rate,
             tags=[],
             exclude_tags=[],
             enable_rebalancing=False,
@@ -1081,7 +1078,7 @@ def run(context: Context) -> int:  # noqa: C901, PLR0915, PLR0912
             user_count = grizzly.setup.user_count or 0 if runner.environment.dispatcher_class == UsersDispatcher else -1
 
             try:
-                runner.start(user_count, grizzly.setup.spawn_rate)
+                runner.start(user_count, spawn_rate)
             except:
                 if isinstance(runner, MasterRunner):
                     runner.send_message('grizzly_worker_quit', None)

--- a/grizzly/scenarios/iterator.py
+++ b/grizzly/scenarios/iterator.py
@@ -230,7 +230,7 @@ class IteratorScenario(GrizzlyScenario):
         # scenario timer
         self.start = perf_counter()
 
-        remote_context = self.consumer.testdata(self.__class__.__name__)
+        remote_context = self.consumer.testdata(self.user._scenario.class_name)
 
         if remote_context is None:
             self.logger.debug('no iteration data available, stop scenario')

--- a/grizzly/testdata/__init__.py
+++ b/grizzly/testdata/__init__.py
@@ -63,6 +63,14 @@ class GrizzlyVariables(dict):
         return module_name, variable_type, cast(str, variable_name), sub_variable_name
 
     @classmethod
+    def get_initialization_value(cls, name: str) -> str:
+        if name.count('.') > 1:
+            variable_spec = GrizzlyVariables.get_variable_spec(name)
+            name = '.'.join([part for part in variable_spec[:-1] if part is not None and part != 'grizzly.testdata.variables'])
+
+        return name
+
+    @classmethod
     def initialize_variable(cls, grizzly: GrizzlyContext, name: str) -> Tuple[Any, Set[str], Dict[str, MessageHandler]]:
         external_dependencies: Set[str] = set()
         message_handler: Dict[str, MessageHandler] = {}

--- a/grizzly/testdata/utils.py
+++ b/grizzly/testdata/utils.py
@@ -33,6 +33,8 @@ def initialize_testdata(grizzly: GrizzlyContext) -> Tuple[TestdataType, Set[str]
     testdata: TestdataType = {}
     template_variables = get_template_variables(grizzly)
 
+    logger.debug('testdata: %r', template_variables)
+
     initialized_datatypes: Dict[str, Any] = {}
     external_dependencies: Set[str] = set()
     message_handlers: Dict[str, MessageHandler] = {}

--- a/grizzly_extras/async_message/sb.py
+++ b/grizzly_extras/async_message/sb.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 
 import logging
 from contextlib import suppress
-from time import perf_counter, sleep
+from time import perf_counter, sleep, time
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, Optional, Tuple, Union, cast
 
 from azure.core.exceptions import ResourceExistsError, ResourceNotFoundError
 from azure.servicebus import ServiceBusClient, ServiceBusMessage, ServiceBusReceiver, ServiceBusSender, TransportType
+from azure.servicebus._pyamqp import ReceiveClient
 from azure.servicebus.amqp import AmqpMessageBodyType
 from azure.servicebus.management import ServiceBusAdministrationClient, SqlRuleFilter, TopicProperties
 
@@ -524,7 +525,7 @@ class AsyncServiceBusHandler(AsyncMessageHandler):
             # than message_wait ago, which will cause a "timeout" when trying to read it now
             # which means we'll not get any messages, even though the endpoint isn't empty
             if message_wait > 0:
-                receiver._handler._last_activity_timestamp = None
+                receiver._handler._last_activity_timestamp = time() if isinstance(receiver._handler, ReceiveClient) else None
 
             for retry in range(1, 4):
                 try:

--- a/tests/e2e/test_example.py
+++ b/tests/e2e/test_example.py
@@ -1,6 +1,7 @@
 """End-to-end test of example/."""
 from __future__ import annotations
 
+from contextlib import suppress
 from pathlib import Path
 from shutil import copytree
 from typing import TYPE_CHECKING, Optional
@@ -112,3 +113,90 @@ def test_e2e_example(e2e_fixture: End2EndFixture) -> None:  # noqa: PLR0915
         if result is not None:
             print(result)
         raise
+
+def test_e2e_example_dry_run(e2e_fixture: End2EndFixture) -> None:  # noqa: PLR0915
+    try:
+        result: Optional[str] = None
+
+        with Path('example/environments/example.yaml').open() as env_yaml_file:
+            env_conf = yaml.full_load(env_yaml_file)
+
+            for name in ['dog', 'cat', 'book']:
+                env_conf['configuration']['facts'][name]['host'] = f'http://{e2e_fixture.host}'
+
+        if e2e_fixture._distributed:
+            # copy examples
+            source = (Path(__file__) / '..' / '..' / '..' / 'example').resolve()
+            example_root = e2e_fixture.root.parent / 'test-example'
+            copytree(source, example_root, dirs_exist_ok=True)
+
+            with (Path(example_root) / 'features' / 'steps' / 'steps.py').open('a') as fd:
+                fd.write(
+                    e2e_fixture.step_start_webserver.format('/srv/grizzly'),
+                )
+
+            # create steps/webserver.py
+            webserver_source = e2e_fixture.test_tmp_dir.parent / 'tests' / 'webserver.py'
+            webserver_destination = example_root / 'features' / 'steps' / 'webserver.py'
+            webserver_destination.write_text(webserver_source.read_text())
+
+            root = (Path(__file__) / '..' / '..' / '..').resolve()
+            feature_file_root = str(example_root).replace(f'{root}/', '')
+            feature_file = f'{feature_file_root}/features/example.feature'
+            feature_file_contents = Path(feature_file).read_text().split('\n')
+
+            index = feature_file_contents.index('  Scenario: dog facts api')
+            # should go last in "Background"-section
+            feature_file_contents.insert(index - 1, f'    Then start webserver on master port "{e2e_fixture.webserver.port}"')
+
+            with Path(feature_file).open('w') as fd:
+                fd.truncate(0)
+                fd.write('\n'.join(feature_file_contents))
+        else:
+            example_root = Path.cwd() / 'example'
+
+        feature_file = 'features/example.feature'
+
+        # use test-example project stucture, but with original project name (image)
+        original_root = e2e_fixture.root
+        e2e_fixture._root = example_root
+
+        code, output = e2e_fixture.execute(feature_file, env_conf=env_conf, project_name=original_root.name, dry_run=True)
+
+        result = ''.join(output)
+
+        # restore original root
+        e2e_fixture._root = original_root
+
+        assert code == 0
+        assert 'WARNING' not in result
+        assert '1 feature passed, 0 failed, 0 skipped' in result
+        assert '3 scenarios passed, 0 failed, 0 skipped' in result
+        assert 'steps passed, 0 failed, 0 skipped, 0 undefined' in result
+
+        assert 'ident   iter  status   description' not in result
+
+        assert 'executing custom.User.request for 002 get-cat-facts and /facts?limit=' not in result
+
+        assert 'sending "client_server" from CLIENT' not in result
+        assert "received from CLIENT" not in result
+        assert "AtomicCustomVariable.foobar='foobar'" not in result
+
+        # check debugging and that task index -> step expression is correct
+        # dog facts api
+        assert 'executing task 1 of 3: iterator' not in result
+
+        # cat facts api
+        assert 'executing task 1 of 5: iterator' not in result
+
+        assert 'foo=BAR, bar=BAR' not in result
+
+        # book api
+        assert 'executing task 1 of 5: iterator' not in result
+    except:
+        if result is not None:
+            print(result)
+        raise
+    finally:
+        with suppress(Exception):
+            del e2e_fixture._env['GRIZZLY_DRY_RUN']

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -928,6 +928,8 @@ def step_start_webserver(context: Context, port: int) -> None:
         env_conf: Optional[Dict[str, Any]] = None,
         testdata: Optional[Dict[str, str]] = None,
         project_name: Optional[str] = None,
+        *,
+        dry_run: bool = False,
     ) -> Tuple[int, List[str]]:
         env_conf_fd: Any
         if env_conf is not None:
@@ -949,6 +951,9 @@ def step_start_webserver(context: Context, port: int) -> None:
                 '-l', '/tmp/grizzly.log',  # noqa: S108
                 feature_file,
             ]
+
+            if dry_run:
+                command.append('--dry-run')
 
             if self._distributed:
                 command = command[:2] + ['--project-name', project_name] + command[2:]

--- a/tests/unit/test_grizzly/test_behave.py
+++ b/tests/unit/test_grizzly/test_behave.py
@@ -135,6 +135,7 @@ def test_after_feature(grizzly_fixture: GrizzlyFixture, mocker: MockerFixture, c
     feature = Feature(None, None, '', '', scenarios=[behave.scenario])
     behave.scenario.steps = [Step(None, None, '', '', ''), Step(None, None, '', '', '')]
     behave.started = datetime.now().astimezone()
+    grizzly.scenario.tasks().clear()
 
     locustrun_mock = mocker.patch(
         'grizzly.behave.locustrun',

--- a/tests/unit/test_grizzly/test_context.py
+++ b/tests/unit/test_grizzly/test_context.py
@@ -132,10 +132,10 @@ class TestGrizzlyContextSetupLocustMessages:
         assert isinstance(context, dict)
         assert context == {}
 
-        def callback(environment: Environment, msg: Message, **kwargs: Any) -> None:  # noqa: ARG001
+        def callback(environment: Environment, msg: Message, *args: Any, **kwargs: Any) -> None:  # noqa: ARG001
             pass
 
-        def callback_ack(environment: Environment, msg: Message, **kwargs: Any) -> None:  # noqa: ARG001
+        def callback_ack(environment: Environment, msg: Message, *args: Any, **kwargs: Any) -> None:  # noqa: ARG001
             pass
 
         context.register(MessageDirection.SERVER_CLIENT, 'test_message', callback)
@@ -283,7 +283,7 @@ class TestGrizzlyContextScenarios:
         assert len(scenarios) == 1
         assert scenarios[-1].name == 'test-1'
         assert scenarios[-1].description == 'test-1'
-        assert scenarios[-1].class_name == 'test-1_001'
+        assert scenarios[-1].class_name == 'IteratorScenario_001'
         assert scenarios[-1].behave is behave_scenario
 
         behave_scenario = Scenario(filename=None, line=None, keyword='', name='test-2')
@@ -291,13 +291,14 @@ class TestGrizzlyContextScenarios:
         assert len(scenarios) == 2
         assert scenarios[-1].name == 'test-2'
         assert scenarios[-1].description == 'test-2'
-        assert scenarios[-1].class_name == 'test-2_002'
+        assert scenarios[-1].class_name == 'IteratorScenario_002'
         assert scenarios[-1].behave is behave_scenario
 
         assert len(scenarios()) == 2
 
-        assert scenarios.find_by_class_name('test-2_002') is scenarios[-1]
+        assert scenarios.find_by_class_name('IteratorScenario_002') is scenarios[-1]
         assert scenarios.find_by_name('test-1') is scenarios[-2]
+        assert scenarios.find_by_class_name('IteratorScenario_001') is scenarios[-2]
 
 
 class TestGrizzlyContextScenario:
@@ -324,11 +325,9 @@ class TestGrizzlyContextScenario:
         assert getattr(scenario, 'pace', '') is None
         assert isinstance(scenario.validation, GrizzlyContextScenarioValidation)
         assert not scenario.failure_exception
+        assert scenario.class_type == 'IteratorScenario'
 
-        assert scenario.class_name == f'Test_{identifier}'
-
-        scenario.name = f'Test_{identifier}'
-        assert scenario.class_name == f'Test_{identifier}'
+        assert scenario.class_name == f'IteratorScenario_{identifier}'
 
         assert not scenario.should_validate()
 

--- a/tests/unit/test_grizzly/testdata/test___init__.py
+++ b/tests/unit/test_grizzly/testdata/test___init__.py
@@ -273,16 +273,17 @@ value1,value2
         finally:
             cleanup()
 
-    @pytest.mark.parametrize(('value', 'expected'), [
-        ('variable', (None, None, 'variable', None)),
-        ('AtomicIntegerIncrementer.foo', ('grizzly.testdata.variables', 'AtomicIntegerIncrementer', 'foo', None)),
-        ('AtomicCsvReader.users.username', ('grizzly.testdata.variables', 'AtomicCsvReader', 'users', 'username')),
-        ('tests.helpers.AtomicCustomVariable.hello', ('tests.helpers', 'AtomicCustomVariable', 'hello', None)),
-        ('tests.helpers.AtomicCustomVariable.foo.bar', ('tests.helpers', 'AtomicCustomVariable', 'foo', 'bar')),
-        ('a.custom.struct', (None, None, 'a.custom.struct', None)),
+    @pytest.mark.parametrize(('value', 'expected_spec', 'expected_init_value'), [
+        ('variable', (None, None, 'variable', None), 'variable'),
+        ('AtomicIntegerIncrementer.foo', ('grizzly.testdata.variables', 'AtomicIntegerIncrementer', 'foo', None), 'AtomicIntegerIncrementer.foo'),
+        ('AtomicCsvReader.users.username', ('grizzly.testdata.variables', 'AtomicCsvReader', 'users', 'username'), 'AtomicCsvReader.users'),
+        ('tests.helpers.AtomicCustomVariable.hello', ('tests.helpers', 'AtomicCustomVariable', 'hello', None), 'tests.helpers.AtomicCustomVariable.hello'),
+        ('tests.helpers.AtomicCustomVariable.foo.bar', ('tests.helpers', 'AtomicCustomVariable', 'foo', 'bar'), 'tests.helpers.AtomicCustomVariable.foo'),
+        ('a.custom.struct', (None, None, 'a.custom.struct', None), 'a.custom.struct'),
     ])
-    def test_get_variable_spec(self, value: str, expected: Tuple[Optional[str], Optional[str], str, Optional[str]]) -> None:
-        assert GrizzlyVariables.get_variable_spec(value) == expected
+    def test_get_variable_spec_and_initialization_value(self, value: str, expected_spec: Tuple[Optional[str], Optional[str], str, Optional[str]], expected_init_value: str) -> None:
+        assert GrizzlyVariables.get_variable_spec(value) == expected_spec
+        assert GrizzlyVariables.get_initialization_value(value) == expected_init_value
 
     class Test_initialize_variable:
         """Unit tests of grizzly.testdata.initialize_variable."""

--- a/tests/unit/test_grizzly/testdata/test_ast.py
+++ b/tests/unit/test_grizzly/testdata/test_ast.py
@@ -48,7 +48,7 @@ def test__parse_template(request_task: RequestTaskFixture, caplog: LogCaptureFix
         actual_variables, allowed_unused = _parse_templates(templates, env=request_task.behave_fixture.grizzly.state.jinja2)
 
         expected_variables = {
-            'TestScenario_001': {
+            'IteratorScenario_001': {
                 'AtomicIntegerIncrementer.messageID',
                 'AtomicIntegerIncrementer.file_number',
                 'AtomicDirectoryContents.test',
@@ -88,7 +88,7 @@ def test__parse_template_nested_pipe(request_task: RequestTaskFixture, caplog: L
         actual_variables, allow_unused = _parse_templates(templates, env=request_task.behave_fixture.grizzly.state.jinja2)
 
         assert actual_variables == {
-            'TestScenario_001': {
+            'IteratorScenario_001': {
                 'AtomicIntegerIncrementer.file_number',
             },
         }
@@ -106,7 +106,7 @@ def test__parse_template_nested_pipe(request_task: RequestTaskFixture, caplog: L
         actual_variables, allow_unused = _parse_templates(templates, env=request_task.behave_fixture.grizzly.state.jinja2)
 
         assert actual_variables == {
-            'TestScenario_001': {
+            'IteratorScenario_001': {
                 'AtomicIntegerIncrementer.file_number',
             },
         }
@@ -122,7 +122,7 @@ def test__parse_template_nested_pipe(request_task: RequestTaskFixture, caplog: L
         actual_variables, allow_unused = _parse_templates(templates, env=request_task.behave_fixture.grizzly.state.jinja2)
 
         assert actual_variables == {
-            'TestScenario_001': {
+            'IteratorScenario_001': {
                 'key',
                 'guid',
                 'AtomicDate.date',
@@ -157,7 +157,7 @@ def test__parse_template_nested_pipe(request_task: RequestTaskFixture, caplog: L
         actual_variables, allow_unused = _parse_templates(templates, env=request_task.behave_fixture.grizzly.state.jinja2)
 
         assert actual_variables == {
-            'TestScenario_001': {
+            'IteratorScenario_001': {
                 'value1',
                 'value2',
                 'value3',
@@ -181,7 +181,7 @@ def test__parse_template_nested_pipe(request_task: RequestTaskFixture, caplog: L
         actual_variables, allow_unused = _parse_templates(templates, env=request_task.behave_fixture.grizzly.state.jinja2)
 
         assert actual_variables == {
-            'TestScenario_001': {
+            'IteratorScenario_001': {
                 'foobar',
                 'world',
             },
@@ -231,7 +231,7 @@ def test__parse_template_nested_pipe(request_task: RequestTaskFixture, caplog: L
         actual_variables, allow_unused = _parse_templates(templates, env=request_task.behave_fixture.grizzly.state.jinja2)
 
         expected_variables = {
-            'TestScenario_001': {
+            'IteratorScenario_001': {
                 'AtomicCsvReader.input.value1',
                 'AtomicCsvReader.input.value2',
                 'id',
@@ -304,7 +304,7 @@ def test_get_template_variables(behave_fixture: BehaveFixture, caplog: LogCaptur
     with caplog.at_level(logging.WARNING):
         variables = get_template_variables(grizzly)
 
-        expected_scenario_name = f'{grizzly.scenario.name}_{grizzly.scenario.identifier}'
+        expected_scenario_name = grizzly.scenario.class_name
 
         assert grizzly.scenario.class_name == expected_scenario_name
         assert variables == {
@@ -346,6 +346,6 @@ def test_get_template_variables_expressions(behave_fixture: BehaveFixture, caplo
 
     with caplog.at_level(logging.WARNING):
         actual_variables = get_template_variables(grizzly)
-        assert actual_variables == {'test scenario_001': {'bar', 'foo'}}
+        assert actual_variables == {'IteratorScenario_001': {'bar', 'foo'}}
 
     assert caplog.messages == []

--- a/tests/unit/test_grizzly/testdata/test_utils.py
+++ b/tests/unit/test_grizzly/testdata/test_utils.py
@@ -96,7 +96,6 @@ def test_initialize_testdata_with_tasks(
         assert message_handlers == {}
         assert scenario_name in testdata
         variables = testdata[scenario_name]
-        assert len(variables) == 15
         assert sorted(variables.keys()) == sorted([
             'AtomicDate.now',
             'AtomicIntegerIncrementer.messageID',
@@ -113,6 +112,7 @@ def test_initialize_testdata_with_tasks(
             'transformer_task',
             'timezone',
             'value',
+            'unused_variable',
         ])
     finally:
         cleanup()


### PR DESCRIPTION
this PR adds `grizzly` functionality for the `grizzly-cli` `--dry-run` argument.

it will run grizzly up until the point where the locust runners is created, and will then quit (return code 0)
from a locust perspective this is up until that, if running distributed, the workers has connected to the master.

this makes it possible to test run any feature files, without actually executing them. this is quite useful to troubleshoot templates and variables used in the feature.

it also contains additional improvements related to AST parsing, related to template local variables (`{% set variable = ... %}`) and also variables that are objects containing "sub" properties (`AtomicCsvReader.file.column`). both of these are related to when writing more complex templates containing some logic depending on the context which they are used.