### PR TITLE
AAD refactoring

### DIFF
--- a/grizzly/auth/__init__.py
+++ b/grizzly/auth/__init__.py
@@ -5,15 +5,19 @@ from __future__ import annotations
 
 import logging
 from abc import ABCMeta, abstractmethod
+from datetime import datetime, timezone
 from enum import Enum
 from functools import wraps
 from importlib import import_module
-from time import time
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, Generic, Literal, Optional, Set, Tuple, Type, TypeVar, Union, cast
+from time import perf_counter
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, Generic, Optional, Set, Type, TypeVar, Union, cast
 from urllib.parse import urlparse
+
+from azure.core.credentials import AccessToken, TokenCredential
 
 from grizzly.tasks import RequestTask
 from grizzly.types import GrizzlyResponse
+from grizzly.types.locust import StopUser
 from grizzly.utils import merge_dicts, safe_del
 
 try:
@@ -44,9 +48,68 @@ P = ParamSpec('P')
 logger = logging.getLogger(__name__)
 
 
+class GrizzlyTokenCredential(TokenCredential, metaclass=ABCMeta):
+    auth_method: AuthMethod
+    auth_type: AuthType
+
+    username: str
+    password: str
+    client_id: str
+
+    _refreshed: bool
+
+    @abstractmethod
+    def __init__(  # noqa: PLR0913
+        self,
+        username: str,
+        password: str,
+        tenant: str,
+        auth_method: AuthMethod,
+        /,
+        host: str,
+        redirect: str | None,
+        initialize: str | None,
+        otp_secret: str | None = None,
+        scope: str | None = None,
+        client_id: str = '04b07795-8ddb-461a-bbee-02f9e1bf7b46',
+    ) -> None: ...
+
+    @property
+    def cookie_name(self) -> str:
+        return '.AspNetCore.Cookies'
+
+    @property
+    def refreshed(self) -> bool:
+        refreshed = self._refreshed
+        self._refreshed = False
+
+        return refreshed
+
+    @abstractmethod
+    def get_token(
+        self,
+        *scopes: str,
+        claims: str | None = None,
+        tenant_id: str | None = None,
+        **_kwargs: Any,
+    ) -> AccessToken: ...
+
+    @abstractmethod
+    def get_oauth_authorization(
+        self, *scopes: str, claims: str | None = None, tenant_id: str | None = None,
+    ) -> AccessToken: ...
+
+    @abstractmethod
+    def get_oauth_token(
+        self, *, code: Optional[str] = None, verifier: Optional[str] = None, resource: Optional[str] = None, tenant_id: str | None = None,
+    ) -> AccessToken: ...
+
+
 class GrizzlyHttpAuthClient(Generic[P], metaclass=ABCMeta):
+    logger: logging.Logger
     host: str
     environment: Environment
