### PR TITLE
retry creating a service bus connection if it times out

### DIFF
--- a/grizzly/scenarios/__init__.py
+++ b/grizzly/scenarios/__init__.py
@@ -77,8 +77,6 @@ class GrizzlyScenario(SequentialTaskSet):
             self.logger.error('no address to testdata producer specified')
             raise StopUser
 
-        self.prefetch()
-
         for task in self.tasks:
             if isinstance(task, grizzlytask):
                 try:  # type: ignore[unreachable]
@@ -86,6 +84,9 @@ class GrizzlyScenario(SequentialTaskSet):
                 except:
                     self.logger.exception('on_start failed for task %r', task)
                     raise StopUser from None
+
+        # only prefetch iterator testdata if everything was started OK
+        self.prefetch()
 
     def on_stop(self) -> None:
         """When locust test is stopping, all tasks on_stop methods must be called, even though

--- a/grizzly/scenarios/iterator.py
+++ b/grizzly/scenarios/iterator.py
@@ -78,7 +78,7 @@ class IteratorScenario(GrizzlyScenario):
                     response_time=response_time,
                     response_length=self.task_count,
                     context=self.user._context,
-                    exception=e,
+                    exception=StopUser('on_start failed for {self.user.__class__.__name__}'),
                 )
             raise StopUser from e
 


### PR DESCRIPTION
the timeout is manifested as an `TypeError` due to bad implementation in `azure.servicebus`.

it also includes a change where iteration testdata isn't prefetched until after all the tasks `on_start` has succeeded. if they would fail, then one iteration of testdata is burned, which we don't want.