### PR TITLE
jsonpath filter one of, `=|`

### DIFF
--- a/grizzly/steps/_helpers.py
+++ b/grizzly/steps/_helpers.py
@@ -18,6 +18,7 @@ from grizzly.testdata.utils import resolve_variable
 from grizzly.types import RequestMethod, ResponseAction, ResponseTarget
 from grizzly.utils import has_template
 from grizzly_extras.arguments import get_unsupported_arguments, parse_arguments, split_value
+from grizzly_extras.text import has_separator
 from grizzly_extras.transformer import TransformerContentType
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -186,7 +187,7 @@ def _add_response_handler(
 
     assert len(expression) > 0, 'expression is empty'
 
-    if '|' in expression:
+    if has_separator('|', expression):
         expression, expression_arguments = split_value(expression)
         arguments = parse_arguments(expression_arguments)
         unsupported_arguments = get_unsupported_arguments(['expected_matches', 'as_json'], arguments)

--- a/grizzly/tasks/clients/__init__.py
+++ b/grizzly/tasks/clients/__init__.py
@@ -34,6 +34,7 @@ from grizzly.testdata.utils import resolve_variable
 from grizzly.types import GrizzlyResponse, RequestDirection, RequestType
 from grizzly.utils import merge_dicts, normalize
 from grizzly_extras.arguments import parse_arguments, split_value
+from grizzly_extras.text import has_separator
 from grizzly_extras.transformer import TransformerContentType
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -106,7 +107,7 @@ class ClientTask(GrizzlyMetaRequestTask):
 
         content_type: TransformerContentType = TransformerContentType.UNDEFINED
 
-        if '|' in endpoint:
+        if has_separator('|', endpoint):
             value, value_arguments = split_value(endpoint)
             arguments = parse_arguments(value_arguments, unquote=True)
 

--- a/grizzly/tasks/clients/http.py
+++ b/grizzly/tasks/clients/http.py
@@ -55,6 +55,7 @@ from grizzly.auth import AAD, GrizzlyHttpAuthClient, refresh_token
 from grizzly.types import GrizzlyResponse, RequestDirection, bool_type
 from grizzly.utils import merge_dicts
 from grizzly_extras.arguments import parse_arguments, split_value
+from grizzly_extras.text import has_separator
 
 from . import ClientTask, client
 
@@ -83,7 +84,7 @@ class HttpClientTask(ClientTask, GrizzlyHttpAuthClient):
     ) -> None:
         verify = True
 
-        if '|' in endpoint:
+        if has_separator('|', endpoint):
             endpoint, endpoint_arguments = split_value(endpoint)
             arguments = parse_arguments(endpoint_arguments, unquote=False)
 

--- a/grizzly/tasks/date.py
+++ b/grizzly/tasks/date.py
@@ -48,6 +48,7 @@ from dateutil.relativedelta import relativedelta
 from grizzly.types import ZoneInfo, ZoneInfoNotFoundError
 from grizzly.utils import parse_timespan
 from grizzly_extras.arguments import get_unsupported_arguments, parse_arguments, split_value
+from grizzly_extras.text import has_separator
 
 from . import GrizzlyTask, grizzlytask, template
 
@@ -67,7 +68,7 @@ class DateTask(GrizzlyTask):
         self.variable = variable
         self.value = value
 
-        if '|' in self.value:
+        if has_separator('|', self.value):
             self.value, date_arguments = split_value(self.value)
             self.arguments = parse_arguments(date_arguments)
 

--- a/grizzly/tasks/request.py
+++ b/grizzly/tasks/request.py
@@ -60,6 +60,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from grizzly_extras.arguments import parse_arguments, split_value, unquote
+from grizzly_extras.text import has_separator
 from grizzly_extras.transformer import TransformerContentType
 
 from . import GrizzlyMetaRequestTask, grizzlytask
@@ -140,7 +141,7 @@ class RequestTask(GrizzlyMetaRequestTask):
 
         content_type: TransformerContentType = TransformerContentType.UNDEFINED
 
-        if '|' in self.endpoint:
+        if has_separator('|', self.endpoint):
             value, value_arguments = split_value(self.endpoint)
             self.arguments = parse_arguments(value_arguments, unquote=True)
 

--- a/grizzly/tasks/until.py
+++ b/grizzly/tasks/until.py
@@ -52,6 +52,7 @@ from grizzly.types import RequestType
 from grizzly.types.locust import StopUser
 from grizzly.utils import safe_del
 from grizzly_extras.arguments import get_unsupported_arguments, parse_arguments, split_value