+    credential: Optional[GrizzlyTokenCredential] = None
     metadata: Dict[str, Any]
     cookies: Dict[str, str]
     __context__: ClassVar[Dict[str, Any]] = {
@@ -54,6 +117,7 @@ class GrizzlyHttpAuthClient(Generic[P], metaclass=ABCMeta):
         'auth': {
             'refresh_time': 3000,
             'provider': None,
+            'tenant': None,
             'client': {
                 'id': None,
                 'secret': None,
@@ -87,12 +151,12 @@ class GrizzlyHttpAuthClient(Generic[P], metaclass=ABCMeta):
         return cast(Set[str], self._context['__context_change_history__'])
 
     @property
-    def __cached_auth__(self) -> Dict[str, str]:
+    def __cached_auth__(self) -> Dict[str, GrizzlyTokenCredential]:
         # clients might not cache auth tokens, let's set it to an empty dict
         # which could be refered to later, without updating client implementation
         if '__cached_auth__' not in self._context:
             self._context['__cached_auth__'] = {}
-        return cast(Dict[str, str], self._context['__cached_auth__'])
+        return cast(Dict[str, GrizzlyTokenCredential], self._context['__cached_auth__'])
 
 
 AuthenticatableFunc = TypeVar('AuthenticatableFunc', bound=Callable[..., GrizzlyResponse])
@@ -116,103 +180,76 @@ class refresh_token(Generic[P]):
 
         self.impl = cast(Type[RefreshToken], impl)
 
-    def __call__(self, func: AuthenticatableFunc) -> AuthenticatableFunc:  # noqa: PLR0915
-        def render(client: GrizzlyHttpAuthClient) -> None:
-            variables = cast(Dict[str, Any], client._context.get('variables', {}))
-            host = client.grizzly.state.jinja2.from_string(client.host).render(**variables)
-            parsed = urlparse(host)
-
-            client.host = f'{parsed.scheme}://{parsed.netloc}'
-
-            client_context = client._context.get(parsed.netloc, None)
-
-            # we have a host specific context that we should merge into current context
-            if client_context is not None:
-                client._context = merge_dicts(client._context, cast(dict, client_context))
-
+    def __call__(self, func: AuthenticatableFunc) -> AuthenticatableFunc:
         @wraps(func)
         def refresh_token(client: GrizzlyHttpAuthClient, *args: P.args, **kwargs: P.kwargs) -> GrizzlyResponse:
-            render(client)
+            # make sure the client has a credential instance, if it is needed
+            self.impl.initialize(client)
 
-            auth_context = client._context.get('auth', None)
+            if client.credential is not None and client.credential.auth_method is not AuthMethod.NONE:
+                request: Optional[RequestTask] = None
+                # look for RequestTask in args, we need to set metadata on it
+                for arg in args:
+                    if isinstance(arg, RequestTask):
+                        request = arg
+                        break
 
-            if auth_context is not None:
-                auth_client = auth_context.get('client', None)
-                auth_user = auth_context.get('user', None)
+                # refresh token if session has been alive for at least refresh_time
+                authorization_token = client.metadata.get('Authorization', None)
+                exception: Optional[Exception] = None
+                start_time = perf_counter()
+                refreshed = False
 
-                use_auth_client = (
-                    auth_client is not None
-                    and auth_client.get('id', None) is not None
-                    and auth_client.get('secret', None) is not None
-                    and auth_context.get('provider', None) is not None
-                )
-                use_auth_user = (
-                    auth_user is not None
-                    and auth_user.get('username', None) is not None
-                    and auth_user.get('password', None) is not None
-                    and (
-                        (
-                            auth_user.get('redirect_uri', None) is not None
-                            and auth_context.get('provider', None) is not None
-                            and auth_client is not None
-                            and auth_client.get('id', None) is not None
-                        )
-                        or auth_user.get('initialize_uri', None) is not None
-                    )
-                )
+                try:
+                    access_token = client.credential.get_token()
+                    refreshed = client.credential.refreshed
 
-                if use_auth_client:
-                    auth_method = AuthMethod.CLIENT
-                elif use_auth_user:
-                    auth_method = AuthMethod.USER
-                else:
-                    auth_method = AuthMethod.NONE
-
-                if auth_method is not AuthMethod.NONE and client.session_started is not None:
-                    request: Optional[RequestTask] = None
-                    # look for RequestTask in args, we need to set metadata on it
-                    for arg in args:
-                        if isinstance(arg, RequestTask):
-                            request = arg
-                            break
-
-                    session_now = time()
-                    session_duration = session_now - client.session_started
-
-                    time_for_refresh = session_duration >= auth_context.get('refresh_time', 3000)
-
-                    # refresh token if session has been alive for at least refresh_time
-                    authorization_token = client.metadata.get('Authorization', None)
-                    if time_for_refresh or (authorization_token is None and client.cookies == {}):
-                        refreshed_for = auth_user.get('username', '<unknown username>') if auth_method == AuthMethod.USER else auth_client.get('id', '<unknown client id>')
-
-                        if time_for_refresh:
+                    if refreshed or (authorization_token is None and client.cookies == {}):
+                        if refreshed:
                             # if credentials are switched after one of the cached has timeout,
                             # it will be None, and hence it will be refreshed next time it is used
-                            client.session_started = time()
                             client.__cached_auth__.clear()
+
+                            refreshed_for = (client.credential.username or '<unknown username>') if client.credential.auth_method == AuthMethod.USER else client.credential.client_id
+                            next_refresh = datetime.fromtimestamp(access_token.expires_on, tz=timezone.utc).astimezone(tz=None)
+
                             logger.info(
-                                '%s/%d %s needs refresh (%f >= %s), reset session started and clear cache',
-                                client.__class__.__name__, id(client), refreshed_for, session_duration, auth_context.get('refresh_time', '3000'),
+                                '%s/%d %s refreshed token until %s, reset session started and clear cache',
+                                client.__class__.__name__, id(client), refreshed_for, next_refresh,
                             )
 
-                        auth_type, secret = self.impl.get_token(client, auth_method)
-
-                        if auth_type == AuthType.HEADER:
-                            header = {'Authorization': f'Bearer {secret}'}
+                        if client.credential.auth_type == AuthType.HEADER:  # add token bearer to headers
+                            header = {'Authorization': f'Bearer {access_token.token}'}
                             client.metadata.update(header)
                             if request is not None:
                                 request.metadata.update(header)
-                        else:
-                            name, value = secret.split('=', 1)
-                            client.cookies.update({name: value})
-
-                        logger.info('%s/%d updated token at %f for %s', client.__class__.__name__, id(client), session_now, refreshed_for)
+                        else:  # add token to cookies
+                            client.cookies.update({client.credential.cookie_name: access_token.token})
                     elif authorization_token is not None and request is not None:  # update current request with active authorization token
                         request.metadata.update({'Authorization': authorization_token})
-                else:
-                    safe_del(client.metadata, 'Authorization')
-                    safe_del(client.metadata, 'Cookie')
+                except Exception as e:
+                    exception = e
+                    client.logger.exception('failed to get token')
+                finally:
+                    if refreshed or exception is not None:
+                        scenario_index = client._scenario.identifier
+                        request_meta = {
+                            'request_type': 'AUTH',
+                            'response_time': int((perf_counter() - start_time) * 1000),
+                            'name': f'{scenario_index} {self.impl.__class__.__name__} OAuth2 {client.credential.auth_method.name.lower()} token: {client.credential.username}',
+                            'context': client._context,
+                            'response': None,
+                            'exception': exception,
+                            'response_length': 0,
+                        }
+
+                        client.environment.events.request.fire(**request_meta)
+
+                    if exception is not None:
+                        raise StopUser from exception
+            else:
+                safe_del(client.metadata, 'Authorization')
+                safe_del(client.metadata, 'Cookie')
 
             bound = func.__get__(client, client.__class__)
 
@@ -221,25 +258,73 @@ class refresh_token(Generic[P]):
         return cast(AuthenticatableFunc, refresh_token)
 
 
+def render(client: GrizzlyHttpAuthClient) -> None:
+    variables = cast(Dict[str, Any], client._context.get('variables', {}))
+    host = client.grizzly.state.jinja2.from_string(client.host).render(**variables)
+    parsed = urlparse(host)
+
+    client.host = f'{parsed.scheme}://{parsed.netloc}'
+
+    client_context = client._context.get(parsed.netloc, None)
+
+    # we have a host specific context that we should merge into current context
+    if client_context is not None:
+        client._context = merge_dicts(client._context, cast(dict, client_context))
+
+
 class RefreshToken(metaclass=ABCMeta):
-    @classmethod
-    def get_token(cls, client: GrizzlyHttpAuthClient, auth_method: Literal[AuthMethod.CLIENT, AuthMethod.USER]) -> Tuple[AuthType, str]:
-        if auth_method == AuthMethod.CLIENT:
-            return cls.get_oauth_token(client)
-
-        return cls.get_oauth_authorization(client)
+    __TOKEN_CREDENTIAL_TYPE__: ClassVar[Type[GrizzlyTokenCredential]]
 
     @classmethod
-    @abstractmethod
-    def get_oauth_authorization(cls, client: GrizzlyHttpAuthClient) -> Tuple[AuthType, str]:  # pragma: no cover
-        message = f'{cls.__name__} has not implemented "get_oauth_authorization"'
-        raise NotImplementedError(message)
+    def initialize(cls, client: GrizzlyHttpAuthClient) -> None:
+        render(client)
 
-    @classmethod
-    @abstractmethod
-    def get_oauth_token(cls, client: GrizzlyHttpAuthClient, pkcs: Optional[Tuple[str, str]] = None) -> Tuple[AuthType, str]:  # pragma: no cover
-        message = f'{cls.__name__} has not implemented "get_oauth_token"'
-        raise NotImplementedError(message)
+        auth_context = client._context.get('auth', None)
+
+        if auth_context is not None:
+            auth_client = auth_context.get('client', {})
+            auth_user = auth_context.get('user', {})
+
+            username = auth_user.get('username', None)
+            password = auth_user.get('password', None)
+            client_id = auth_client.get('id', None)
+
+            # nothing has changed, use existing crendential
+            if client.credential is not None and (client.credential.username == username and client.credential.password == password):
+                return
+
+            tenant = auth_context.get('tenant', auth_context.get('provider', None))
+            initialize_uri = auth_user.get('initialize_uri', None)
+            redirect_uri = auth_user.get('redirect_uri', None)
+
+            use_auth_client = (
+                client_id is not None
+                and auth_client.get('secret', None) is not None
+                and tenant is not None
+            )
+            use_auth_user = (
+                username is not None
+                and password is not None
+                and (
+                    (
+                        redirect_uri is not None
+                        and tenant is not None
+                        and client_id is not None
+                    )
+                    or initialize_uri is not None
+                )
+            )
+
+            if use_auth_client:
+                auth_method = AuthMethod.CLIENT
+                password = auth_client.get('secret', None)
+            elif use_auth_user:
+                auth_method = AuthMethod.USER
+                initialize_uri = auth_user.get('initialize_uri', None)
+            else:
+                auth_method = AuthMethod.NONE
+
+            client.credential = cls.__TOKEN_CREDENTIAL_TYPE__(username, password, tenant, auth_method, host=client.host, client_id=client_id, redirect=redirect_uri, initialize=initialize_uri)
 
 
 from .aad import AAD

--- a/grizzly/tasks/clients/http.py
+++ b/grizzly/tasks/clients/http.py
@@ -43,6 +43,7 @@ For more details, see {@pylink grizzly.auth.aad}.
 """
 from __future__ import annotations
 
+import logging
 from json import dumps as jsondumps
 from time import time
 from typing import TYPE_CHECKING, Any, Dict, Optional
@@ -122,6 +123,9 @@ class HttpClientTask(ClientTask, GrizzlyHttpAuthClient):
 
         self.__class__._context.update({'host': self.host})
         self.__class__._context = merge_dicts(self.__class__._context, self._scenario.context)
+
+        if not hasattr(self, 'logger'):
+            self.logger = logging.getLogger(f'{self.__class__.__name__}/{id(self)}')
 
     def on_start(self, parent: GrizzlyScenario) -> None:
         super().on_start(parent)

--- a/tests/e2e/steps/scenario/test_response.py
+++ b/tests/e2e/steps/scenario/test_response.py
@@ -52,12 +52,12 @@ def test_e2e_step_response_save_matches(e2e_fixture: End2EndFixture) -> None:
 
     index = 0
     for target in targets:
-        table.append({'target': target.name.lower(), 'index': str(index), 'attr_name': 'foobar'})
+        table.append({'target': target.name.lower(), 'index': str(index), 'attr_name': 'Foobar'})
 
         scenario += [
-            f'Given value for variable "expression_{index}" is "$.foobar"',
+            f'Given value for variable "expression_{index}" is "$.Foobar"',
             f'Given value for variable "tmp_{index}" is "none"',
-            f'Then get request with name "{target.name.lower()}-handler" from endpoint "/api/echo?foobar=foo | content_type=json"',
+            f'Then get request with name "{target.name.lower()}-handler" from endpoint "/api/echo?Foobar=foo | content_type=json"',
             'And metadata "foobar" is "foobar"',
             f'Then save response {target.name.lower()} "{{{{ expression_{index} }}}} | expected_matches=1" that matches "foo.*$" in variable "tmp_{index}"',
             f'Then log message "tmp_{index}={{{{ tmp_{index} }}}}"',
@@ -189,13 +189,13 @@ def test_e2e_step_response_save(e2e_fixture: End2EndFixture) -> None:
 
     index = 0
     for target in targets:
-        attr_name = 'foobar'
+        attr_name = 'Foobar'
         table.append({'target': target.name.lower(), 'index': str(index), 'attr_name': attr_name})
 
         scenario += [
             f'Given value for variable "tmp_{index}" is "none"',
             f'And value for variable "expected_matches_{index}" is "1"',
-            f'Then get request with name "{target.name.lower()}-handler" from endpoint "/api/echo?foobar=foo | content_type=json"',
+            f'Then get request with name "{target.name.lower()}-handler" from endpoint "/api/echo?Foobar=foo | content_type=json"',
             'And metadata "foobar" is "foobar"',
             f'Then save response {target.name.lower()} "$.{attr_name} | expected_matches=\'{{{{ expected_matches_{index} }}}}\'" in variable "tmp_{index}"',
             f'Then log message "expected_matches_{index}={{{{ expected_matches_{index} }}}}, tmp_{index}={{{{ tmp_{index} }}}}"',

--- a/tests/e2e/test_auth.py
+++ b/tests/e2e/test_auth.py
@@ -17,6 +17,12 @@ def test_e2e_auth_user_token(e2e_fixture: End2EndFixture) -> None:
     if e2e_fixture._distributed:
         pytest.skip('telling the webserver what to expected auth-wise is not as simple when running dist, compare to running local')
 
+    def before_feature(context: Context, *_args: Any, **_kwargs: Any) -> None:  # noqa: ARG001
+        from grizzly.auth.aad import AzureAadCredential
+        AzureAadCredential.provider_url_template = f'http://{e2e_fixture.host}/{{tenant}}{e2e_fixture.webserver.auth_provider_uri}'
+
+    e2e_fixture.add_before_feature(before_feature)
+
     def after_feature(context: Context, *_args: Any, **_kwargs: Any) -> None:
         from grizzly.locust import on_master
         if on_master(context):
@@ -27,14 +33,14 @@ def test_e2e_auth_user_token(e2e_fixture: End2EndFixture) -> None:
         stats = grizzly.state.locust.environment.stats
 
         expectations = [
-            ('001 AAD OAuth2 client token v1.0: dummy-client-id', 'AUTH', 0, 1),
-            ('001 RestApi auth', 'SCEN', 0, 2),
-            ('001 RestApi auth', 'TSTD', 0, 2),
-            ('001 restapi-echo', 'GET', 0, 2),
-            ('002 AAD OAuth2 client token v1.0: dummy-client-id', 'AUTH', 0, 1),
-            ('002 HttpClientTask auth', 'SCEN', 0, 2),
-            ('002 HttpClientTask auth', 'TSTD', 0, 2),
-            ('002 httpclient-echo', 'CLTSK', 0, 2),
+            ('001 AAD OAuth2 client token: dummy-client-id', 'AUTH', 0, 1),
+            ('001 RestApi auth', 'SCEN', 0, 3),
+            ('001 RestApi auth', 'TSTD', 0, 3),
+            ('001 restapi-echo', 'GET', 0, 3),
+            ('002 AAD OAuth2 client token: dummy-client-id', 'AUTH', 0, 1),
+            ('002 HttpClientTask auth', 'SCEN', 0, 3),
+            ('002 HttpClientTask auth', 'TSTD', 0, 3),
+            ('002 httpclient-echo', 'CLTSK', 0, 3),
         ]
 
         for name, method, expected_num_failures, expected_num_requests in expectations:
@@ -46,6 +52,7 @@ def test_e2e_auth_user_token(e2e_fixture: End2EndFixture) -> None:
 
     # inject expected properties
     e2e_fixture.webserver.auth = {
+        'tenant': 'example.com',
         'client': {
             'id': 'dummy-client-id',
             'secret': 'dummy-client-secret',
@@ -73,23 +80,25 @@ def test_e2e_auth_user_token(e2e_fixture: End2EndFixture) -> None:
             And spawn rate is "2" users per second
         Scenario: RestApi auth
             Given a user of type "RestApi" load testing "http://{e2e_fixture.host}"
-            And set context variable "auth.provider" to "http://{e2e_fixture.host}{e2e_fixture.webserver.auth_provider_uri}"
+            And set context variable "auth.tenant" to "{e2e_fixture.webserver.auth['tenant']}"
             And set context variable "auth.client.id" to "{e2e_fixture.webserver.auth['client']['id']}"
             And set context variable "auth.client.secret" to "{e2e_fixture.webserver.auth['client']['secret']}"
             {add_metadata()}
-            And repeat for "2" iterations
+            And repeat for "3" iterations
             Then get request with name "restapi-echo" from endpoint "/api/echo"
 
         Scenario: HttpClientTask auth
             Given a user of type "RestApi" load testing "http://{e2e_fixture.host}"
             And value for variable "foobar" is "none"
-            And set context variable "{e2e_fixture.host}/auth.provider" to "http://{e2e_fixture.host}{e2e_fixture.webserver.auth_provider_uri}"
+            And set context variable "{e2e_fixture.host}/auth.tenant" to "{e2e_fixture.webserver.auth['tenant']}"
             And set context variable "{e2e_fixture.host}/auth.client.id" to "{e2e_fixture.webserver.auth['client']['id']}"
             And set context variable "{e2e_fixture.host}/auth.client.secret" to "{e2e_fixture.webserver.auth['client']['secret']}"
-            And repeat for "2" iterations
+            And repeat for "3" iterations
             Then get "http://{e2e_fixture.host}/api/echo" with name "httpclient-echo" and save response payload in "foobar"
             {add_metadata()}
         """))
+
+        # patch so that we use our own webserver and not tries to test against real
 
         rc, _ = e2e_fixture.execute(feature_file)
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -901,6 +901,9 @@ def step_start_webserver(context: Context, port: int) -> None:
                 source_lines[0] = re.sub(r'^def .*?\(', f'def {key}_before_feature(', source_lines[0])
                 source = '\n'.join(source_lines)
 
+                # "render" references to myself
+                source = source.replace('{e2e_fixture.host}', self.host).replace('{e2e_fixture.webserver.auth_provider_uri}', self.webserver.auth_provider_uri)
+
                 fd.write(source + '\n\n')
 
             fd.write('def after_feature(context: Context, feature: Feature, *args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> None:\n')

--- a/tests/unit/test_grizzly/test_utils.py
+++ b/tests/unit/test_grizzly/test_utils.py
@@ -147,6 +147,7 @@ def test_create_user_class_type(behave_fixture: BehaveFixture) -> None:  # noqa:
         'auth': {
             'refresh_time': 3000,
             'provider': None,
+            'tenant': None,
             'client': {
                 'id': None,
                 'secret': None,
@@ -178,6 +179,7 @@ def test_create_user_class_type(behave_fixture: BehaveFixture) -> None:  # noqa:
         'auth': {
             'refresh_time': 3000,
             'provider': None,
+            'tenant': None,
             'client': {
                 'id': None,
                 'secret': None,
@@ -245,6 +247,7 @@ def test_create_user_class_type(behave_fixture: BehaveFixture) -> None:  # noqa:
         'auth': {
             'refresh_time': 1337,
             'provider': 'https://auth.example.com',
+            'tenant': None,
             'client': {
                 'id': None,
                 'secret': None,
@@ -282,6 +285,7 @@ def test_create_user_class_type(behave_fixture: BehaveFixture) -> None:  # noqa:
         'auth': {
             'refresh_time': 1337,
             'provider': 'https://auth.example.com',
+            'tenant': None,
             'client': {
                 'id': None,
                 'secret': None,
@@ -329,6 +333,7 @@ def test_create_user_class_type(behave_fixture: BehaveFixture) -> None:  # noqa:
         'auth': {
             'refresh_time': 3000,
             'provider': None,
+            'tenant': None,
             'client': {
                 'id': None,
                 'secret': None,
@@ -371,6 +376,7 @@ def test_create_user_class_type(behave_fixture: BehaveFixture) -> None:  # noqa:
         'auth': {
             'refresh_time': 3000,
             'provider': None,
+            'tenant': None,
             'client': {
                 'id': None,
                 'secret': None,

--- a/tests/webserver.py
+++ b/tests/webserver.py
@@ -209,16 +209,14 @@ def app_until_attribute(attribute: str) -> FlaskResponse:
     return response
 
 
-@app.route('/oauth2/authorize')
-def app_oauth2_authorize() -> FlaskResponse:
-    return jsonify({'message': 'not implemented'}, status=400)
+@app.route('/<tenant>/oauth2/v2.0/authorize')
+def app_oauth2_authorize(tenant: str) -> FlaskResponse:
+    return jsonify({'message': f'not implemented for {tenant}'}, status=400)
 
 
-@app.route('/oauth2/token', methods=['POST'])
-def app_oauth2_token() -> FlaskResponse:
+@app.route('/<tenant>/oauth2/v2.0/token', methods=['POST'])
+def app_oauth2_token(tenant: str) -> FlaskResponse:
     form = request.form
-
-    logger.debug('/oauth2/token called with form=%r', form)
 
     if auth_expected is None:
         response = jsonify({'error_description': 'not setup for authentication'})
@@ -226,6 +224,7 @@ def app_oauth2_token() -> FlaskResponse:
         return response
 
     try:
+        assert tenant == auth_expected['tenant'], f'{tenant} != {auth_expected["tenant"]}'
         assert form['grant_type'] == 'client_credentials', f'grant_type {form["grant_type"]} != client_credentials'
         assert form['client_secret'] == auth_expected['client']['secret'], f'client_secret {form["client_secret"]} != {auth_expected["client"]["secret"]}'
         assert form['client_id'] == auth_expected['client']['id'], f'client_id {form["client_id"]} != {auth_expected["client"]["id"]}'
@@ -269,7 +268,7 @@ class Webserver:
 
     @property
     def auth_provider_uri(self) -> str:
-        return '/oauth2'
+        return '/oauth2/v2.0'
 
     def start(self) -> None:
         self._greenlet = gevent.spawn(lambda: self._web_server.serve_forever())


### PR DESCRIPTION
This PR introduces a reafactoring for `grizzly.auth.aad`, to make it compatible with `azure.core.credentials.TokenCredential`.

This makes it possible to introduce other way to connect to, e.g., service bus and blob storage other than connection strings (which is bad practice).