### PR TITLE
increment value in keystore

### DIFF
--- a/grizzly/steps/scenario/tasks/keystore.py
+++ b/grizzly/steps/scenario/tasks/keystore.py
@@ -80,3 +80,22 @@ def step_task_keystore_set(context: Context, key: str, value: str) -> None:
     except JSONDecodeError as e:
         message = f'"{value}" is not valid JSON'
         raise AssertionError(message) from e
+
+
+@then('increment "{key}" in keystore and save in variable "{variable}"')
+def step_task_keystore_inc_default_step(context: Context, key: str, variable: str) -> None:
+    """Increment the integer value for `key` (with step `1`) using the {@pylink grizzly.tasks.keystore} task.
+
+    If there is no value for `key` incrementing will start from 0. The new value is saved in `variable`.
+
+    See {@pylink grizzly.tasks.keystore} task documentation for more information.
+
+    Example:
+    ```gherkin
+    Given value for variable "counter" is "none"
+    Then increment "counter" in keystore and save in variable "counter"
+    ```
+
+    """
+    grizzly = cast(GrizzlyContext, context.grizzly)
+    grizzly.scenario.tasks.add(KeystoreTask(key, 'inc', variable))

--- a/grizzly/testdata/communication.py
+++ b/grizzly/testdata/communication.py
@@ -270,15 +270,11 @@ class TestdataProducer:
         elif request['action'] == 'inc':
             key = response.get('key', None)
             step = response.get('data', 1)
-            value = self.keystore.get(key, None)
+            value = self.keystore.get(key, 0)
             response.update({'data': None})
 
             if key is None:  # pragma: no cover
                 self.logger.error('key %s does not exist', key)
-                return response
-
-            if value is None:
-                self.logger.error('cannot increment a non existing value for key "%s"', key)
                 return response
 
             if isinstance(value, int):

--- a/grizzly/testdata/communication.py
+++ b/grizzly/testdata/communication.py
@@ -118,6 +118,22 @@ class TestdataConsumer:
 
         self._keystore_request(request)
 