+from grizzly_extras.text import has_separator
 from grizzly_extras.transformer import Transformer, TransformerContentType, TransformerError, transformer
 
 from . import GrizzlyMetaRequestTask, GrizzlyTask, grizzlytask, template
@@ -88,7 +89,7 @@ class UntilRequestTask(GrizzlyTask):
 
         self.transform = transformer.available.get(self.request.content_type, None)
 
-        if '|' in self.condition:
+        if has_separator('|', self.condition):
             self.condition, until_arguments = split_value(self.condition)
 
             if '{{' in until_arguments and '}}' in until_arguments:

--- a/grizzly/testdata/variables/csv_reader.py
+++ b/grizzly/testdata/variables/csv_reader.py
@@ -63,6 +63,7 @@ from typing import Any, ClassVar, Dict, List, Optional, Type, cast
 
 from grizzly.types import bool_type
 from grizzly_extras.arguments import parse_arguments, split_value
+from grizzly_extras.text import has_separator
 
 from . import AtomicVariable
 
@@ -71,7 +72,7 @@ def atomiccsvreader__base_type__(value: str) -> str:
     """Validate values that `AtomicCsvReader` can be initialized with."""
     grizzly_context_requests = Path(environ.get('GRIZZLY_CONTEXT_ROOT', '')) / 'requests'
 
-    if '|' in value:
+    if has_separator('|', value):
         csv_file, csv_arguments = split_value(value)
 
         try:
@@ -123,7 +124,7 @@ class AtomicCsvReader(AtomicVariable[Dict[str, Any]]):
 
             settings = {'repeat': False, 'random': False}
 
-            if '|' in safe_value:
+            if has_separator('|', safe_value):
                 csv_file, csv_arguments = split_value(safe_value)
                 arguments = parse_arguments(csv_arguments)
 

--- a/grizzly/testdata/variables/date.py
+++ b/grizzly/testdata/variables/date.py
@@ -40,6 +40,7 @@ from dateutil.relativedelta import relativedelta
 from grizzly.types import ZoneInfo, ZoneInfoNotFoundError
 from grizzly.utils import parse_timespan
 from grizzly_extras.arguments import parse_arguments, split_value
+from grizzly_extras.text import has_separator
 
 from . import AtomicVariable
 
@@ -50,7 +51,7 @@ def atomicdate__base_type__(value: str) -> str:  # noqa: PLR0912
         message = f'AtomicDate: {value} ({type(value)}) is not a string'  # type: ignore[unreachable]
         raise TypeError(message)
 
-    if '|' in value:
+    if has_separator('|', value):
         date_value, date_arguments = split_value(value)
 
         try:

--- a/grizzly/testdata/variables/directory_contents.py
+++ b/grizzly/testdata/variables/directory_contents.py
@@ -42,6 +42,7 @@ from typing import Any, ClassVar, Dict, List, Optional, Type, cast
 
 from grizzly.types import bool_type
 from grizzly_extras.arguments import parse_arguments, split_value
+from grizzly_extras.text import has_separator
 
 from . import AtomicVariable
 
@@ -49,7 +50,7 @@ from . import AtomicVariable
 def atomicdirectorycontents__base_type__(value: str) -> str:
     """Validate values that `AtomicDirectoryContents` can be initialized with."""
     grizzly_context_requests = Path(environ.get('GRIZZLY_CONTEXT_ROOT', '')) / 'requests'
-    if '|' in value:
+    if has_separator('|', value):
         [directory_value, directory_arguments] = split_value(value)
 
         try:
@@ -99,7 +100,7 @@ class AtomicDirectoryContents(AtomicVariable[str]):
 
             settings = {'repeat': False, 'random': False}
 
-            if '|' in safe_value:
+            if has_separator('|', safe_value):
                 directory, directory_arguments = split_value(safe_value)
 
                 arguments = parse_arguments(directory_arguments)

--- a/grizzly/testdata/variables/integer_incrementer.py
+++ b/grizzly/testdata/variables/integer_incrementer.py
@@ -80,6 +80,7 @@ from typing import Any, ClassVar, Dict, Optional, Type, Union, cast
 
 from grizzly.types import bool_type
 from grizzly_extras.arguments import parse_arguments, split_value
+from grizzly_extras.text import has_separator
 
 from . import AtomicVariable, AtomicVariablePersist
 
@@ -89,7 +90,7 @@ def atomicintegerincrementer__base_type__(value: Union[str, int]) -> str:
     if isinstance(value, int):
         return str(value)
 
-    if '|' in value:
+    if has_separator('|', value):
         try:
             initial_value, incrementer_arguments = split_value(value)
             initial_value = str(int(float(initial_value)))
