### PR TITLE
`ServiceBusUser` and `IteratorScenario` improvements

### DIFF
--- a/grizzly/auth/aad.py
+++ b/grizzly/auth/aad.py
@@ -116,6 +116,7 @@ from uuid import uuid4
 
 import requests
 from pyotp import TOTP
+from requests.adapters import HTTPAdapter, Retry
 
 from grizzly.types import ZoneInfo
 from grizzly.types.locust import StopUser
@@ -250,6 +251,9 @@ class AAD(RefreshToken):
             total_response_length = 0
 
             with requests.Session() as session:
+                retries = Retry(total=3, connect=3, read=3, status=0, backoff_factor=0.1)
+                session.mount('https://', HTTPAdapter(max_retries=retries))
+
                 headers: Dict[str, str]
                 payload: Dict[str, Any]
                 data: Dict[str, Any]

--- a/grizzly/scenarios/__init__.py
+++ b/grizzly/scenarios/__init__.py
@@ -81,7 +81,11 @@ class GrizzlyScenario(SequentialTaskSet):
 
         for task in self.tasks:
             if isinstance(task, grizzlytask):
-                task.on_start(self)  # type: ignore[unreachable]
+                try:  # type: ignore[unreachable]
+                    task.on_start(self)
+                except:
+                    self.logger.exception('on_start failed for task %r', task)
+                    raise StopUser from None
 
     def on_stop(self) -> None:
         """When locust test is stopping, all tasks on_stop methods must be called, even though

--- a/grizzly/users/__init__.py
+++ b/grizzly/users/__init__.py
@@ -33,6 +33,7 @@ from grizzly.exceptions import RestartScenario
 from grizzly.types import GrizzlyResponse, RequestType, ScenarioState
 from grizzly.types.locust import Environment, StopUser
 from grizzly.utils import has_template, merge_dicts
+from grizzly_extras.async_message import AsyncMessageError
 
 T = TypeVar('T', bound=UserMeta)
 
@@ -179,7 +180,7 @@ class GrizzlyUser(User, metaclass=GrizzlyUserMeta):
             response_length = len((payload or '').encode())
 
             # execute response listeners
-            if not isinstance(exception, (RestartScenario, StopUser)):
+            if not isinstance(exception, (RestartScenario, StopUser, AsyncMessageError)):
                 try:
                     self.event_hook.fire(
                         name=request.name,

--- a/grizzly/users/servicebus.py
+++ b/grizzly/users/servicebus.py
@@ -323,7 +323,8 @@ class ServiceBusUser(GrizzlyUser):
         self.say_hello(request)
 
         request_context = cast(AsyncMessageContext, dict(self.am_context))
-        request_context['endpoint'] = request.endpoint
+        consume = (request.arguments or {}).get('consume', 'False').lower() == 'true'
+        request_context.update({'endpoint': request.endpoint, 'consume': consume})
 
         am_request: AsyncMessageRequest = {
             'action': request.method.name,

--- a/grizzly_extras/async_message/sb.py
+++ b/grizzly_extras/async_message/sb.py
@@ -536,6 +536,11 @@ class AsyncServiceBusHandler(AsyncMessageHandler):
 
             wait_start = perf_counter()
 
+            # make sure receiver or it's handler hasn't gone stale
+            if receiver is None or receiver._handler is None:
+                self._hello(request, force=True)
+                receiver = self._receiver_cache[cache_endpoint]
+
             # reset last activity timestamp, might be set from previous usage that was more
             # than message_wait ago, which will cause a "timeout" when trying to read it now
             # which means we'll not get any messages, even though the endpoint isn't empty

--- a/tests/unit/test_grizzly/users/test_servicebus.py
+++ b/tests/unit/test_grizzly/users/test_servicebus.py
@@ -379,13 +379,7 @@ class TestServiceBusUser:
         )
         request_fire_spy.reset_mock()
 
-        response_event_fire_spy.assert_called_once_with(
-            name=f'{parent.user._scenario.identifier} {task.name}',
-            request=ANY(RequestTask),
-            context=(None, None),
-            user=parent.user,
-            exception=ANY(AsyncMessageError, message='unknown error'),
-        )
+        response_event_fire_spy.assert_not_called()
         response_event_fire_spy.reset_mock()
 
         # successful request

--- a/tests/unit/test_grizzly_extras/async_message/test_sb.py
+++ b/tests/unit/test_grizzly_extras/async_message/test_sb.py
@@ -275,11 +275,14 @@ class TestAsyncServiceBusHandler:
         # all good
         mgmt_client_mock.get_subscription.side_effect = None
 
-        assert handlers[request['action']](handler, request) == {'message': 'removed subscription my-subscription on topic my-topic'}
+        actual_response = handlers[request['action']](handler, request)
+        assert list(actual_response.keys()) == ['message']
+        assert (actual_response.get('message', None) or '').startswith('removed subscription my-subscription on topic my-topic (stats: active_message_count=')
 
         mgmt_client_mock.get_topic.assert_called_once_with(topic_name='my-topic')
         mgmt_client_mock.get_subscription.assert_called_once_with(topic_name='my-topic', subscription_name='my-subscription')
         mgmt_client_mock.delete_subscription.assert_called_once_with(topic_name='my-topic', subscription_name='my-subscription')
+        mgmt_client_mock.get_subscription_runtime_properties.assert_called_once_with(topic_name='my-topic', subscription_name='my-subscription')
 
     def test_from_message(self) -> None:
         assert AsyncServiceBusHandler.from_message(None) == (None, None)


### PR DESCRIPTION
requests made by `ServiceBusUser` now supports endpoint argument `consume`, which in combination with `expression` means that messages, where the payload, does not match `expression` is consumed from the queue/topic-subscription. so it's possible to filter messages that are not interesting.

additional information in logs when `execute_next_task` throws an exception (hopefully). getting exceptions from greenlets is tricky.

also, removes double logging of exceptions that is thrown in `excecute_next_task`.