+    def keystore_inc(self, key: str, step: int = 1) -> Optional[int]:
+        request = {
+            'action': 'inc',
+            'key': key,
+            'data': step,
+        }
+
+        response = self._keystore_request(request)
+
+        value = (response or {}).get('data', None)
+
+        if value is not None:
+            return int(value)
+
+        return value
+
     def _keystore_request(self, request: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         request.update({
             'message': 'keystore',
@@ -246,8 +262,35 @@ class TestdataProducer:
             key = response.get('key', None)
             value = response.get('data', None)
 
-            if key is not None:
-                self.keystore.update({key: value})
+            if key is None:
+                self.logger.error('key %s does not exist', key)
+                return response
+
+            self.keystore.update({key: value})
+        elif request['action'] == 'inc':
+            key = response.get('key', None)
+            step = response.get('data', 1)
+            value = self.keystore.get(key, None)
+            response.update({'data': None})
+
+            if key is None:  # pragma: no cover
+                self.logger.error('key %s does not exist', key)
+                return response
+
+            if value is None:
+                self.logger.error('cannot increment a non existing value for key "%s"', key)
+                return response
+
+            if isinstance(value, int):
+                new_value = value + step
+            elif isinstance(value, str) and value.isnumeric():
+                new_value = int(value) + step
+            else:
+                self.logger.error('value %r for key "%s" cannot be incremented', value, key)
+                return response
+
+            self.keystore.update({key: new_value})
+            response.update({'data': new_value})
         else:
             self.logger.error('received unknown keystore action "%s"', request['action'])
             response['data'] = None

--- a/tests/e2e/steps/scenario/test_tasks.py
+++ b/tests/e2e/steps/scenario/test_tasks.py
@@ -1143,18 +1143,21 @@ def test_e2e_step_task_keystore(e2e_fixture: End2EndFixture) -> None:
         grizzly = cast(GrizzlyContext, context.grizzly)
         grizzly.scenario.tasks().pop()  # remove dummy task
 
-        assert len(grizzly.scenario.tasks()) == 4
+        assert len(grizzly.scenario.tasks()) == 5
 
     e2e_fixture.add_validator(validate_keystore_task)
 
     feature_file = e2e_fixture.test_steps(
         scenario=[
+            'And repeat for "2" iterations',
             'And value for variable "foobar" is "none"',
             'And value for variable "barfoo" is "none"',
+            'And value for variable "counter" is "none"',
             'Then set "foobar" in keystore with value "[\'hello\', \'world\']"',
             'Then get "foobar" from keystore and save in variable "foobar"',
             'Then get "barfoo" from keystore and save in variable "barfoo", with default value "{\'hello\': \'world\'}"',
-            'Then log message "foobar={{ foobar }}, barfoo={{ barfoo }}"',
+            'Then increment "counter" in keystore and save in variable "counter"',
+            'Then log message "foobar={{ foobar }}, barfoo={{ barfoo }}, counter={{ counter }}"',
         ],
     )
 
@@ -1164,7 +1167,8 @@ def test_e2e_step_task_keystore(e2e_fixture: End2EndFixture) -> None:
 
     result = ''.join(output)
 
-    assert "foobar=['hello', 'world'], barfoo={'hello': 'world'}" in result
+    assert "foobar=['hello', 'world'], barfoo={'hello': 'world'}, counter=1" in result
+    assert "foobar=['hello', 'world'], barfoo={'hello': 'world'}, counter=2" in result
 
     persistent_file = e2e_fixture.root / 'features' / 'persistent' / f'{Path(feature_file).stem}.json'
     assert not persistent_file.exists()

--- a/tests/unit/test_grizzly/tasks/test_keystore.py
+++ b/tests/unit/test_grizzly/tasks/test_keystore.py
@@ -16,10 +16,10 @@ if TYPE_CHECKING:  # pragma: no cover
 
 class TestKeystoreTask:
     def test___init__(self, grizzly_fixture: GrizzlyFixture) -> None:
-        with pytest.raises(AssertionError, match='action context for get must be a string'):
+        with pytest.raises(RuntimeError, match='action context for get must be a string'):
             KeystoreTask('foobar', 'get', None)
 
-        with pytest.raises(AssertionError, match='foobar has not been initialized'):
+        with pytest.raises(RuntimeError, match='variable "foobar" has not been initialized'):
             KeystoreTask('foobar', 'get', 'foobar')
 
         grizzly_fixture.grizzly.state.variables.update({'foobar': 'none'})
@@ -38,7 +38,7 @@ class TestKeystoreTask:
         assert task.action_context == 'foobar'
         assert task.default_value == ['hello', 'world']
 
-        with pytest.raises(AssertionError, match='action context for set cannot be None'):
+        with pytest.raises(RuntimeError, match='action context for set cannot be None'):
             KeystoreTask('foobar', 'set', None)
 
         task = KeystoreTask('foobar', 'set', {'hello': 'world'})
@@ -48,7 +48,7 @@ class TestKeystoreTask:
         assert task.action_context == {'hello': 'world'}
         assert task.default_value is None
 
-        with pytest.raises(AssertionError, match='unknown is not a valid action'):
+        with pytest.raises(RuntimeError, match='unknown is not a valid action'):
             KeystoreTask('foobar', 'unknown', None)  # type: ignore[arg-type]
 
     def test___call___get(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:

--- a/tests/unit/test_grizzly/testdata/test_communication.py
+++ b/tests/unit/test_grizzly/testdata/test_communication.py
@@ -214,10 +214,10 @@ value3,value4
                         'message': 'keystore',
                         'action': 'inc',
                         'key': 'counter',
-                        'data': None,
+                        'data': 1,
                     }
 
-                assert caplog.messages == ['cannot increment a non existing value for key "counter"']
+                assert caplog.messages == []
 
                 caplog.clear()
                 producer.keystore.update({'counter': 'asdf'})

--- a/tests/unit/test_grizzly/testdata/test_communication.py
+++ b/tests/unit/test_grizzly/testdata/test_communication.py
@@ -36,6 +36,7 @@ class TestTestdataProducer:
         behave_fixture: BehaveFixture,
         grizzly_fixture: GrizzlyFixture,
         cleanup: AtomicVariableCleanupFixture,
+        caplog: LogCaptureFixture,
     ) -> None:
         producer: Optional[TestdataProducer] = None
         context: Optional[zmq.Context] = None
@@ -204,6 +205,58 @@ value3,value4
                     'key': 'foobar',
                     'data': {'hello': 'world'},
                 }
+
+                caplog.clear()
+
+                with caplog.at_level(logging.ERROR):
+                    message = request_keystore('inc', 'counter', 1)
+                    assert message == {
+                        'message': 'keystore',
+                        'action': 'inc',
+                        'key': 'counter',
+                        'data': None,
+                    }
+
+                assert caplog.messages == ['cannot increment a non existing value for key "counter"']
+
+                caplog.clear()
+                producer.keystore.update({'counter': 'asdf'})
+
+                with caplog.at_level(logging.ERROR):
+                    message = request_keystore('inc', 'counter', 1)
+                    assert message == {
+                        'message': 'keystore',
+                        'action': 'inc',
+                        'key': 'counter',
+                        'data': None,
+                    }
+
+                assert caplog.messages == ['value \'asdf\' for key "counter" cannot be incremented']
+
+                caplog.clear()
+                producer.keystore.update({'counter': 1})
+
+                with caplog.at_level(logging.ERROR):
+                    message = request_keystore('inc', 'counter', 1)
+                    assert message == {
+                        'message': 'keystore',
+                        'action': 'inc',
+                        'key': 'counter',
+                        'data': 2,
+                    }
+
+                assert caplog.messages == []
+
+                with caplog.at_level(logging.ERROR):
+                    message = request_keystore('inc', 'counter', 10)
+                    assert message == {
+                        'message': 'keystore',
+                        'action': 'inc',
+                        'key': 'counter',
+                        'data': 12,
+                    }
+
+                assert caplog.messages == []
 
                 message = request_testdata()
                 assert message['action'] == 'stop'
@@ -729,7 +782,7 @@ class TestTestdataConsumer:
 
         assert caplog.messages == ['no testdata received']
 
-    def test_keystore_get_set(self, mocker: MockerFixture, noop_zmq: NoopZmqFixture, grizzly_fixture: GrizzlyFixture) -> None:
+    def test_keystore(self, mocker: MockerFixture, noop_zmq: NoopZmqFixture, grizzly_fixture: GrizzlyFixture) -> None:
         noop_zmq('grizzly.testdata.communication')
         parent = grizzly_fixture()
 
@@ -778,3 +831,27 @@ class TestTestdataConsumer:
             'identifier': consumer.identifier,
             'data': {'hello': 'world'},
         })
+
+        request_spy = mocker.patch.object(consumer, '_request', side_effect=echo)
+
+        assert consumer.keystore_inc('counter') == 1
+
+        request_spy.assert_called_once_with({
+            'action': 'inc',
+            'key': 'counter',
+            'message': 'keystore',
+            'identifier': consumer.identifier,
+            'data': 1,
+        })
+        request_spy.reset_mock()
+
+        assert consumer.keystore_inc('counter', step=10) == 10
+
+        request_spy.assert_called_once_with({
+            'action': 'inc',
+            'key': 'counter',
+            'message': 'keystore',
+            'identifier': consumer.identifier,
+            'data': 10,
+        })
+


### PR DESCRIPTION
a synchronized way of increment an integer in keystore on-demand (compared to `AtomicIntegerIncrementer`).

step implementation only supports incrementing by step 1. if no value is found in the keystore, it will assume 0 and start incrementing from that.