@@ -136,7 +137,7 @@ class AtomicIntegerIncrementer(AtomicVariable[int], AtomicVariablePersist):
         with self.semaphore(outer=outer_lock):
             safe_value = self.__class__.__base_type__(value)
 
-            if '|' in safe_value:
+            if has_separator('|', safe_value):
                 incrementer_value, incrementer_arguments = split_value(safe_value)
                 initial_value = incrementer_value
                 arguments = parse_arguments(incrementer_arguments)

--- a/grizzly/testdata/variables/random_string.py
+++ b/grizzly/testdata/variables/random_string.py
@@ -44,6 +44,7 @@ from uuid import uuid4
 
 from grizzly.types import bool_type, int_rounded_float_type
 from grizzly_extras.arguments import parse_arguments, split_value
+from grizzly_extras.text import has_separator
 
 from . import AtomicVariable
 
@@ -54,7 +55,7 @@ def atomicrandomstring__base_type__(value: str) -> str:
         message = 'AtomicRandomString: no string pattern specified'
         raise ValueError(message)
 
-    if '|' in value:
+    if has_separator('|', value):
         string_pattern, string_arguments = split_value(value)
 
         try:
@@ -116,7 +117,7 @@ class AtomicRandomString(AtomicVariable[str]):
 
             settings = {'upper': False, 'count': 1}
 
-            if '|' in safe_value:
+            if has_separator('|', safe_value):
                 string_pattern, string_arguments = split_value(safe_value)
 
                 arguments = parse_arguments(string_arguments)

--- a/grizzly/utils.py
+++ b/grizzly/utils.py
@@ -285,8 +285,16 @@ def check_mq_client_logs(context: Context) -> None:
 
 def async_message_request_wrapper(parent: GrizzlyScenario, client: zmq.Socket, request: AsyncMessageRequest) -> AsyncMessageResponse:
     """Wrap `grizzly_extras.async_message.async_message_request` to make it easier to communicating with `async-messaged` from within `grizzly`."""
-    request_json = jsondumps(request)
-    request = jsonloads(parent.render(request_json))
+    request_string: Optional[str] = None
+    request_rendered: Optional[str] = None
+
+    try:
+        request_string = jsondumps(request)
+        request_rendered = parent.render(request_string)
+        request = jsonloads(request_rendered)
+    except:
+        parent.user.logger.error('failed to render request:\ntemplate=%r\nrendered=%r', request, request_rendered)  # noqa: TRY400
+        raise
 
     if request.get('client', None) is None:
         request.update({'client': id(parent.user)})

