### PR TITLE
fixing stability issues identified during ~5h tests

### DIFF
--- a/grizzly/auth/__init__.py
+++ b/grizzly/auth/__init__.py
@@ -149,8 +149,14 @@ class refresh_token(Generic[P]):
                         next_refresh = datetime.fromtimestamp(access_token.expires_on, tz=timezone.utc).astimezone(tz=None)
 
                         logger.info(
-                            '%s/%d %s %s %s token until %s',
-                            client.__class__.__name__, id(client), action_for, action_name, client.credential.auth_method.name.lower(), next_refresh,
+                            '%s/%d %s %s %s token until %s, token=%r',
+                            client.__class__.__name__,
+                            id(client),
+                            action_for,
+                            action_name,
+                            client.credential.auth_method.name.lower(),
+                            next_refresh,
+                            client.credential._token_payload,
                         )
 
                     # always make sure client and request has the right token

--- a/grizzly/auth/__init__.py
+++ b/grizzly/auth/__init__.py
@@ -149,14 +149,13 @@ class refresh_token(Generic[P]):
                         next_refresh = datetime.fromtimestamp(access_token.expires_on, tz=timezone.utc).astimezone(tz=None)
 
                         logger.info(
-                            '%s/%d %s %s %s token until %s, token=%r',
+                            '%s/%d %s %s %s token until %s',
                             client.__class__.__name__,
                             id(client),
                             action_for,
                             action_name,
                             client.credential.auth_method.name.lower(),
                             next_refresh,
-                            client.credential._token_payload,
                         )
 
                     # always make sure client and request has the right token

--- a/grizzly/events/response_handler.py
+++ b/grizzly/events/response_handler.py
@@ -6,6 +6,8 @@ from contextlib import suppress
 from json import dumps as jsondumps
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
+from locust.exception import ResponseError
+
 from grizzly.context import GrizzlyContext
 from grizzly.events import GrizzlyEventHandler
 from grizzly.exceptions import ResponseHandlerError
@@ -173,10 +175,14 @@ class ResponseHandler(GrizzlyEventHandler):
         name: str,
         context: GrizzlyResponse,
         request: RequestTask,
-        exception: Optional[Exception] = None,  # noqa: ARG002
+        exception: Optional[Exception] = None,
         **_kwargs: Any,
     ) -> None:
         if getattr(request, 'response', None) is None:
+            return
+
+        # do not run response handlers if there was an `ResponseError`
+        if isinstance(exception, ResponseError):
             return
 
         handlers = request.response.handlers

--- a/grizzly/gevent.py
+++ b/grizzly/gevent.py
@@ -41,6 +41,15 @@ class GreenletWithExceptionCatching(Greenlet):
             **kwargs,
         )
 
+    def spawn_blocking(self, func: Callable, *args: Any, **kwargs: Any) -> None:
+        """Spawn a greenlet executing the function and wait for the function to finish.
+        Get the result of the executed function, if there was an exception raised, it will be
+        re-raised by `get`.
+        """
+        greenlet = self.spawn(func, *args, **kwargs)
+        greenlet.join()
+        greenlet.get()
+
     def spawn_later(self, seconds: int, func: Callable, *args: Any, **kwargs: Any) -> Greenlet:
         """Spawn a greenlet `seconds` in the future, in a way that any exceptions can be handled where it was spawned."""
         return super().spawn_later(

--- a/grizzly/locust.py
+++ b/grizzly/locust.py
@@ -956,6 +956,10 @@ def run(context: Context) -> int:  # noqa: C901, PLR0915, PLR0912
                     port,
                 )
                 logger.debug('connected to locust master: %s:%d', host, port)
+
+                # increase heartbeat timeout towards master
+                from locust import runners
+                runners.MASTER_HEARTBEAT_TIMEOUT = runners.MASTER_HEARTBEAT_TIMEOUT * 3
             except OSError:
                 logger.exception('failed to connect to locust master at %s:%d', host, port)
                 return 1

