### PR TITLE
refresh token bug

### DIFF
--- a/grizzly/auth/__init__.py
+++ b/grizzly/auth/__init__.py
@@ -112,7 +112,7 @@ class refresh_token(Generic[P]):
 
     def __call__(self, func: AuthenticatableFunc) -> AuthenticatableFunc:
         @wraps(func)
-        def refresh_token(client: GrizzlyHttpAuthClient, *args: P.args, **kwargs: P.kwargs) -> GrizzlyResponse:  # noqa: PLR0912
+        def refresh_token(client: GrizzlyHttpAuthClient, *args: P.args, **kwargs: P.kwargs) -> GrizzlyResponse:
             # make sure the client has a credential instance, if it is needed
             self.impl.initialize(client)
 
@@ -153,15 +153,15 @@ class refresh_token(Generic[P]):
                             client.__class__.__name__, id(client), action_for, action_name, client.credential.auth_method.name.lower(), next_refresh,
                         )
 
-                        if client.credential.auth_type == AuthType.HEADER:  # add token bearer to headers
-                            header = {'Authorization': f'Bearer {access_token.token}'}
-                            client.metadata.update(header)
-                            if request is not None:
-                                request.metadata.update(header)
-                        else:  # add token to cookies
-                            client.cookies.update({client.credential.COOKIE_NAME: access_token.token})
-                    elif authorization_token is not None and request is not None:  # update current request with active authorization token
-                        request.metadata.update({'Authorization': authorization_token})
+                    # always make sure client and request has the right token
+                    if client.credential.auth_type == AuthType.HEADER:  # add token bearer to headers
+                        header = {'Authorization': f'Bearer {access_token.token}'}
+                        client.metadata.update(header)
+                        if request is not None:
+                            request.metadata.update(header)
+                    else:  # add token to cookies
+                        client.cookies.update({client.credential.COOKIE_NAME: access_token.token})
+
                 except Exception as e:
                     exception = e
                     client.logger.exception('failed to get token')

--- a/grizzly/auth/__init__.py
+++ b/grizzly/auth/__init__.py
@@ -130,7 +130,6 @@ class refresh_token(Generic[P]):
                 start_time = perf_counter()
                 refreshed = False
                 action_triggered = False
-
                 action_for = (client.credential.username or '<unknown username>') if client.credential.auth_method == AuthMethod.USER else client.credential.client_id
 
                 try:

--- a/grizzly/users/restapi.py
+++ b/grizzly/users/restapi.py
@@ -391,10 +391,9 @@ class RestApiUser(GrizzlyUser, AsyncRequests, GrizzlyHttpAuthClient, metaclass=R
 
         cached_credential = self.__cached_auth__.get(cache_key, None)
 
-        safe_del(self.metadata, 'Authorization')
-        safe_del(self.cookies, '.AspNetCore.Cookies')
+        self.credential = cached_credential
 
-        if cached_credential is not None:   # restore from cache
-            self.credential = cached_credential
-        else:  # remove from metadata, to force a re-authentication
-            self.credential = None
+        # force re-auth
+        if cached_credential is None:
+            safe_del(self.metadata, 'Authorization')
+            safe_del(self.cookies, '.AspNetCore.Cookies')


### PR DESCRIPTION
there was a bug introduced in #317 that caused tokens to be claimed in every iteration, when switching `auth.user` credentials.

at the same time as that one was found, it also pointed to making sure that tokens should be refreshed at least 5 minutes before `expires_on` expires, so went with 10 minutes to be on the safe side.