--- a/grizzly/utils.py
+++ b/grizzly/utils.py
@@ -290,7 +290,7 @@ def async_message_request_wrapper(parent: GrizzlyScenario, client: zmq.Socket, r
 
     try:
         request_string = jsondumps(request)
-        request_rendered = parent.render(request_string)
+        request_rendered = parent.render(request_string, escape_values=True)
         request = jsonloads(request_rendered)
     except:
         parent.user.logger.error('failed to render request:\ntemplate=%r\nrendered=%r', request, request_rendered)  # noqa: TRY400

--- a/grizzly_extras/arguments.py
+++ b/grizzly_extras/arguments.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Tuple, cast
 
+from .text import has_sequence
+
 
 def split_value(value: str, separator: str = '|') -> Tuple[str, str]:
     return cast(Tuple[str, str], tuple([v.strip() for v in value.split(separator, 1)]))
@@ -23,7 +25,7 @@ def unquote(argument: str) -> str:
     return argument
 
 
-def parse_arguments(arguments: str, separator: str = '=', *, unquote: bool = True) -> Dict[str, Any]:  # noqa: C901, PLR0912
+def parse_arguments(arguments: str, separator: str = '=', *, unquote: bool = True) -> Dict[str, Any]:  # noqa: C901, PLR0912, PLR0915
     if separator not in arguments or (arguments.count(separator) > 1 and (arguments.count('"') < 2 and arguments.count("'") < 2) and ', ' not in arguments):
         message = f'incorrect format in arguments: "{arguments}"'
         raise ValueError(message)
@@ -47,7 +49,7 @@ def parse_arguments(arguments: str, separator: str = '=', *, unquote: bool = Tru
             message = f'incorrect format for argument: "{argument.strip()}"'
             raise ValueError(message)
 
-        [key, value] = argument.strip().split(separator, 1)
+        key, value = argument.strip().split(separator, 1)
 
         key = key.strip()
         if '"' in key or "'" in key or ' ' in key:
@@ -62,10 +64,13 @@ def parse_arguments(arguments: str, separator: str = '=', *, unquote: bool = Tru
 
         start_quote: Optional[str] = None
 
-        inline_quotes = '==' in value and value.index('==') == value.rindex('==') and '?' not in value and '@' not in value
+        has_equals = has_sequence('==', value)
+        has_or = has_sequence('|=', value)
+        inline_quotes = (has_equals or has_or) and '?' not in value and '@' not in value
+        sequence = '==' if has_equals else '|='
 
         # == = 2 characters ------------------------------------------v
-        start_index = 0 if not inline_quotes else value.index('==') + 2
+        start_index = 0 if not inline_quotes else value.index(sequence) + 2
 
         if value[start_index] in ['"', "'"]:
             if value[-1] != value[start_index]:

--- a/grizzly_extras/arguments.py
+++ b/grizzly_extras/arguments.py
@@ -11,7 +11,25 @@ from .text import has_sequence
 
 
 def split_value(value: str, separator: str = '|') -> Tuple[str, str]:
-    return cast(Tuple[str, str], tuple([v.strip() for v in value.split(separator, 1)]))
+    operators = ["=", "|"]
+
+    try:
+        if value.count(separator) > 1:
+            left_index = value.index(separator)
+            right_index = value.rindex(separator)
+
+            if value[left_index + 1] not in operators:
+                values = value.split(separator, 1)
+            elif value[right_index + 1] not in operators:
+                values = value.rsplit(separator, 1)
+            else:
+                raise ValueError  # default
+        else:
+            raise ValueError  # default
+    except ValueError:
+        values = value.split(separator, 1)
+
+    return cast(Tuple[str, str], tuple([v.strip() for v in values]))
 
 
 def get_unsupported_arguments(valid_arguments: List[str], arguments: Dict[str, Any]) -> List[str]:

--- a/grizzly_extras/text.py
+++ b/grizzly_extras/text.py
@@ -150,3 +150,17 @@ class PermutationEnum(Enum, metaclass=PermutationMeta):
 def has_sequence(sequence: str, value: str) -> bool:
     """Test string for a sequence of characters, and that it only occurs once in the string."""
     return sequence in value and value.index(sequence) == value.rindex(sequence)
+
+def has_separator(separator: str, value: str) -> bool:
+    """Test string for separator, which is not connected to any other operators."""
+    operators = ["=", "|"]
+
+    try:
+        left_index = value.index(separator)
+    except ValueError:
+        return False
+
+    try:
+        return value[left_index + 1] not in operators
+    except IndexError:
+        return separator in value

--- a/grizzly_extras/text.py
+++ b/grizzly_extras/text.py
@@ -145,3 +145,8 @@ class PermutationEnum(Enum, metaclass=PermutationMeta):
     def from_string(cls, value: str) -> Enum:
         message = f'{cls.__name__} has not implemented `from_string`'
         raise NotImplementedError(message)  # pragma: no cover
+
+
+def has_sequence(sequence: str, value: str) -> bool:
+    """Test string for a sequence of characters, and that it only occurs once in the string."""
+    return sequence in value and value.index(sequence) == value.rindex(sequence)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools ==69.2.0", "wheel ==0.43.0", "setuptools-scm ==8.0.4"]
+requires = ["setuptools ==69.2.0", "wheel ==0.43.0", "setuptools-scm ==8.1.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/tests/unit/test_grizzly/tasks/clients/test_servicebus.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_servicebus.py
@@ -165,7 +165,7 @@ class TestServiceBusClientTask:
 
         task = cls_task(
             RequestDirection.FROM, (
-                'sb://my-sbns/topic:my-topic/subscription:my-subscription'
+                'sb://my-sbns/topic:my-topic/subscription:my-subscription/expression:$.name|=\'["hello", "world"]\''
                 ';SharedAccessKeyName=AccessKey;SharedAccessKey=37aabb777f454324=#MessageWait=120&ContentType=json'
             ),
             'test',
@@ -175,7 +175,7 @@ class TestServiceBusClientTask:
         assert task.context == {
             'url': 'sb://my-sbns.servicebus.windows.net/;SharedAccessKeyName=AccessKey;SharedAccessKey=37aabb777f454324=',
             'connection': 'receiver',
-            'endpoint': 'topic:my-topic, subscription:my-subscription',
+            'endpoint': 'topic:my-topic, subscription:my-subscription, expression:$.name|=\'["hello", "world"]\'',
             'message_wait': 120,
             'consume': False,
             'content_type': 'JSON',

--- a/tests/unit/test_grizzly_extras/test_arguments.py
+++ b/tests/unit/test_grizzly_extras/test_arguments.py
@@ -15,6 +15,9 @@ def test_split_value(separator: str) -> None:
         'hello', f'world {separator} foo {separator} bar',
     )
 
+    assert split_value('hello|=test | yo') == ('hello|=test', 'yo')
+    assert split_value('hello | test|yo') == ('hello', 'test|yo')
+
 
 def test_get_unsupported_arguments() -> None:
     assert get_unsupported_arguments(['hello', 'world'], {

--- a/tests/unit/test_grizzly_extras/test_arguments.py
+++ b/tests/unit/test_grizzly_extras/test_arguments.py
@@ -39,7 +39,7 @@ def test_unquote() -> None:
 
 
 @pytest.mark.parametrize('separator', ['=', ':', '%'])
-def test_parse_arguments(separator: str) -> None:
+def test_parse_arguments(separator: str) -> None:  # noqa: PLR0915
     with pytest.raises(ValueError, match='incorrect format in arguments:'):
         parse_arguments('argument', separator)
 
@@ -87,6 +87,24 @@ def test_parse_arguments(separator: str) -> None:
 
     assert arguments == {
         'arg1': '$.expression=="{{ value }}"',
+    }
+
+    arguments = parse_arguments(f'arg1{separator}$.expression|="[\'a\', \'b\', \'c\']"', separator)
+
+    assert arguments == {
+        'arg1': '$.expression|="[\'a\', \'b\', \'c\']"',
+    }
+
+    arguments = parse_arguments(f'arg1{separator}$.expression|=\'["a", "b", "c"]\'', separator)
+
+    assert arguments == {
+        'arg1': '$.expression|=\'["a", "b", "c"]\'',
+    }
+
+    arguments = parse_arguments(f'arg1{separator}$.expression|="[1, 2, 3]"', separator)
+
+    assert arguments == {
+        'arg1': '$.expression|="[1, 2, 3]"',
     }
 
     with pytest.raises(ValueError, match='incorrect format in arguments: '):

--- a/tests/unit/test_grizzly_extras/test_transformer.py
+++ b/tests/unit/test_grizzly_extras/test_transformer.py
@@ -215,6 +215,47 @@ class TestJsonTransformer:
 
         assert actual != []
 
+        # <!-- test equal
+        get_values = JsonTransformer.parser('$.id==2')
+        actual = get_values(document)
+        assert actual == []
+
+        get_values = JsonTransformer.parser('$.id==1')
+        actual = get_values(document)
+        assert actual == ['1']
+        # // -->
+
+        # <!-- test or
+        get_values = JsonTransformer.parser('$.id|=[2, 3]')
+        actual = get_values(document)
+        assert actual == []
+
+        get_values = JsonTransformer.parser('$.id|=\'[1, 2, 3]\'')
+        actual = get_values(document)
+        assert actual == ['1']
+
+        document.update({'id': 3})
+        actual = get_values(document)
+        assert actual == ['3']
+
+        document.update({'id': 2})
+        actual = get_values(document)
+        assert actual == ['2']
+
+        get_values = JsonTransformer.parser('$.id|="[1, 2, 3]"')
+        document.update({'id': 1})
+        actual = get_values(document)
+        assert actual == ['1']
+
+        document.update({'id': 3})
+        actual = get_values(document)
+        assert actual == ['3']
+
+        document.update({'id': 2})
+        actual = get_values(document)
+        assert actual == ['2']
+        # // -->
+
 
 class TestXmlTransformer:
     def test_transform(self) -> None:


### PR DESCRIPTION
adding support for service bus message expressions like "this property expression should be one of the following values".
this is done by using `|=` as an operator, and right side should be a json representation of a list/sequence of values that it will allow.

if the property expression matches one of the values, that message is returned, e.g.:
```
Then get "sb://$conf::sb.name$.servicebus.windows.net/topic:events/subscription:my-subscription/expression:$.eventId|='["foo", "bar"]'#Consume=True&MessageWait=$conf::sb.message.wait$&ContentType=json" with name "events" and save response payload in "event"
      """
      1=1
      """
```

this request will accept messages `{"eventId": "foo"}` and `{"eventId": "bar"}`, but not anything else.

additional problems was identified and fixed:
- `|=` caused problems when parsing arguments, since `|` is considered a seperator for `<value> | <arguments>`
- when "batch" rendering a object/list (dump object/list as a string, render string, load string as object/list), if the variable values contained `"` it would cause the last step (load string as...) to fail, since the string is an invalid json string