--- a/grizzly/scenarios/__init__.py
+++ b/grizzly/scenarios/__init__.py
@@ -114,9 +114,7 @@ class GrizzlyScenario(SequentialTaskSet):
         raised in the greenlet should be caught else where.
         """
         try:
-            self.task_greenlet = self.task_greenlet_factory.spawn(super().execute_next_task)
-            if self.task_greenlet is not None:  # stupid mypy?!
-                self.task_greenlet.join()
+            self.task_greenlet_factory.spawn_blocking(super().execute_next_task)
         finally:
             self.task_greenlet = None
 

--- a/grizzly/users/__init__.py
+++ b/grizzly/users/__init__.py
@@ -179,7 +179,7 @@ class GrizzlyUser(User, metaclass=GrizzlyUserMeta):
             total_time = int((perf_counter() - start_time) * 1000)
             response_length = len((payload or '').encode())
 
-            # execute response listeners
+            # execute response listeners, but not on these exceptions
             if not isinstance(exception, (RestartScenario, StopUser, AsyncMessageError)):
                 try:
                     self.event_hook.fire(

--- a/grizzly/users/restapi.py
+++ b/grizzly/users/restapi.py
@@ -315,6 +315,8 @@ class RestApiUser(GrizzlyUser, AsyncRequests, GrizzlyHttpAuthClient, metaclass=R
                     if response.status_code == 401 and self.credential is not None and self.credential._access_token is not None:
                         token_expires = datetime.fromtimestamp(self.credential._access_token.expires_on, tz=timezone.utc).astimezone(tz=None)
                         message = f'{message} (token expires {token_expires})'
+                        # @TODO: should probably be removed when concluding troubleshooting
+                        self.logger.error('%s:\n%r\n%s', message, self.credential._token_payload, dict(response.request.headers))
 
                     response.failure(ResponseError(message))
 

--- a/grizzly/users/restapi.py
+++ b/grizzly/users/restapi.py
@@ -315,8 +315,6 @@ class RestApiUser(GrizzlyUser, AsyncRequests, GrizzlyHttpAuthClient, metaclass=R
                     if response.status_code == 401 and self.credential is not None and self.credential._access_token is not None:
                         token_expires = datetime.fromtimestamp(self.credential._access_token.expires_on, tz=timezone.utc).astimezone(tz=None)
                         message = f'{message} (token expires {token_expires})'
-                        # @TODO: should probably be removed when concluding troubleshooting
-                        self.logger.error('%s:\n%r\n%s', message, self.credential._token_payload, dict(response.request.headers))
 
                     response.failure(ResponseError(message))
 

--- a/tests/unit/test_grizzly/auth/test___init__.py
+++ b/tests/unit/test_grizzly/auth/test___init__.py
@@ -54,6 +54,7 @@ class DummyAuthCredential(AzureAadCredential):
 
         self._refreshed = False
         self._access_token = None
+        self._token_payload = None
 
     def get_token(self, *scopes: str, claims: str | None = None, tenant_id: str | None = None, **_kwargs: Any) -> AccessToken:  # noqa: ARG002
         now = datetime.now(tz=timezone.utc).timestamp()

--- a/tests/unit/test_grizzly/test_gevent.py
+++ b/tests/unit/test_grizzly/test_gevent.py
@@ -42,6 +42,21 @@ class TestGreenletWithExceptionCatching:
 
         wrap_exceptions_spy.assert_called_once_with(g.handle_exception)
 
+    def test_spawn_blocking(self) -> None:
+        def fail() -> None:
+            msg = 'foobar'
+            raise RuntimeError(msg)
+
+        def ok() -> None:
+            pass
+
+        factory = GreenletWithExceptionCatching()
+
+        with pytest.raises(RuntimeError, match='foobar'):
+            factory.spawn_blocking(fail)
+
+        factory.spawn_blocking(ok)
+
     def test_spawn_later(self, mocker: MockerFixture) -> None:
         g = GreenletWithExceptionCatching()
         wrap_exceptions_spy = mocker.spy(g, 'wrap_exceptions')


### PR DESCRIPTION
- response handlers does not need to execute on 40x and 50x responses, or rather when the request results in `locust.exception.ResponseError`
- exceptions raised inside a request, which is executed in a seperate greenlet, should be raised from the starting greenlet, so that correct handling could be done in the scenario
- heartbeat timeout between worker and master, could've been related to a hickup, but increased the timeout by 3 times to give some room.

the biggest issue was tokens, where the [calculated] `expires_on` said it was valid, resulted in 401. turned out that the `expires_in` (number of seconds it is valid) is not really exact.

when debugging the issue, it turned out that the token payload contains information that a just received token has been valid for 5 minutes, and that the expire property didn't match with the calculated timestamp based on `expires_in`.

the solution is to use the `exp` timestamp, as in, from the token payload.