### PR TITLE
no heartbeat problems

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.10, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.10-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.10-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
-ARG VARIANT="3.11"
+ARG VARIANT="3.12"
 
 # IBM MQ libraries dependencies
 FROM alpine:latest as dependencies
@@ -12,7 +12,7 @@ RUN mkdir /root/ibm && cd /root/ibm && \
 # End IBM MQ libraries dependencies
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.209.5/containers/python-3/.devcontainer/base.Dockerfile
 
-FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
+FROM mcr.microsoft.com/vscode/devcontainers/python:1-${VARIANT}
 
 RUN rm  -rf /etc/apt/sources.list.d/yarn.list || true && \
     apt-get update

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,10 +6,7 @@
         "dockerfile": "Dockerfile",
         "context": "..",
         "args": {
-            // Update 'VARIANT' to pick a Python version: 3, 3.10, 3.9, 3.8, 3.7, 3.6
-            // Append -bullseye or -buster to pin to an OS version.
-            // Use -bullseye variants on local on arm64/Apple Silicon.
-            "VARIANT": "3.11",
+            "VARIANT": "3.12",
             // Options
             "INSTALL_NODE": "true",
             "NODE_VERSION": "lts/*"

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         runs-on: ['ubuntu-latest']
         include:
           - python-version: '3.11'

--- a/example/features/steps/custom.py
+++ b/example/features/steps/custom.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 from json import loads as jsonloads
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING, Any
 
 from grizzly.tasks import GrizzlyTask, RequestTask, grizzlytask
 from grizzly.testdata.variables import AtomicVariable
@@ -23,7 +23,7 @@ class User(RestApiUser):
 
 
 class Task(GrizzlyTask):
-    data: Dict[str, str]
+    data: dict[str, str]
     logger = logging.getLogger(__name__)
 
     def __init__(self, data: str) -> None:

--- a/grizzly/auth/__init__.py
+++ b/grizzly/auth/__init__.py
@@ -224,6 +224,7 @@ class RefreshToken(metaclass=ABCMeta):
 
             username = auth_user.get('username', None)
             password = auth_user.get('password', None) or auth_client.get('secret', None)
+            otp_secret = auth_user.get('otp_secret', None)
             client_id = auth_client.get('id', None)
 
             # nothing has changed, use existing crendential
@@ -274,6 +275,7 @@ class RefreshToken(metaclass=ABCMeta):
                 client_id=client_id,
                 redirect=redirect_uri,
                 initialize=initialize_uri,
+                otp_secret=otp_secret,
             )
 
 

--- a/grizzly/auth/__init__.py
+++ b/grizzly/auth/__init__.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 from functools import wraps
 from importlib import import_module
 from time import perf_counter
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, Generic, Optional, Set, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Generic, Optional, TypeVar, Union, cast
 from urllib.parse import urlparse
 
 from azure.core.credentials import AccessToken
@@ -40,9 +40,9 @@ class GrizzlyHttpAuthClient(Generic[P], metaclass=ABCMeta):
     host: str
     environment: Environment
     credential: Optional[AzureAadCredential] = None
-    metadata: Dict[str, Any]
-    cookies: Dict[str, str]
-    __context__: ClassVar[Dict[str, Any]] = {
+    metadata: dict[str, Any]
+    cookies: dict[str, str]
+    __context__: ClassVar[dict[str, Any]] = {
         'verify_certificates': True,
         'auth': {
             'refresh_time': 3000,
@@ -68,7 +68,7 @@ class GrizzlyHttpAuthClient(Generic[P], metaclass=ABCMeta):
     session_started: Optional[float]
     grizzly: GrizzlyContext
     _scenario: GrizzlyContextScenario
-    _context: Dict[str, Any]
+    _context: dict[str, Any]
 
     def add_metadata(self, key: str, value: str) -> None:
         if self._context.get('metadata', None) is None:
@@ -77,25 +77,25 @@ class GrizzlyHttpAuthClient(Generic[P], metaclass=ABCMeta):
         cast(dict, self._context['metadata']).update({key: value})
 
     @property
-    def __context_change_history__(self) -> Set[str]:
-        return cast(Set[str], self._context['__context_change_history__'])
+    def __context_change_history__(self) -> set[str]:
+        return cast(set[str], self._context['__context_change_history__'])
 
     @property
-    def __cached_auth__(self) -> Dict[str, AzureAadCredential]:
+    def __cached_auth__(self) -> dict[str, AzureAadCredential]:
         # clients might not cache auth tokens, let's set it to an empty dict
         # which could be refered to later, without updating client implementation
         if '__cached_auth__' not in self._context:
             self._context['__cached_auth__'] = {}
-        return cast(Dict[str, AzureAadCredential], self._context['__cached_auth__'])
+        return cast(dict[str, AzureAadCredential], self._context['__cached_auth__'])
 
 
 AuthenticatableFunc = TypeVar('AuthenticatableFunc', bound=Callable[..., GrizzlyResponse])
 
 
 class refresh_token(Generic[P]):
-    impl: Type[RefreshToken]
+    impl: type[RefreshToken]
 
-    def __init__(self, impl: Union[Type[RefreshToken], str]) -> None:
+    def __init__(self, impl: Union[type[RefreshToken], str]) -> None:
         if isinstance(impl, str):
             if impl.count('.') > 1:
                 module_name, class_name = impl.rsplit('.', 1)
@@ -108,7 +108,7 @@ class refresh_token(Generic[P]):
             assert issubclass(dynamic_impl, RefreshToken), f'{module_name}.{class_name} is not a subclass of {RefreshToken.__module__}.{RefreshToken.__name__}'
             impl = dynamic_impl
 
-        self.impl = cast(Type[RefreshToken], impl)
+        self.impl = cast(type[RefreshToken], impl)
 
     def __call__(self, func: AuthenticatableFunc) -> AuthenticatableFunc:
         @wraps(func)
@@ -196,7 +196,7 @@ class refresh_token(Generic[P]):
 
 
 def render(client: GrizzlyHttpAuthClient) -> None:
-    variables = cast(Dict[str, Any], client._context.get('variables', {}))
+    variables = cast(dict[str, Any], client._context.get('variables', {}))
     host = client.grizzly.state.jinja2.from_string(client.host).render(**variables)
     parsed = urlparse(host)
 
@@ -210,7 +210,7 @@ def render(client: GrizzlyHttpAuthClient) -> None:
 
 
 class RefreshToken(metaclass=ABCMeta):
-    __TOKEN_CREDENTIAL_TYPE__: ClassVar[Type[AzureAadCredential]]
+    __TOKEN_CREDENTIAL_TYPE__: ClassVar[type[AzureAadCredential]]
 
     @classmethod
     def initialize(cls, client: GrizzlyHttpAuthClient) -> None:

--- a/grizzly/behave.py
+++ b/grizzly/behave.py
@@ -21,7 +21,8 @@ from .locust import run as locustrun
 from .testdata.variables import destroy_variables
 from .types import RequestType
 from .types.behave import Context, Feature, Scenario, Status, Step
-from .utils import check_mq_client_logs, fail_direct, in_correct_section
+from .utils import fail_direct, in_correct_section
+from .utils.protocols import mq_client_logs
 
 logger = logging.getLogger(__name__)
 
@@ -129,7 +130,7 @@ def after_feature(context: Context, feature: Feature, *_args: Any, **_kwargs: An
             return_code = after_feature_master(return_code, status, context, feature)
 
             if pymqi.__name__ != 'grizzly_extras.dummy_pymqi' and not on_worker(context):
-                check_mq_client_logs(context)
+                mq_client_logs(context)
 
         if return_code != 0:
             cause = 'locust test failed' if return_code != ABORTED_RETURN_CODE else 'locust test aborted'

--- a/grizzly/behave.py
+++ b/grizzly/behave.py
@@ -9,7 +9,7 @@ from os import environ
 from pathlib import Path
 from textwrap import indent
 from time import perf_counter as time
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Optional, cast
 
 import setproctitle as proc
 from behave.reporter.summary import SummaryReporter
@@ -78,7 +78,7 @@ def after_feature_master(return_code: int, status: Optional[Status], context: Co
     if status is None:
         status = Status.failed
 
-    for behave_scenario in cast(List[Scenario], feature.scenarios):
+    for behave_scenario in cast(list[Scenario], feature.scenarios):
         grizzly_scenario = grizzly.scenarios.find_by_description(behave_scenario.name)
         if grizzly_scenario is None:
             continue
@@ -149,7 +149,7 @@ def after_feature(context: Context, feature: Feature, *_args: Any, **_kwargs: An
     if has_exceptions:
         buffer: list[str] = []
 
-        for scenario_name, exceptions in cast(Dict[Optional[str], List[AssertionError]], context.exceptions).items():
+        for scenario_name, exceptions in cast(dict[Optional[str], list[AssertionError]], context.exceptions).items():
             if scenario_name is not None:
                 buffer.append(f'Scenario: {scenario_name}')
             else:
@@ -223,7 +223,7 @@ def after_scenario(context: Context, *_args: Any, **_kwargs: Any) -> None:
 
     assert grizzly.scenario.tasks.tmp.conditional is None, f'conditional "{grizzly.scenario.tasks.tmp.conditional.name}" has not been closed'
 
-    for scenario_name, exceptions in cast(Dict[Optional[str], List[StepError]], context.exceptions).items():
+    for scenario_name, exceptions in cast(dict[Optional[str], list[StepError]], context.exceptions).items():
         if scenario_name != context.scenario.name:
             continue
 

--- a/grizzly/context.py
+++ b/grizzly/context.py
@@ -5,7 +5,7 @@ import logging
 from dataclasses import dataclass, field
 from os import environ
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Type, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union, cast
 
 import yaml
 from jinja2 import Environment
@@ -27,10 +27,10 @@ if TYPE_CHECKING:  # pragma: no cover
 
 logger = logging.getLogger(__name__)
 
-def load_configuration_file() -> Dict[str, Any]:
+def load_configuration_file() -> dict[str, Any]:
     """Load a grizzly environment file and flatten the structure."""
     configuration_file = environ.get('GRIZZLY_CONFIGURATION_FILE', None)
-    configuration: Dict[str, Any] = {}
+    configuration: dict[str, Any] = {}
 
     if configuration_file is None:
         return configuration
@@ -123,11 +123,11 @@ class GrizzlyContextState:
     spawning_complete: bool = field(default=False)
     background_section_done: bool = field(default=False)
     variables: GrizzlyVariables = field(init=False, default_factory=GrizzlyVariables)
-    configuration: Dict[str, Any] = field(init=False, default_factory=load_configuration_file)
-    alias: Dict[str, str] = field(init=False, default_factory=dict)
+    configuration: dict[str, Any] = field(init=False, default_factory=load_configuration_file)
+    alias: dict[str, str] = field(init=False, default_factory=dict)
     verbose: bool = field(default=False)
     locust: Union[MasterRunner, WorkerRunner, LocalRunner] = field(init=False, repr=False)
-    persistent: Dict[str, str] = field(init=False, repr=False, default_factory=dict)
+    persistent: dict[str, str] = field(init=False, repr=False, default_factory=dict)
     _jinja2: Environment = field(init=False, repr=False, default_factory=jinja2_environment_factory)
 
     @property
@@ -187,10 +187,10 @@ class GrizzlyContextTasksTmp:
     _conditional: Optional[ConditionalTask]
     _loop: Optional[LoopTask]
 
-    _timers: Dict[str, Optional[TimerTask]]
-    _custom: Dict[str, Optional[GrizzlyTaskWrapper]]
+    _timers: dict[str, Optional[TimerTask]]
+    _custom: dict[str, Optional[GrizzlyTaskWrapper]]
 
-    __stack__: List[GrizzlyTaskWrapper]
+    __stack__: list[GrizzlyTaskWrapper]
 
     def __init__(self) -> None:
         self.__stack__ = []
@@ -215,25 +215,25 @@ class GrizzlyContextTasksTmp:
         return self._loop
 
     @property
-    def custom(self) -> Dict[str, Optional[GrizzlyTaskWrapper]]:
+    def custom(self) -> dict[str, Optional[GrizzlyTaskWrapper]]:
         return self._custom
 
     @custom.setter
-    def custom(self, value: Dict[str, Optional[GrizzlyTaskWrapper]]) -> None:
+    def custom(self, value: dict[str, Optional[GrizzlyTaskWrapper]]) -> None:
         self._custom = value
 
     @property
-    def timers(self) -> Dict[str, Optional[TimerTask]]:
+    def timers(self) -> dict[str, Optional[TimerTask]]:
         return self._timers
 
     @timers.setter
-    def timers(self, value: Dict[str, Optional[TimerTask]]) -> None:
+    def timers(self, value: dict[str, Optional[TimerTask]]) -> None:
         self._timers = value
 
 
-class GrizzlyContextTasks(List['GrizzlyTask']):
+class GrizzlyContextTasks(list['GrizzlyTask']):
     _tmp: GrizzlyContextTasksTmp
-    behave_steps: Dict[int, str]
+    behave_steps: dict[int, str]
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -245,8 +245,8 @@ class GrizzlyContextTasks(List['GrizzlyTask']):
     def tmp(self) -> GrizzlyContextTasksTmp:
         return self._tmp
 
-    def __call__(self, *filtered_type: type[GrizzlyTask]) -> List[GrizzlyTask]:
-        tasks = self.tmp.__stack__[-1].peek() if len(self.tmp.__stack__) > 0 else cast(List['GrizzlyTask'], self)
+    def __call__(self, *filtered_type: type[GrizzlyTask]) -> list[GrizzlyTask]:
+        tasks = self.tmp.__stack__[-1].peek() if len(self.tmp.__stack__) > 0 else cast(list['GrizzlyTask'], self)
 
         if len(filtered_type) > 0:
             tasks = [task for task in tasks if isinstance(task, filtered_type)]
@@ -271,11 +271,11 @@ class GrizzlyContextScenario:
     pace: Optional[str] = field(init=False, repr=False, hash=False, compare=False, default=None)
 
     behave: Scenario = field(init=True, repr=False, hash=False, compare=False)
-    context: Dict[str, Any] = field(init=False, repr=False, hash=False, compare=False, default_factory=dict)
+    context: dict[str, Any] = field(init=False, repr=False, hash=False, compare=False, default_factory=dict)
     _tasks: GrizzlyContextTasks = field(init=False, repr=False, hash=False, compare=False)
     validation: GrizzlyContextScenarioValidation = field(init=False, hash=False, compare=False, default_factory=GrizzlyContextScenarioValidation)
-    failure_exception: Optional[Type[Exception]] = field(init=False, default=None)
-    orphan_templates: List[str] = field(init=False, repr=False, hash=False, compare=False, default_factory=list)
+    failure_exception: Optional[type[Exception]] = field(init=False, default=None)
+    orphan_templates: list[str] = field(init=False, repr=False, hash=False, compare=False, default_factory=list)
 
     def __post_init__(self) -> None:
         self.name = self.behave.name
@@ -315,7 +315,7 @@ class GrizzlyContextScenario:
         )
 
 
-class GrizzlyContextSetupLocustMessages(Dict[MessageDirection, Dict[str, MessageCallback]]):
+class GrizzlyContextSetupLocustMessages(dict[MessageDirection, dict[str, MessageCallback]]):
     def register(self, direction: MessageDirection, message_type: str, callback: MessageCallback) -> None:
         if direction not in self:
             self[direction] = {}
@@ -336,21 +336,21 @@ class GrizzlyContextSetupLocust:
 class GrizzlyContextSetup:
     log_level: str = field(init=False, default='INFO')
 
-    global_context: Dict[str, Any] = field(init=False, repr=False, hash=False, compare=False, default_factory=dict)
+    global_context: dict[str, Any] = field(init=False, repr=False, hash=False, compare=False, default_factory=dict)
 
     user_count: Optional[int] = field(init=False, default=None)
     spawn_rate: Optional[float] = field(init=False, default=None)
     timespan: Optional[str] = field(init=False, default=None)
-    dispatcher_class: Optional[Type[UsersDispatcher]] = field(init=False, default=None)
+    dispatcher_class: Optional[type[UsersDispatcher]] = field(init=False, default=None)
 
     statistics_url: Optional[str] = field(init=False, default=None)
 
     locust: GrizzlyContextSetupLocust = field(init=False, default_factory=GrizzlyContextSetupLocust)
 
 
-class GrizzlyContextScenarios(List[GrizzlyContextScenario]):
-    def __call__(self) -> List[GrizzlyContextScenario]:
-        return cast(List[GrizzlyContextScenario], self)
+class GrizzlyContextScenarios(list[GrizzlyContextScenario]):
+    def __call__(self) -> list[GrizzlyContextScenario]:
+        return cast(list[GrizzlyContextScenario], self)
 
     def find_by_class_name(self, class_name: str) -> Optional[GrizzlyContextScenario]:
         return self._find(class_name, 'class_name')

--- a/grizzly/events/__init__.py
+++ b/grizzly/events/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from locust.event import EventHook
 
@@ -14,7 +14,7 @@ if TYPE_CHECKING:  # pragma: no cover
 class GrizzlyEventHook(EventHook):
     """Override locust.events.EventHook to get types, and not to catch any exceptions."""
 
-    _handlers: List[GrizzlyEventHandler]
+    _handlers: list[GrizzlyEventHandler]
 
     def __init__(self) -> None:
         self._handlers = []

--- a/grizzly/events/request_logger.py
+++ b/grizzly/events/request_logger.py
@@ -6,7 +6,7 @@ import traceback
 from datetime import datetime, timedelta
 from os import environ
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Optional
 from urllib.parse import urlparse, urlunparse
 
 from jinja2 import Template
@@ -41,7 +41,7 @@ payload:
 
 
 class RequestLogger(GrizzlyEventHandler):
-    _context: Dict[str, Any]
+    _context: dict[str, Any]
 
     log_dir: Path
 
@@ -72,8 +72,8 @@ class RequestLogger(GrizzlyEventHandler):
         request: RequestTask,
         context: GrizzlyResponse,
         exception: Optional[Exception],
-        kwargs: Dict[str, Any],
-    ) -> Dict[str, Any]:
+        kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
         parsed = urlparse(self.user.host or '')
         sep = ''
         if (len(parsed.path) > 0 and parsed.path[-1] != '/' and request.endpoint[0] != '/') or (parsed.path == '' and request.endpoint[0] != '/'):
@@ -82,9 +82,9 @@ class RequestLogger(GrizzlyEventHandler):
         parsed = parsed._replace(path=f'{parsed.path}{sep}{request.endpoint}')
         url = urlunparse(parsed)
 
-        request_metadata: Optional[Dict[str, Any]] = None
+        request_metadata: Optional[dict[str, Any]] = None
         request_payload: Optional[str] = None
-        response_metadata: Optional[Dict[str, Any]] = None
+        response_metadata: Optional[dict[str, Any]] = None
         response_payload: Optional[str] = None
 
         response_metadata, response_payload = context
@@ -140,7 +140,7 @@ class RequestLogger(GrizzlyEventHandler):
 
         log_date = datetime.now().astimezone()
 
-        variables: Dict[str, Any] = {
+        variables: dict[str, Any] = {
             'method': request.method.name,
             'stacktrace': None,
             'request': {

--- a/grizzly/events/response_handler.py
+++ b/grizzly/events/response_handler.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from contextlib import suppress
 from json import dumps as jsondumps
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Optional
 
 from locust.exception import ResponseError
 
@@ -30,7 +30,7 @@ class ResponseHandlerAction(ABC):
     @abstractmethod
     def __call__(
         self,
-        input_context: Tuple[TransformerContentType, HandlerContextType],
+        input_context: tuple[TransformerContentType, HandlerContextType],
         user: GrizzlyUser,
     ) -> None:  # pragma: no cover
         message = f'{self.__class__.__name__} has not implemented __call__'
@@ -38,15 +38,15 @@ class ResponseHandlerAction(ABC):
 
     def get_match(
         self,
-        input_context: Tuple[TransformerContentType, HandlerContextType],
+        input_context: tuple[TransformerContentType, HandlerContextType],
         user: GrizzlyUser,
         *,
         condition: bool = False,
-    ) -> Tuple[Optional[str], str, str]:
+    ) -> tuple[Optional[str], str, str]:
         """Contains common logic for both save and validation handlers.
 
         Args:
-            input_context (Tuple[TransformerContentType, Any]): content type and transformed payload
+            input_context (tuple[TransformerContentType, Any]): content type and transformed payload
             expression (str): expression to extract value from `input_context`
             match_with (str): regular expression that the extracted value must match
             user (ContextVariablesUser): user that executed task (request)
@@ -74,7 +74,7 @@ class ResponseHandlerAction(ABC):
         values = input_get_values(input_payload)
 
         # get a list of all matches in values
-        matches: List[str] = []
+        matches: list[str] = []
         for value in values:
             matched_values = match_get_values(value)
 
@@ -129,7 +129,7 @@ class ValidationHandlerAction(ResponseHandlerAction):
 
     def __call__(
         self,
-        input_context: Tuple[TransformerContentType, HandlerContextType],
+        input_context: tuple[TransformerContentType, HandlerContextType],
         user: GrizzlyUser,
     ) -> None:
         match, expression, match_with = self.get_match(input_context, user, condition=self.condition)
@@ -155,7 +155,7 @@ class SaveHandlerAction(ResponseHandlerAction):
 
     def __call__(
         self,
-        input_context: Tuple[TransformerContentType, HandlerContextType],
+        input_context: tuple[TransformerContentType, HandlerContextType],
         user: GrizzlyUser,
     ) -> None:
         match, expression, _ = self.get_match(input_context, user)
@@ -191,7 +191,7 @@ class ResponseHandler(GrizzlyEventHandler):
         if len(handlers.payload) < 1 and len(handlers.metadata) < 1:
             return
 
-        response_metadata: Optional[Dict[str, Any]]
+        response_metadata: Optional[dict[str, Any]]
         response_payload: Optional[str]
 
         response_metadata, response_payload = context

--- a/grizzly/listeners/__init__.py
+++ b/grizzly/listeners/__init__.py
@@ -136,7 +136,7 @@ def spawning_complete(grizzly: GrizzlyContext) -> Callable[..., None]:
 
 
 def worker_report(client_id: str, data: Dict[str, Any]) -> None:  # noqa: ARG001
-    logger.info('receved worker_report from %s', client_id)
+    logger.info('received worker_report from %s', client_id)
 
 
 def quitting(**_kwargs: Any) -> None:

--- a/grizzly/listeners/__init__.py
+++ b/grizzly/listeners/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 from os import environ
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, cast
+from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 from urllib.parse import urlparse
 
 import gevent
@@ -135,7 +135,7 @@ def spawning_complete(grizzly: GrizzlyContext) -> Callable[..., None]:
     return gspawning_complete
 
 
-def worker_report(client_id: str, data: Dict[str, Any]) -> None:  # noqa: ARG001
+def worker_report(client_id: str, data: dict[str, Any]) -> None:  # noqa: ARG001
     logger.info('received worker_report from %s', client_id)
 
 
@@ -182,7 +182,7 @@ def grizzly_worker_quit(environment: Environment, msg: Message, **_kwargs: Any) 
 def validate_result(grizzly: GrizzlyContext) -> Callable[Concatenate[Environment, P], None]:
     def gvalidate_result(environment: Environment, **_kwargs: P.kwargs) -> None:
         # first, aggregate statistics per scenario
-        scenario_stats: Dict[str, RequestStats] = {}
+        scenario_stats: dict[str, RequestStats] = {}
 
         for scenario in grizzly.scenarios():
             request_stats = RequestStats()

--- a/grizzly/listeners/__init__.py
+++ b/grizzly/listeners/__init__.py
@@ -135,6 +135,10 @@ def spawning_complete(grizzly: GrizzlyContext) -> Callable[..., None]:
     return gspawning_complete
 
 
+def worker_report(client_id: str, data: Dict[str, Any]) -> None:  # noqa: ARG001
+    logger.info('receved worker_report from %s', client_id)
+
+
 def quitting(**_kwargs: Any) -> None:
     logger.debug('locust quitting')
     global producer_greenlet, producer  # noqa: PLW0603

--- a/grizzly/listeners/appinsights.py
+++ b/grizzly/listeners/appinsights.py
@@ -21,7 +21,7 @@ endpoint = tostring(customDimensions["endpoint"])
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Optional
 from urllib.parse import parse_qs, urlparse
 
 from opencensus.ext.azure.log_exporter import AzureLogHandler
@@ -89,7 +89,7 @@ class ApplicationInsightsListener:
 
     def _create_custom_dimensions_dict(
         self, method: str, result: str, response_time: int, response_length: int, endpoint: str, exception: Optional[Any] = None,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         return {
             'method': method,
             'result': result,

--- a/grizzly/listeners/influxdb.py
+++ b/grizzly/listeners/influxdb.py
@@ -8,7 +8,7 @@ import logging
 import os
 from datetime import datetime, timedelta, timezone
 from platform import node as get_hostname
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Type, TypedDict, cast
+from typing import TYPE_CHECKING, Any, Literal, Optional, TypedDict, cast
 from urllib.parse import parse_qs, unquote, urlparse
 
 import gevent
@@ -32,9 +32,9 @@ class InfluxDbError(Exception):
 
 class InfluxDbPoint(TypedDict):
     measurement: str
-    tags: Dict[str, Any]
+    tags: dict[str, Any]
     time: str
-    fields: Dict[str, Any]
+    fields: dict[str, Any]
 
 
 class InfluxDb:
@@ -69,7 +69,7 @@ class InfluxDb:
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
+        exc_type: Optional[type[BaseException]],
         exc: Optional[BaseException],
         traceback: Optional[TracebackType],
     ) -> Literal[True]:
@@ -87,14 +87,14 @@ class InfluxDb:
 
         return True
 
-    def read(self, table: str, columns: List[str]) -> List[Dict[str, Any]]:
+    def read(self, table: str, columns: list[str]) -> list[dict[str, Any]]:
         query = f'select {",".join(columns)} from "{table}";'  # noqa: S608
         logger.debug('query: %s', query)
         result = self.client.query(query)
 
-        return cast(List[Dict[str, Any]], result.raw['series'])
+        return cast(list[dict[str, Any]], result.raw['series'])
 
-    def write(self, values: List[InfluxDbPoint]) -> None:
+    def write(self, values: list[InfluxDbPoint]) -> None:
         try:
             self.client.write_points(values)
             logger.debug('successfully wrote %d points to %s@%s:%d', len(values), self.database, self.host, self.port)
@@ -144,7 +144,7 @@ class InfluxDbListener:
         self.environment = environment
         self._hostname = get_hostname()
         self._username = os.getenv('USER', 'unknown')
-        self._events: List[InfluxDbPoint] = []
+        self._events: list[InfluxDbPoint] = []
         self._finished = False
         self._profile_name = params['ProfileName'][0] if 'ProfileName' in params else ''
         self._description = params['Description'][0] if 'Description' in params else ''
@@ -182,7 +182,7 @@ class InfluxDbListener:
         assert runner is not None, 'no runner is set'
 
         while not self.finished:
-            points: List[Any] = []
+            points: list[Any] = []
             timestamp = datetime.now(timezone.utc).isoformat()
 
             for user_class_name, user_count in runner.user_classes_count.items():
@@ -229,7 +229,7 @@ class InfluxDbListener:
         request_type: str,
         name: str,
         result: str,
-        metrics: Dict[str, Any],
+        metrics: dict[str, Any],
         exception: Optional[Any] = None,
     ) -> None:
         if exception is not None:
@@ -320,8 +320,8 @@ class InfluxDbListener:
         except Exception:
             self.logger.exception('failed to write metric for "%s %s"', request_type, name)
 
-    def _create_metrics(self, response_time: int, response_length: int) -> Dict[str, Any]:
-        metrics: Dict[str, Any] = {}
+    def _create_metrics(self, response_time: int, response_length: int) -> dict[str, Any]:
+        metrics: dict[str, Any] = {}
 
         metrics['response_time'] = response_time
         metrics['response_length'] = response_length if response_length >= 0 else None
@@ -369,7 +369,7 @@ class InfluxDbListener:
 
         timestamp = datetime.now(timezone.utc)
 
-        metrics: Dict[str, float] = {
+        metrics: dict[str, float] = {
             'cpu': cpu_usage,
             'memory': memory_usage,
         }

--- a/grizzly/listeners/influxdb.py
+++ b/grizzly/listeners/influxdb.py
@@ -14,7 +14,6 @@ from urllib.parse import parse_qs, unquote, urlparse
 import gevent
 from influxdb import InfluxDBClient
 from influxdb.exceptions import InfluxDBClientError
-from locust.runners import WorkerRunner
 
 from grizzly.context import GrizzlyContext
 from grizzly.types.locust import CatchResponseError, Environment

--- a/grizzly/listeners/influxdb.py
+++ b/grizzly/listeners/influxdb.py
@@ -150,11 +150,12 @@ class InfluxDbListener:
         self._description = params['Description'][0] if 'Description' in params else ''
 
         self.run_events_greenlet = gevent.spawn(self.run_events)
-        self.run_user_count_greenlet = gevent.spawn(self.run_user_count)
         self.connection = self.create_client().connect()
         self.grizzly = GrizzlyContext()
         self.logger = logging.getLogger(__name__)
         self.environment.events.request.add_listener(self.request)
+        self.environment.events.report_to_master.add_listener(self.report_to_master)
+        self.environment.events.heartbeat.add_listener(self.heartbeat)
         self.environment.events.quit.add_listener(self.on_quit)
 
     def on_quit(self, *_args: Any, **_kwargs: Any) -> None:
@@ -172,39 +173,6 @@ class InfluxDbListener:
     @property
     def finished(self) -> bool:
         return self._finished
-
-    def run_user_count(self) -> None:
-        runner = self.environment.runner
-
-        assert runner is not None, 'no runner is set'
-
-        while not self.finished:
-            points: List[Any] = []
-            timestamp = datetime.now(timezone.utc).isoformat()
-
-            for user_class_name, user_count in runner.user_classes_count.items():
-                point: InfluxDbPoint = {
-                    'measurement': 'user_count',
-                    'tags': {
-                        'environment': self._target_environment,
-                        'testplan': self._testplan,
-                        'profile': self._profile_name,
-                        'description': self._description,
-                        'hostname': self._hostname,
-                        'user_class': user_class_name,
-                    },
-                    'time': timestamp,
-                    'fields': {
-                        'user_count': user_count,
-                    },
-                }
-                points.append(point)
-
-            if len(points) > 0:
-                self.connection.write(points)
-
-            if not self.finished:
-                gevent.sleep(5.0)
 
     def run_events(self) -> None:
         while not self.finished:
@@ -324,3 +292,76 @@ class InfluxDbListener:
         metrics['response_length'] = response_length if response_length >= 0 else None
 
         return metrics
+
+    def heartbeat(self, client_id: str, direction: str, time: float) -> None:
+        timestamp = datetime.fromtimestamp(time, tz=timezone.utc)
+
+        tags = {
+            'client_id': client_id,
+            'testplan': self._testplan,
+            'hostname': self._hostname,
+            'environment': self._target_environment,
+            'profile': self._profile_name,
+            'description': self._description,
+            'direction': direction,
+        }
+
+        event: InfluxDbPoint = {
+            'measurement': 'heartbeat',
+            'tags': tags,
+            'time': timestamp.isoformat(),
+            'fields': {
+                'value': 1,
+            },
+        }
+
+        self._events.append(event)
+
+    def report_to_master(self, client_id: str, data: Dict[str, Any]) -> None:  # noqa: ARG002
+        timestamp = datetime.now(timezone.utc).isoformat()
+
+        for user_class_name, user_count in data.get('user_classes_count', {}).items():
+            event: InfluxDbPoint = {
+                'measurement': 'user_count',
+                'tags': {
+                    'environment': self._target_environment,
+                    'testplan': self._testplan,
+                    'profile': self._profile_name,
+                    'description': self._description,
+                    'hostname': self._hostname,
+                    'user_class': user_class_name,
+                },
+                'time': timestamp,
+                'fields': {
+                    'user_count': user_count,
+                },
+            }
+
+            self._events.append(event)
+
+    def usage_monitor(self, environment: Environment, cpu_usage: float, memory_usage: float) -> None:  # noqa: ARG002
+        tags = {
+            'testplan': self._testplan,
+            'hostname': self._hostname,
+            'environment': self._target_environment,
+            'profile': self._profile_name,
+            'description': self._description,
+        }
+
+        timestamp = datetime.now(timezone.utc)
+
+        metrics: Dict[str, float] = {
+            'cpu': cpu_usage,
+            'memory': memory_usage,
+        }
+
+        event: InfluxDbPoint = {
+            'measurement': 'usage_monitor',
+            'tags': tags,
+            'time': timestamp.isoformat(),
+            'fields': {
+                **metrics,
+            },
+        }
+
+        self._events.append(event)

--- a/grizzly/locust.py
+++ b/grizzly/locust.py
@@ -963,6 +963,7 @@ def run(context: Context) -> int:  # noqa: C901, PLR0915, PLR0912
                 # increase heartbeat timeout towards master
                 from locust import runners
                 runners.MASTER_HEARTBEAT_TIMEOUT = runners.MASTER_HEARTBEAT_TIMEOUT * 3
+                runners.WORKER_LOG_REPORT_INTERVAL = -1
             except OSError:
                 logger.exception('failed to connect to locust master at %s:%d', host, port)
                 return 1

--- a/grizzly/locust.py
+++ b/grizzly/locust.py
@@ -26,7 +26,7 @@ from roundrobin import smooth
 
 from . import __locust_version__, __version__
 from .context import GrizzlyContext
-from .listeners import init, init_statistics_listener, locust_test_start, locust_test_stop, quitting, spawning_complete, validate_result
+from .listeners import init, init_statistics_listener, locust_test_start, locust_test_stop, quitting, spawning_complete, validate_result, worker_report
 from .testdata.utils import initialize_testdata
 from .types import RequestType, TestdataType
 from .types.behave import Context, Status
@@ -767,6 +767,7 @@ def setup_environment_listeners(context: Context, *, testdata: Optional[Testdata
             environment.events.quitting.add_listener(validate_result(grizzly))
 
         environment.events.quitting.add_listener(quitting)
+        environment.events.worker_report.add_listener(worker_report)
 
     environment.events.init.add_listener(init(grizzly, testdata))
     environment.events.test_start.add_listener(locust_test_start(grizzly))

--- a/grizzly/locust.py
+++ b/grizzly/locust.py
@@ -13,7 +13,7 @@ from operator import attrgetter, itemgetter
 from os import environ
 from signal import SIGINT, SIGTERM, Signals
 from time import perf_counter
-from typing import TYPE_CHECKING, Any, Callable, Dict, Generator, Iterator, List, NoReturn, Optional, Set, SupportsIndex, Tuple, Type, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Callable, NoReturn, Optional, SupportsIndex, TypeVar, cast
 
 import gevent
 from locust import events
@@ -41,6 +41,8 @@ __all__ = [
 
 
 if TYPE_CHECKING:
+    from collections.abc import Generator, Iterator
+
     from locust.runners import WorkerNode
 
 
@@ -55,7 +57,7 @@ stats_logger = logging.getLogger('locust.stats_logger')
 T = TypeVar('T')
 
 
-class LengthOptimizedList(List[T]):
+class LengthOptimizedlist(list[T]):
     """Simple implementation of a list that keeps track of its length for speed optimizations."""
 
     __optimized_length__: int
@@ -120,7 +122,7 @@ class FixedUsersDispatcher(UsersDispatcher):
 
         self._user_count_per_dispatch_iteration: int
 
-        self._active_users: LengthOptimizedList[tuple[WorkerNode, str]] = LengthOptimizedList()
+        self._active_users: LengthOptimizedlist[tuple[WorkerNode, str]] = LengthOptimizedlist()
 
         self._spawn_rate: float
 
@@ -272,7 +274,7 @@ class FixedUsersDispatcher(UsersDispatcher):
         # this dispatcher does not care about target_user_count
         assert target_user_count == -1
 
-        grizzly_user_classes = cast(Optional[List[Type[GrizzlyUser]]], user_classes)
+        grizzly_user_classes = cast(Optional[list[type[GrizzlyUser]]], user_classes)
 
         if grizzly_user_classes is not None and self._user_classes != sorted(grizzly_user_classes, key=attrgetter('__name__')):
             self._user_classes = sorted(grizzly_user_classes, key=attrgetter('__name__'))
@@ -280,11 +282,11 @@ class FixedUsersDispatcher(UsersDispatcher):
             # map original user classes (supplied when users dispatcher was created), with additional new ones (might be duplicates)
             self._users_to_sticky_tag = {
                 user_class.__name__: user_class.sticky_tag or '__orphan__'
-                for user_class in cast(List[Type[GrizzlyUser]], self._original_user_classes + grizzly_user_classes)
+                for user_class in cast(list[type[GrizzlyUser]], self._original_user_classes + grizzly_user_classes)
             }
 
             self._user_class_name_to_type = {
-                user_class.__name__: user_class for user_class in cast(List[Type[GrizzlyUser]], self._original_user_classes + grizzly_user_classes)
+                user_class.__name__: user_class for user_class in cast(list[type[GrizzlyUser]], self._original_user_classes + grizzly_user_classes)
             }
 
             # only merge target user count for classes that has been specified in user classes
@@ -564,7 +566,7 @@ class FixedUsersDispatcher(UsersDispatcher):
 
     def _grizzly_distribute_users(
         self, target_user_count: dict[str, int],
-    ) -> tuple[dict[str, dict[str, int]], Generator[str | None, None, None], LengthOptimizedList[tuple[WorkerNode, str]]]:
+    ) -> tuple[dict[str, dict[str, int]], Generator[str | None, None, None], LengthOptimizedlist[tuple[WorkerNode, str]]]:
         """Distribute users on available workers, and continue user cycle from there."""
         # used target as setup based on user class values, without changing the original value
 
@@ -580,7 +582,7 @@ class FixedUsersDispatcher(UsersDispatcher):
             for worker_node in self._worker_nodes
         }
 
-        active_users: LengthOptimizedList[tuple[WorkerNode, str]] = LengthOptimizedList()
+        active_users: LengthOptimizedlist[tuple[WorkerNode, str]] = LengthOptimizedlist()
 
         user_count_target = sum(target_user_count.values())
         current_user_count: dict[str, int] = {}
@@ -645,15 +647,15 @@ def on_local(context: Context) -> bool:
     return value
 
 
-def setup_locust_scenarios(grizzly: GrizzlyContext) -> Tuple[List[Type[GrizzlyUser]], Set[str]]:
-    user_classes: List[Type[GrizzlyUser]] = []
+def setup_locust_scenarios(grizzly: GrizzlyContext) -> tuple[list[type[GrizzlyUser]], set[str]]:
+    user_classes: list[type[GrizzlyUser]] = []
 
     scenarios = grizzly.scenarios()
 
     assert len(scenarios) > 0, 'no scenarios in feature'
 
-    external_dependencies: Set[str] = set()
-    distribution: Dict[str, int] = {}
+    external_dependencies: set[str] = set()
+    distribution: dict[str, int] = {}
 
     if grizzly.setup.dispatcher_class in [UsersDispatcher, None]:
         user_count = grizzly.setup.user_count or 0
@@ -783,7 +785,7 @@ def setup_environment_listeners(context: Context, *, testdata: Optional[Testdata
 
 def print_scenario_summary(grizzly: GrizzlyContext) -> None:
     def create_separator(max_length_iterations: int, max_length_status: int, max_length_description: int) -> str:
-        separator: List[str] = []
+        separator: list[str] = []
         separator.append('-' * 5)
         separator.append('-|-')
         separator.append('-' * max_length_iterations)
@@ -795,7 +797,7 @@ def print_scenario_summary(grizzly: GrizzlyContext) -> None:
 
         return ''.join(separator)
 
-    rows: List[str] = []
+    rows: list[str] = []
     max_length_description = len('description')
     max_length_iterations = len('iter')
     max_length_status = len('status')
@@ -852,7 +854,7 @@ def grizzly_test_abort(*_args: Any, **_kwargs: Any) -> None:
     if not abort_test:
         abort_test = True
 
-def shutdown_external_processes(processes: Dict[str, subprocess.Popen], greenlet: Optional[gevent.Greenlet]) -> None:
+def shutdown_external_processes(processes: dict[str, subprocess.Popen], greenlet: Optional[gevent.Greenlet]) -> None:
     if len(processes) < 1:
         return
 
@@ -916,7 +918,7 @@ def run(context: Context) -> int:  # noqa: C901, PLR0915, PLR0912
 
     watch_running_external_processes_greenlet: Optional[gevent.Greenlet] = None
 
-    external_processes: Dict[str, subprocess.Popen] = {}
+    external_processes: dict[str, subprocess.Popen] = {}
 
     user_classes, variable_dependencies = setup_locust_scenarios(grizzly)
     external_dependencies.update(variable_dependencies)
@@ -930,7 +932,7 @@ def run(context: Context) -> int:  # noqa: C901, PLR0915, PLR0912
             grizzly.setup.dispatcher_class = UsersDispatcher
 
         environment = Environment(
-            user_classes=cast(List[Type[User]], user_classes),
+            user_classes=cast(list[type[User]], user_classes),
             shape_class=None,
             events=events,
             stop_timeout=300,  # only wait at most?
@@ -987,7 +989,7 @@ def run(context: Context) -> int:  # noqa: C901, PLR0915, PLR0912
             if grizzly.state.verbose:
                 env['GRIZZLY_EXTRAS_LOGLEVEL'] = 'DEBUG'
 
-            parameters: Dict[str, Any] = {}
+            parameters: dict[str, Any] = {}
             if sys.platform == 'win32':
                 parameters.update({'creationflags': subprocess.CREATE_NEW_PROCESS_GROUP})
             else:
@@ -1008,7 +1010,7 @@ def run(context: Context) -> int:  # noqa: C901, PLR0915, PLR0912
                     **parameters,
                 )})
 
-            def start_watching_external_processes(processes: Dict[str, subprocess.Popen]) -> Callable[[], None]:
+            def start_watching_external_processes(processes: dict[str, subprocess.Popen]) -> Callable[[], None]:
                 logger.info('making sure external processes are alive every 10 seconds')
 
                 def watch_running_external_processes() -> None:
@@ -1054,8 +1056,8 @@ def run(context: Context) -> int:  # noqa: C901, PLR0915, PLR0912
             headless: bool
             num_users: int
             spawn_rate: float
-            tags: List[str]
-            exclude_tags: List[str]
+            tags: list[str]
+            exclude_tags: list[str]
             enable_rebalancing: bool
 
         environment.parsed_options = LocustOption(
@@ -1228,7 +1230,7 @@ def run(context: Context) -> int:  # noqa: C901, PLR0915, PLR0912
         shutdown_external_processes(external_processes, watch_running_external_processes_greenlet)
 
 
-def _grizzly_sort_stats(stats: lstats.RequestStats) -> List[Tuple[str, str, int]]:
+def _grizzly_sort_stats(stats: lstats.RequestStats) -> list[tuple[str, str, int]]:
     locust_keys: list[tuple[str, str | None]] = sorted(stats.entries.keys())
 
     previous_ident: str | None = None

--- a/grizzly/locust.py
+++ b/grizzly/locust.py
@@ -973,6 +973,7 @@ def run(context: Context) -> int:  # noqa: C901, PLR0915, PLR0912
 
         if environ.get('GRIZZLY_DRY_RUN', 'false').lower() == 'true':
             if isinstance(runner, MasterRunner):
+                logger.info('dry-run starting locust-%s via grizzly-%s', __locust_version__, __version__)
                 runner.send_message('grizzly_worker_quit', None)
 
             if not isinstance(runner, WorkerRunner):

--- a/grizzly/scenarios/__init__.py
+++ b/grizzly/scenarios/__init__.py
@@ -114,8 +114,11 @@ class GrizzlyScenario(SequentialTaskSet):
                 except Exception:
                     self.logger.exception('on_stop failed')
 
-        self.consumer.stop()
-        self.user.scenario_state = ScenarioState.STOPPED
+        try:
+            self.consumer.stop()
+            self.user.scenario_state = ScenarioState.STOPPED
+        except:
+            self.logger.exception('on_stop failed')
 
     def on_quitting(self, *_args: Any, **kwargs: Any) -> None:
         """When locust is quitting, with abort=True (signal received) we should force the

--- a/grizzly/scenarios/__init__.py
+++ b/grizzly/scenarios/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 from os import environ
-from typing import TYPE_CHECKING, Any, Dict, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 from locust.user.sequential_taskset import SequentialTaskSet
 
@@ -49,8 +49,8 @@ class GrizzlyScenario(SequentialTaskSet):
         cls.tasks.append(task_factory())
 
     @classmethod
-    def _escape_values(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        _values: Dict[str, Any] = {}
+    def _escape_values(cls, values: dict[str, Any]) -> dict[str, Any]:
+        _values: dict[str, Any] = {}
 
         for key, value in values.items():
             _value = value.replace('"', '\\"') if isinstance(value, str) else value
@@ -58,7 +58,7 @@ class GrizzlyScenario(SequentialTaskSet):
 
         return _values
 
-    def render(self, template: str, variables: Optional[Dict[str, Any]] = None, *, escape_values: bool = False) -> str:
+    def render(self, template: str, variables: Optional[dict[str, Any]] = None, *, escape_values: bool = False) -> str:
         if not has_template(template):
             return template
 

--- a/grizzly/scenarios/iterator.py
+++ b/grizzly/scenarios/iterator.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from contextlib import suppress
 from json import dumps as jsondumps
 from time import perf_counter
-from typing import TYPE_CHECKING, ClassVar, Dict, Optional
+from typing import TYPE_CHECKING, ClassVar, Optional
 
 from gevent import sleep as gsleep
 from gevent.exceptions import GreenletExit
@@ -36,7 +36,7 @@ class IteratorScenario(GrizzlyScenario):
     start: Optional[float]
     task_count: ClassVar[int] = 0
     stats: StatsEntry
-    behave_steps: ClassVar[Dict[int, str]]
+    behave_steps: ClassVar[dict[int, str]]
     pace_time: ClassVar[Optional[str]] = None  # class variable injected by `grizzly.utils.create_scenario_class_type`
 
     _prefetch: bool

--- a/grizzly/scenarios/iterator.py
+++ b/grizzly/scenarios/iterator.py
@@ -80,6 +80,7 @@ class IteratorScenario(GrizzlyScenario):
                     context=self.user._context,
                     exception=StopUser('on_start failed for {self.user.__class__.__name__}'),
                 )
+            self.on_stop()
             raise StopUser from e
 
         while True:
@@ -92,6 +93,7 @@ class IteratorScenario(GrizzlyScenario):
 
                 try:
                     if self.user._state == LOCUST_STATE_STOPPING:
+                        self.on_stop()
                         raise StopUser
 
                     try:
@@ -115,6 +117,7 @@ class IteratorScenario(GrizzlyScenario):
                     # tasks will wrap the grizzly.exceptions.StopScenario thrown when aborting to what ever
                     # the scenario has specified todo when failing, we must force it to stop scenario
                     if self.abort:
+                        self.on_stop()
                         raise StopUser from e
 
                     self.logger.info('restarting scenario at task %d of %d', self.current_task_index+1, self.task_count)
@@ -130,10 +133,6 @@ class IteratorScenario(GrizzlyScenario):
                     self.wait()
             except InterruptTaskSet as e:
                 if self.user._scenario_state != ScenarioState.STOPPING:
-                    try:
-                        self.on_stop()
-                    except:
-                        self.logger.exception('on_stop failed')
                     self.start = None
 
                     if e.reschedule:
@@ -159,11 +158,7 @@ class IteratorScenario(GrizzlyScenario):
                         exception = StopUser
 
                     self.iteration_stop(has_error=has_error)
-
-                    try:
-                        self.on_stop()
-                    except:
-                        self.logger.exception('on_stop failed')
+                    self.on_stop()
 
                     # to avoid spawning of a new user, we should wait until spawning is complete
                     # if we abort too soon, locust will see that there are too few users, and spawn
@@ -189,6 +184,7 @@ class IteratorScenario(GrizzlyScenario):
                         self.logger.exception('unhandled exception: %s', e.__class__.__qualname__)
                     self.wait()
                 else:
+                    self.on_stop()
                     raise
 
     def iteration_stop(self, *, has_error: bool = False) -> None:

--- a/grizzly/steps/_helpers.py
+++ b/grizzly/steps/_helpers.py
@@ -5,7 +5,7 @@ import logging
 import re
 from errno import ENAMETOOLONG
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Type, cast
+from typing import TYPE_CHECKING, Optional, cast
 from urllib.parse import urlparse
 
 import jinja2 as j2
@@ -33,7 +33,7 @@ def create_request_task(
     source: Optional[str],
     endpoint: str,
     name: Optional[str] = None,
-    substitutes: Optional[Dict[str, str]] = None,
+    substitutes: Optional[dict[str, str]] = None,
     content_type: Optional[TransformerContentType] = None,
 ) -> RequestTask:
     return _create_request_task(context.config.base_dir, method, source, endpoint, name, substitutes=substitutes, content_type=content_type)
@@ -45,7 +45,7 @@ def _create_request_task(
     source: Optional[str],
     endpoint: str,
     name: Optional[str] = None,
-    substitutes: Optional[Dict[str, str]] = None,
+    substitutes: Optional[dict[str, str]] = None,
     content_type: Optional[TransformerContentType] = None,
 ) -> RequestTask:
     path = Path(base_dir) / 'requests'
@@ -108,14 +108,14 @@ def add_request_task(
     endpoint: Optional[str] = None,
     *,
     in_scenario: Optional[bool] = True,
-) -> List[Tuple[RequestTask, Dict[str, str]]]:
+) -> list[tuple[RequestTask, dict[str, str]]]:
     grizzly = cast(GrizzlyContext, context.grizzly)
 
     scenario_tasks_count = len(grizzly.scenario.tasks())
 
-    request_tasks: List[Tuple[RequestTask, Dict[str, str]]] = []
+    request_tasks: list[tuple[RequestTask, dict[str, str]]] = []
 
-    table: List[Optional[Row]]
+    table: list[Optional[Row]]
     content_type: Optional[TransformerContentType] = None
 
     if endpoint is not None and ('$env::' in endpoint or '$conf::' in endpoint):
@@ -142,7 +142,7 @@ def add_request_task(
         orig_name = name
         orig_source = source
 
-        substitutes: Dict[str, str] = {}
+        substitutes: dict[str, str] = {}
 
         if row is not None:
             for key, value in row.as_dict().items():
@@ -256,7 +256,7 @@ def normalize_step_name(step_name: str) -> str:
     return re.sub(r'"[^"]*"', '""', step_name)
 
 
-def get_task_client(grizzly: GrizzlyContext, endpoint: str) -> Type[ClientTask]:
+def get_task_client(grizzly: GrizzlyContext, endpoint: str) -> type[ClientTask]:
     scheme = urlparse(endpoint).scheme
 
     if not (scheme is not None and len(scheme) > 0):

--- a/grizzly/steps/scenario/tasks/write_file.py
+++ b/grizzly/steps/scenario/tasks/write_file.py
@@ -28,9 +28,34 @@ def step_task_write_file(context: Context, content: str, file_name: str) -> None
     ```
 
     Args:
-        content (str): what to write in the file
+        content (str): what to write in the file, can be base64 encoded
         file_name (str): file name, which can include non-existing directory levels (will be created)
 
     """
     grizzly = cast(GrizzlyContext, context.grizzly)
     grizzly.scenario.tasks.add(WriteFileTask(file_name=file_name, content=content))
+
+
+@then('write "{content}" in temporary file "{file_name}"')
+def step_task_write_temp_file(context: Context, content: str, file_name: str) -> None:
+    """Create an instance of the {@pylink grizzly.tasks.write_file} task, which will remove the file when test is stopped.
+
+    Writes specified content, as-is, in the specified file (no line break added), the file will be removed when the test stops.
+    The file will be created in the first iteration, and then be a no-op task for any following iterations.
+
+    Both content and file name support templating, and content can be base64 encoded.
+
+    See {@pylink grizzly.tasks.write_file} task documentation for more information about the task.
+
+    Example:
+    ```gherkin
+    Then write "$env::BASE64_ENCODED_BINARY_FILE" in temporary file "certificate.bin"
+    ```
+
+    Args:
+        content (str): what to write in the file, can be base64 encoded
+        file_name (str): file name, which can include non-existing directory levels (will be created)
+
+    """
+    grizzly = cast(GrizzlyContext, context.grizzly)
+    grizzly.scenario.tasks.add(WriteFileTask(file_name=file_name, content=content, temp_file=True))

--- a/grizzly/tasks/__init__.py
+++ b/grizzly/tasks/__init__.py
@@ -54,7 +54,7 @@ from abc import ABC, ABCMeta, abstractmethod
 from inspect import getmro
 from os import environ
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, List, Optional, Set, Type, Union, cast, overload
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Optional, Union, cast, overload
 
 from grizzly.context import GrizzlyContext
 from grizzly.utils import has_template
@@ -136,7 +136,7 @@ class grizzlytask:
 
 
 class GrizzlyTask(ABC):
-    __template_attributes__: ClassVar[Set[str]] = set()
+    __template_attributes__: ClassVar[set[str]] = set()
 
     _context_root: str
 
@@ -162,8 +162,8 @@ class GrizzlyTask(ABC):
 
         return value
 
-    def _get_value_templates(self, value: Any) -> Set[str]:
-        templates: Set[str] = set()
+    def _get_value_templates(self, value: Any) -> set[str]:
+        templates: set[str] = set()
 
         if isinstance(value, str):
             value = self._get_template_value_str(value)
@@ -187,8 +187,8 @@ class GrizzlyTask(ABC):
 
         return templates
 
-    def get_templates(self) -> List[str]:
-        templates: Set[str] = set()
+    def get_templates(self) -> list[str]:
+        templates: set[str] = set()
         for attribute in self.__template_attributes__:
             value = getattr(self, attribute, None)
             if value is None:
@@ -224,20 +224,20 @@ class GrizzlyTaskWrapper(GrizzlyTask, metaclass=ABCMeta):
         raise NotImplementedError(message)  # pragma: no cover
 
     @abstractmethod
-    def peek(self) -> List[GrizzlyTask]:
+    def peek(self) -> list[GrizzlyTask]:
         message = f'{self.__class__.__name__} has not implemented peek'
         raise NotImplementedError(message)  # pragma: no cover
 
 
 class template:
-    attributes: List[str]
+    attributes: list[str]
 
     def __init__(self, attribute: str, *additional_attributes: str) -> None:
         self.attributes = [attribute]
         if len(additional_attributes) > 0:
             self.attributes += list(additional_attributes)
 
-    def __call__(self, cls: Type[GrizzlyTask]) -> Type[GrizzlyTask]:
+    def __call__(self, cls: type[GrizzlyTask]) -> type[GrizzlyTask]:
         # this class should have it's own instance of this set, not shared with all
         # other tasks that inherits GrizzlyTask
         if len(cls.__template_attributes__) < 1:

--- a/grizzly/tasks/async_group.py
+++ b/grizzly/tasks/async_group.py
@@ -29,7 +29,7 @@ import inspect
 import logging
 from os import environ
 from time import perf_counter as time_perf_counter
-from typing import TYPE_CHECKING, Any, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Optional
 
 import gevent
 
@@ -44,7 +44,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 @template('name', 'tasks')
 class AsyncRequestGroupTask(GrizzlyTaskWrapper):
-    tasks: List[GrizzlyTask]
+    tasks: list[GrizzlyTask]
 
     def __init__(self, name: str) -> None:
         super().__init__()
@@ -61,7 +61,7 @@ class AsyncRequestGroupTask(GrizzlyTaskWrapper):
         task.async_request = True
         self.tasks.append(task)
 
-    def peek(self) -> List[GrizzlyTask]:
+    def peek(self) -> list[GrizzlyTask]:
         return self.tasks
 
     def __call__(self) -> grizzlytask:  # noqa: C901
@@ -74,7 +74,7 @@ class AsyncRequestGroupTask(GrizzlyTaskWrapper):
             exception: Optional[Exception] = None
             response_length = 0
 
-            def trace_green(event: str, args: Tuple[gevent.Greenlet, gevent.Greenlet]) -> None:  # pragma: no cover
+            def trace_green(event: str, args: tuple[gevent.Greenlet, gevent.Greenlet]) -> None:  # pragma: no cover
                 src, target = args
 
                 if src is gevent.hub.get_hub():
@@ -95,7 +95,7 @@ class AsyncRequestGroupTask(GrizzlyTaskWrapper):
 
                     parent.user.logger.debug(''.join(buff))
 
-            greenlets: List[gevent.Greenlet] = []
+            greenlets: list[gevent.Greenlet] = []
             start = time_perf_counter()
 
             try:

--- a/grizzly/tasks/clients/__init__.py
+++ b/grizzly/tasks/clients/__init__.py
@@ -26,7 +26,7 @@ from json import dumps as jsondumps
 from os import environ
 from pathlib import Path
 from time import perf_counter as time
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Generator, List, Optional, Type, cast, final
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, cast, final
 from urllib.parse import unquote, urlparse
 
 from grizzly.tasks import GrizzlyMetaRequestTask, grizzlytask, template
@@ -38,6 +38,8 @@ from grizzly_extras.text import has_separator
 from grizzly_extras.transformer import TransformerContentType
 
 if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Generator
+
     from grizzly.context import GrizzlyContext, GrizzlyContextScenario
     from grizzly.scenarios import GrizzlyScenario
 
@@ -47,14 +49,14 @@ if TYPE_CHECKING:  # pragma: no cover
 class ClientTask(GrizzlyMetaRequestTask):
     __scenario__: ClassVar[GrizzlyContextScenario]
     _scenario: GrizzlyContextScenario
-    _schemes: List[str]
+    _schemes: list[str]
     _scheme: str
     _short_name: str
-    _direction_arrow: ClassVar[Dict[RequestDirection, str]] = {
+    _direction_arrow: ClassVar[dict[RequestDirection, str]] = {
         RequestDirection.FROM: '<-',
         RequestDirection.TO: '->',
     }
-    _context: ClassVar[Dict[str, Any]] = {}
+    _context: ClassVar[dict[str, Any]] = {}
 
     host: str
     grizzly: GrizzlyContext
@@ -233,11 +235,11 @@ class ClientTask(GrizzlyMetaRequestTask):
         raise NotImplementedError(message)
 
     @contextmanager
-    def action(self, parent: GrizzlyScenario, action: Optional[str] = None, *, suppress: bool = False) -> Generator[Dict[str, Any], None, None]:
+    def action(self, parent: GrizzlyScenario, action: Optional[str] = None, *, suppress: bool = False) -> Generator[dict[str, Any], None, None]:
         exception: Optional[Exception] = None
         response_length = 0
         start_time = time()
-        meta: Dict[str, Any] = {}
+        meta: dict[str, Any] = {}
 
         try:
             # get metadata back from actual implementation
@@ -276,7 +278,7 @@ class ClientTask(GrizzlyMetaRequestTask):
 
                 meta.get('request', {}).update({'time': response_time})
 
-                request_log: Dict[str, Any] = {
+                request_log: dict[str, Any] = {
                     'stacktrace': None,
                     'response': meta.get('response'),
                     'request': meta.get('request'),
@@ -299,8 +301,8 @@ class ClientTask(GrizzlyMetaRequestTask):
 
 
 class client:
-    available: ClassVar[Dict[str, Type[ClientTask]]] = {}
-    schemes: List[str]
+    available: ClassVar[dict[str, type[ClientTask]]] = {}
+    schemes: list[str]
 
     def __init__(self, scheme: str, *additional_schemes: str) -> None:
         schemes = [scheme]
@@ -308,7 +310,7 @@ class client:
             schemes += list(additional_schemes)
         self.schemes = schemes
 
-    def __call__(self, impl: Type[ClientTask]) -> Type[ClientTask]:
+    def __call__(self, impl: type[ClientTask]) -> type[ClientTask]:
         available = {scheme: impl for scheme in self.schemes}
         impl._schemes = self.schemes
         client.available.update(available)

--- a/grizzly/tasks/clients/blobstorage.py
+++ b/grizzly/tasks/clients/blobstorage.py
@@ -63,7 +63,7 @@ from __future__ import annotations
 import logging
 from mimetypes import guess_type as mimetype_guess
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional, cast
+from typing import TYPE_CHECKING, Optional, cast
 from urllib.parse import parse_qs, quote, urlparse
 
 from azure.storage.blob import BlobServiceClient, ContentSettings
@@ -126,7 +126,7 @@ class BlobStorageClientTask(ClientTask):
 
         # See urllib/parse.py:771-774, explicit + characters are replaced with white space,
         # AccountKey could contain explicit + characters, so we must quote them first.
-        parsed_query: List[str] = []
+        parsed_query: list[str] = []
         if len(parsed.query) > 0:
             for parameter in parsed.query.split('&'):
                 key, value = parameter.split('=', 1)

--- a/grizzly/tasks/clients/http.py
+++ b/grizzly/tasks/clients/http.py
@@ -48,12 +48,13 @@ from json import dumps as jsondumps
 from time import time
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
-import requests
+from geventhttpclient import Session
 from locust.exception import CatchResponseError
 
 from grizzly.auth import AAD, GrizzlyHttpAuthClient, refresh_token
 from grizzly.types import GrizzlyResponse, RequestDirection, bool_type
 from grizzly.utils import merge_dicts
+from grizzly.utils.protocols import http_populate_cookiejar
 from grizzly_extras.arguments import parse_arguments, split_value
 from grizzly_extras.text import has_separator
 
@@ -148,9 +149,14 @@ class HttpClientTask(ClientTask, GrizzlyHttpAuthClient):
                 'payload': None,
             }})
 
-            response = requests.get(url, headers=self.metadata, cookies=self.cookies, timeout=60, **self.arguments)
 
-            payload = response.text
+            with Session() as client:
+                http_populate_cookiejar(client, self.cookies, url=url)
+                response = client.get(url, headers=self.metadata, **self.arguments)
+
+            text = response.text
+            payload = text.decode() if isinstance(text, (bytearray, bytes)) else text
+
             metadata = dict(response.headers)
 
             exception: Optional[Exception] = None
@@ -166,9 +172,8 @@ class HttpClientTask(ClientTask, GrizzlyHttpAuthClient):
                 if self.metadata_variable is not None:
                     parent.user._context['variables'][self.metadata_variable] = jsondumps(metadata)
 
-            meta['response_length'] = len(payload.encode())
-
             meta.update({
+                'response_length': len(payload.encode()),
                 'response': {
                     'url': response.url,
                     'metadata': metadata,

--- a/grizzly/tasks/clients/http.py
+++ b/grizzly/tasks/clients/http.py
@@ -46,7 +46,7 @@ from __future__ import annotations
 import logging
 from json import dumps as jsondumps
 from time import time
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from geventhttpclient import Session
 from locust.exception import CatchResponseError
@@ -66,8 +66,8 @@ if TYPE_CHECKING:  # pragma: no cover
 
 @client('http', 'https')
 class HttpClientTask(ClientTask, GrizzlyHttpAuthClient):
-    arguments: Dict[str, Any]
-    metadata: Dict[str, Any]
+    arguments: dict[str, Any]
+    metadata: dict[str, Any]
     session_started: Optional[float]
     host: str
 

--- a/grizzly/tasks/clients/messagequeue.py
+++ b/grizzly/tasks/clients/messagequeue.py
@@ -84,7 +84,7 @@ from zmq.error import ZMQError
 
 from grizzly.testdata.utils import resolve_variable
 from grizzly.types import GrizzlyResponse, RequestDirection, RequestType
-from grizzly.utils import zmq_disconnect
+from grizzly.utils.protocols import zmq_disconnect
 from grizzly_extras.async_message import AsyncMessageContext, AsyncMessageRequest, AsyncMessageResponse
 from grizzly_extras.async_message.utils import async_message_request
 

--- a/grizzly/tasks/clients/messagequeue.py
+++ b/grizzly/tasks/clients/messagequeue.py
@@ -76,7 +76,7 @@ from contextlib import contextmanager
 from json import dumps as jsondumps
 from pathlib import Path
 from platform import node as hostname
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Generator, List, Optional, Set, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, cast
 from urllib.parse import parse_qs, unquote, urlparse
 
 import zmq.green as zmq
@@ -96,16 +96,18 @@ except:
     from grizzly_extras import dummy_pymqi as pymqi
 
 if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Generator
+
     from grizzly.scenarios import GrizzlyScenario
 
 
 @client('mq', 'mqs')
 class MessageQueueClientTask(ClientTask):
-    __dependencies__: ClassVar[Set[str]] = {'async-messaged'}
+    __dependencies__: ClassVar[set[str]] = {'async-messaged'}
 
     _zmq_url = 'tcp://127.0.0.1:5554'
     _zmq_context: zmq.Context
-    _worker: Dict[int, str]
+    _worker: dict[int, str]
 
     endpoint_path: str
     context: AsyncMessageContext
@@ -254,7 +256,7 @@ class MessageQueueClientTask(ClientTask):
             if client is not None:
                 zmq_disconnect(client, destroy_context=False)
 
-    def connect(self, client_id: int, client: zmq.Socket, meta: Dict[str, Any]) -> None:
+    def connect(self, client_id: int, client: zmq.Socket, meta: dict[str, Any]) -> None:
         request: AsyncMessageRequest = {
             'action': RequestType.CONNECT(),
             'client': client_id,
@@ -319,7 +321,7 @@ class MessageQueueClientTask(ClientTask):
                 return response
 
     def get(self, parent: GrizzlyScenario) -> GrizzlyResponse:
-        endpoint: List[str] = [self.endpoint_path]
+        endpoint: list[str] = [self.endpoint_path]
         if self.max_message_size is not None:
             endpoint.append(f'max_message_size:{self.max_message_size}')
 

--- a/grizzly/tasks/clients/servicebus.py
+++ b/grizzly/tasks/clients/servicebus.py
@@ -98,7 +98,7 @@ from json import dumps as jsondumps
 from pathlib import Path
 from platform import node as hostname
 from textwrap import dedent
-from typing import TYPE_CHECKING, ClassVar, Dict, Optional, Set, cast
+from typing import TYPE_CHECKING, ClassVar, Optional, cast
 from urllib.parse import parse_qs, quote_plus, unquote_plus, urlparse
 
 import zmq.green as zmq
@@ -144,12 +144,12 @@ class State:
 @template('context')
 @client('sb')
 class ServiceBusClientTask(ClientTask):
-    __dependencies__: ClassVar[Set[str]] = {'async-messaged'}
+    __dependencies__: ClassVar[set[str]] = {'async-messaged'}
 
     _zmq_url = 'tcp://127.0.0.1:5554'
     _zmq_context: zmq.Context
 
-    _state: Dict[GrizzlyScenario, State]
+    _state: dict[GrizzlyScenario, State]
     context: AsyncMessageContext
 
     def __init__(  # noqa: PLR0915

--- a/grizzly/tasks/clients/servicebus.py
+++ b/grizzly/tasks/clients/servicebus.py
@@ -105,7 +105,7 @@ import zmq.green as zmq
 
 from grizzly.tasks import template
 from grizzly.types import GrizzlyResponse, RequestDirection, RequestType
-from grizzly.utils import async_message_request_wrapper, zmq_disconnect
+from grizzly.utils.protocols import async_message_request_wrapper, zmq_disconnect
 from grizzly_extras.arguments import parse_arguments
 from grizzly_extras.transformer import TransformerContentType
 

--- a/grizzly/tasks/conditional.py
+++ b/grizzly/tasks/conditional.py
@@ -33,7 +33,7 @@ the set for `condition` will have its own entry in the statistics, see respectiv
 from __future__ import annotations
 
 from time import perf_counter
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from gevent import sleep as gsleep
 
@@ -47,7 +47,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 @template('condition', 'tasks', 'name')
 class ConditionalTask(GrizzlyTaskWrapper):
-    tasks: Dict[bool, List[GrizzlyTask]]
+    tasks: dict[bool, list[GrizzlyTask]]
 
     name: str
     condition: str
@@ -82,7 +82,7 @@ class ConditionalTask(GrizzlyTaskWrapper):
 
             self.tasks[self._pointer].append(task)
 
-    def peek(self) -> List[GrizzlyTask]:
+    def peek(self) -> list[GrizzlyTask]:
         """Return all wrapped tasks, for current pointer."""
         if self._pointer is not None:
             return self.tasks[self._pointer]
@@ -90,7 +90,7 @@ class ConditionalTask(GrizzlyTaskWrapper):
         return []
 
     def __call__(self) -> grizzlytask:
-        tasks: Dict[bool, List[grizzlytask]] = {}
+        tasks: dict[bool, list[grizzlytask]] = {}
 
         for pointer, pointer_tasks in self.tasks.items():
             tasks.update({pointer: [t() for t in pointer_tasks]})

--- a/grizzly/tasks/date.py
+++ b/grizzly/tasks/date.py
@@ -39,7 +39,7 @@ In addition to this it is also possible to append milliseconds with `:ms` and re
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Dict, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 from dateutil.parser import ParserError
 from dateutil.parser import parse as dateparser
@@ -60,7 +60,7 @@ if TYPE_CHECKING:  # pragma: no cover
 class DateTask(GrizzlyTask):
     variable: str
     value: str
-    arguments: Dict[str, Optional[str]]
+    arguments: dict[str, Optional[str]]
 
     def __init__(self, variable: str, value: str) -> None:
         super().__init__()
@@ -86,7 +86,7 @@ class DateTask(GrizzlyTask):
         def task(parent: GrizzlyScenario) -> Any:
             value_rendered = parent.render(self.value, {'datetime': datetime})
 
-            arguments_rendered: Dict[str, str] = {}
+            arguments_rendered: dict[str, str] = {}
 
             for argument_name, argument_value in self.arguments.items():
                 if argument_value is None:

--- a/grizzly/tasks/loop.py
+++ b/grizzly/tasks/loop.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 from json import loads as jsonloads
 from time import perf_counter
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from gevent import sleep as gsleep
 
@@ -39,7 +39,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 @template('values', 'tasks')
 class LoopTask(GrizzlyTaskWrapper):
-    tasks: List[GrizzlyTask]
+    tasks: list[GrizzlyTask]
 
     name: str
     values: str
@@ -62,7 +62,7 @@ class LoopTask(GrizzlyTaskWrapper):
             task.name = f'{self.name}:{task_name}'
         self.tasks.append(task)
 
-    def peek(self) -> List[GrizzlyTask]:
+    def peek(self) -> list[GrizzlyTask]:
         return self.tasks
 
     def __call__(self) -> grizzlytask:

--- a/grizzly/tasks/request.py
+++ b/grizzly/tasks/request.py
@@ -57,7 +57,7 @@ And set response content type to "application/json"
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from grizzly_extras.arguments import parse_arguments, split_value, unquote
 from grizzly_extras.text import has_separator
@@ -75,8 +75,8 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 class RequestTaskHandlers:
-    metadata: List[ResponseHandlerAction]
-    payload: List[ResponseHandlerAction]
+    metadata: list[ResponseHandlerAction]
+    payload: list[ResponseHandlerAction]
 
     def __init__(self) -> None:
         self.metadata = []
@@ -90,7 +90,7 @@ class RequestTaskHandlers:
 
 
 class RequestTaskResponse:
-    status_codes: List[int]
+    status_codes: list[int]
     content_type: TransformerContentType
     handlers: RequestTaskHandlers
 
@@ -117,8 +117,8 @@ class RequestTask(GrizzlyMetaRequestTask):
     endpoint: str
     _template: Optional[Template]
     _source: Optional[str]
-    arguments: Optional[Dict[str, str]]
-    metadata: Dict[str, str]
+    arguments: Optional[dict[str, str]]
+    metadata: dict[str, str]
     async_request: bool
 
     response: RequestTaskResponse

--- a/grizzly/tasks/set_variable.py
+++ b/grizzly/tasks/set_variable.py
@@ -17,7 +17,8 @@ This task does not have any request statistics entries.
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, MutableMapping, Optional, Type, cast
+from collections.abc import MutableMapping
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 from grizzly.testdata import GrizzlyVariables
 from grizzly.testdata.utils import create_context_variable, read_file
@@ -38,7 +39,7 @@ class SetVariableTask(GrizzlyTask):
     variable_type: VariableType
 
     _variable_instance: Optional[MutableMapping[str, Any]] = None
-    _variable_instance_type: Optional[Type[AtomicVariable]] = None
+    _variable_instance_type: Optional[type[AtomicVariable]] = None
     _variable_key: str
 
     def __init__(self, variable: str, value: str, variable_type: VariableType) -> None:

--- a/grizzly/tasks/transformer.py
+++ b/grizzly/tasks/transformer.py
@@ -29,7 +29,7 @@ then have the request type `TRNSF`.
 from __future__ import annotations
 
 from time import perf_counter
-from typing import TYPE_CHECKING, Any, Callable, List, Type
+from typing import TYPE_CHECKING, Any, Callable
 
 from grizzly_extras.transformer import Transformer, TransformerContentType, TransformerError, transformer
 
@@ -46,8 +46,8 @@ class TransformerTask(GrizzlyTask):
     content: str
     content_type: TransformerContentType
 
-    _transformer: Type[Transformer]
-    _parser: Callable[[Any], List[str]]
+    _transformer: type[Transformer]
+    _parser: Callable[[Any], list[str]]
 
     def __init__(
         self,

--- a/grizzly/tasks/until.py
+++ b/grizzly/tasks/until.py
@@ -43,7 +43,7 @@ from __future__ import annotations
 import json
 import logging
 from time import perf_counter
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Type, cast
+from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
 from gevent import sleep as gsleep
 
@@ -69,8 +69,8 @@ class UntilRequestTask(GrizzlyTask):
     request: GrizzlyMetaRequestTask
     condition: str
 
-    transform: Optional[Type[Transformer]]
-    matcher: Callable[[Any], List[str]]
+    transform: Optional[type[Transformer]]
+    matcher: Callable[[Any], list[str]]
 
     retries: int
     wait: float
@@ -177,7 +177,7 @@ class UntilRequestTask(GrizzlyTask):
                 # remove any errors produced during until loop
                 error_count_after = len(parent.user.environment.stats.errors.keys())
                 if error_count_after > error_count_before:
-                    error_keys: List[str] = []
+                    error_keys: list[str] = []
                     for error_key, error in parent.user.environment.stats.errors.items():
                         if error.name == f'{parent.user._scenario.identifier} {self.request.name}':
                             error_keys.append(error_key)

--- a/grizzly/tasks/write_file.py
+++ b/grizzly/tasks/write_file.py
@@ -13,8 +13,13 @@ If the specified file already exist, new content will be appended to the existin
 """
 from __future__ import annotations
 
+from base64 import b64decode
+from contextlib import suppress
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
+
+from grizzly.testdata.utils import resolve_parameters
+from grizzly.utils import has_parameter
 
 from . import GrizzlyTask, grizzlytask, template
 
@@ -26,12 +31,23 @@ if TYPE_CHECKING:  # pragma: no cover
 class WriteFileTask(GrizzlyTask):
     content: str
     file_name: str
+    file: Optional[Path] = None
+    temp_file: bool
 
-    def __init__(self, file_name: str, content: str) -> None:
+    def __init__(self, file_name: str, content: str, *, temp_file: bool = False) -> None:
         super().__init__()
 
         self.file_name = file_name
         self.content = content
+        self.temp_file = temp_file
+
+        # check if content is stored in parameters
+        if has_parameter(self.content):
+            self.content = resolve_parameters(self.grizzly, self.content)
+
+        # always base64 decode, since it could be base64 encoded
+        with suppress(Exception):
+            self.content = b64decode(self.content).decode()
 
     def __call__(self) -> grizzlytask:
         @grizzlytask
@@ -39,15 +55,26 @@ class WriteFileTask(GrizzlyTask):
             file_name = parent.render(self.file_name)
             file = Path(self._context_root) / 'requests' / file_name
 
+
+            # file has already been created
+            if self.temp_file and self.file is not None and file.exists():
+                return
+
+            self.file = file
+
             response_length = 0
 
             try:
                 content = parent.render(self.content)
 
-                file.parent.mkdir(parents=True, exist_ok=True)
+                self.file.parent.mkdir(parents=True, exist_ok=True)
 
-                with file.open('a+') as fd:
-                    response_length = fd.write(f'{content}\n')
+                mode = 'a+' if not self.temp_file else 'w+'
+
+                line_break = '\n' if mode == 'a+' else ''
+
+                with self.file.open(mode) as fd:
+                    response_length = fd.write(f'{content}{line_break}')
             except Exception as exception:
                 parent.user.environment.events.request.fire(
                     request_type='FWRT',
@@ -57,5 +84,10 @@ class WriteFileTask(GrizzlyTask):
                     context=parent.user._context,
                     exception=exception,
                 )
+
+        @task.on_stop
+        def on_stop(parent: GrizzlyScenario) -> None:  # noqa: ARG001
+            if self.file is not None and self.temp_file:
+                self.file.unlink(missing_ok=True)
 
         return task

--- a/grizzly/testdata/__init__.py
+++ b/grizzly/testdata/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from importlib import import_module
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple, Type, cast
+from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
 from grizzly.types import GrizzlyVariableType
 
@@ -20,26 +20,26 @@ __all__ = [
 
 class GrizzlyVariables(dict):
     @classmethod
-    def load_variable(cls, module_name: str, class_name: str) -> Type[AtomicVariable]:
+    def load_variable(cls, module_name: str, class_name: str) -> type[AtomicVariable]:
         if module_name not in globals():
             module = import_module(module_name)
             globals()[class_name] = getattr(module, class_name)
 
         variable = globals()[class_name]
-        return cast(Type['AtomicVariable'], variable)
+        return cast(type['AtomicVariable'], variable)
 
     @classmethod
-    def get_variable_spec(cls, name: str) -> Tuple[Optional[str], Optional[str], str, Optional[str]]:
+    def get_variable_spec(cls, name: str) -> tuple[Optional[str], Optional[str], str, Optional[str]]:
         dot_count = name.count('.')
 
         if dot_count == 0 or 'Atomic' not in name:
             return None, None, name, None
 
-        namespace: List[str] = []
+        namespace: list[str] = []
         module_name: Optional[str] = None
         variable_type: Optional[str] = None
         variable_name: Optional[str] = None
-        sub_variable_names: List[str] = []
+        sub_variable_names: list[str] = []
 
         for part in name.split('.'):
             if part.startswith('Atomic'):
@@ -71,9 +71,9 @@ class GrizzlyVariables(dict):
         return name
 
     @classmethod
-    def initialize_variable(cls, grizzly: GrizzlyContext, name: str) -> Tuple[Any, Set[str], Dict[str, MessageHandler]]:
-        external_dependencies: Set[str] = set()
-        message_handler: Dict[str, MessageHandler] = {}
+    def initialize_variable(cls, grizzly: GrizzlyContext, name: str) -> tuple[Any, set[str], dict[str, MessageHandler]]:
+        external_dependencies: set[str] = set()
+        message_handler: dict[str, MessageHandler] = {}
 
         default_value = grizzly.state.variables.get(name, None)
         if default_value is None:

--- a/grizzly/testdata/ast.py
+++ b/grizzly/testdata/ast.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import itertools
 import logging
-from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Set
+from typing import TYPE_CHECKING, Any, Optional
 
 from jinja2 import Environment as Jinja2Environment
 from jinja2 import nodes as j2
@@ -11,12 +11,14 @@ from jinja2 import nodes as j2
 from . import GrizzlyVariables
 
 if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Generator
+
     from grizzly.context import GrizzlyContext, GrizzlyContextScenario
 
 logger = logging.getLogger(__name__)
 
 
-class AstVariableNameSet(Set[str]):
+class AstVariableNameSet(set[str]):
     def add(self, variable: str) -> None:
         if '.' in variable:
             variable = GrizzlyVariables.get_initialization_value(variable)
@@ -26,11 +28,11 @@ class AstVariableNameSet(Set[str]):
             super().add(variable)
 
 
-class AstVariableSet(Dict[str, Set[str]]):
+class AstVariableSet(dict[str, set[str]]):
     __conditional__: AstVariableNameSet
-    __map__: Dict[str, str]
-    __init_map__: Dict[str, Set[str]]
-    __local__: Set[str]
+    __map__: dict[str, str]
+    __init_map__: dict[str, set[str]]
+    __local__: set[str]
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -170,11 +172,11 @@ def get_template_variables(grizzly: GrizzlyContext) -> dict[str, set[str]]:
     return filtered_template_variables
 
 
-def walk_attr(node: j2.Getattr) -> List[str]:
+def walk_attr(node: j2.Getattr) -> list[str]:
     """Recursivley walk an AST node to get a complete variable name."""
 
-    def _walk_attr(parent: j2.Getattr) -> List[str]:
-        attributes: List[str] = []
+    def _walk_attr(parent: j2.Getattr) -> list[str]:
+        attributes: list[str] = []
         attr = getattr(parent, 'attr', None)
         if attr is not None:
             attributes.append(attr)
@@ -196,11 +198,11 @@ def walk_attr(node: j2.Getattr) -> List[str]:
     return attributes
 
 
-def _parse_templates(templates: Dict[GrizzlyContextScenario, Set[str]], *, env: Jinja2Environment) -> AstVariableSet:  # noqa: C901, PLR0915
+def _parse_templates(templates: dict[GrizzlyContextScenario, set[str]], *, env: Jinja2Environment) -> AstVariableSet:  # noqa: C901, PLR0915
     variables = AstVariableSet()
 
-    def _getattr(node: j2.Node) -> Generator[List[str], None, None]:  # noqa: C901, PLR0912, PLR0915
-        attributes: Optional[List[str]] = None
+    def _getattr(node: j2.Node) -> Generator[list[str], None, None]:  # noqa: C901, PLR0912, PLR0915
+        attributes: Optional[list[str]] = None
 
         if isinstance(node, j2.Getattr):
             child_node = getattr(node, 'node', None)
@@ -319,7 +321,7 @@ def _parse_templates(templates: Dict[GrizzlyContextScenario, Set[str]], *, env: 
         if attributes is not None:
             yield attributes
 
-    def _build_variable(attributes: List[str]) -> Optional[str]:
+    def _build_variable(attributes: list[str]) -> Optional[str]:
         if len(attributes) == 0:
             return None
 

--- a/grizzly/testdata/communication.py
+++ b/grizzly/testdata/communication.py
@@ -16,7 +16,7 @@ from zmq.error import Again as ZMQAgain
 from zmq.error import ZMQError
 
 from grizzly.types.locust import Environment, StopUser
-from grizzly.utils import zmq_disconnect
+from grizzly.utils.protocols import zmq_disconnect
 
 from . import GrizzlyVariables
 from .utils import transform

--- a/grizzly/testdata/communication.py
+++ b/grizzly/testdata/communication.py
@@ -7,7 +7,7 @@ from itertools import chain
 from json import dumps as jsondumps
 from os import environ
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 import zmq.green as zmq
 from gevent import sleep as gsleep
@@ -62,7 +62,7 @@ class TestdataConsumer:
         finally:
             self.stopped = True
 
-    def testdata(self, scenario: str) -> Optional[Dict[str, Any]]:
+    def testdata(self, scenario: str) -> Optional[dict[str, Any]]:
         request = {
             'message': 'testdata',
             'identifier': self.identifier,
@@ -87,7 +87,7 @@ class TestdataConsumer:
 
         self.logger.debug('received: %r', data)
 
-        variables: Optional[Dict[str, Any]] = None
+        variables: Optional[dict[str, Any]] = None
         if 'variables' in data:
             variables = transform(self.scenario.grizzly, data['variables'], objectify=True, scenario=self.scenario.user._scenario)
             del data['variables']
@@ -97,7 +97,7 @@ class TestdataConsumer:
         if variables is not None:
             data['variables'] = variables
 
-        return cast(Dict[str, Any], data)
+        return cast(dict[str, Any], data)
 
     def keystore_get(self, key: str) -> Optional[Any]:
         request = {
@@ -134,7 +134,7 @@ class TestdataConsumer:
 
         return value
 
-    def _keystore_request(self, request: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    def _keystore_request(self, request: dict[str, Any]) -> Optional[dict[str, Any]]:
         request.update({
             'message': 'keystore',
             'identifier': self.identifier,
@@ -142,16 +142,16 @@ class TestdataConsumer:
 
         return self._request(request)
 
-    def _request(self, request: Dict[str, str]) -> Optional[Dict[str, Any]]:
+    def _request(self, request: dict[str, str]) -> Optional[dict[str, Any]]:
         self.socket.send_json(request)
 
         self.logger.debug('waiting for response from producer')
-        message: Dict[str, Any]
+        message: dict[str, Any]
 
         # loop and NOBLOCK needed when running in local mode, to let other gevent threads get time
         while True:
             try:
-                message = cast(Dict[str, Any], self.socket.recv_json(flags=zmq.NOBLOCK))
+                message = cast(dict[str, Any], self.socket.recv_json(flags=zmq.NOBLOCK))
                 break
             except ZMQAgain:
                 gsleep(0.1)  # let other greenlets execute
@@ -169,11 +169,11 @@ class TestdataProducer:
     logger: logging.Logger
     semaphore = Semaphore()
     grizzly: GrizzlyContext
-    scenarios_iteration: Dict[str, int]
+    scenarios_iteration: dict[str, int]
     testdata: TestdataType
     environment: Environment
     has_persisted: bool
-    keystore: Dict[str, Any]
+    keystore: dict[str, Any]
 
     def __init__(self, grizzly: GrizzlyContext, testdata: TestdataType, address: str = 'tcp://127.0.0.1:5555') -> None:
         self.grizzly = grizzly
@@ -217,7 +217,7 @@ class TestdataProducer:
             return
 
         try:
-            variable_state: Dict[str, Union[str, Dict[str, Any]]] = {}
+            variable_state: dict[str, Union[str, dict[str, Any]]] = {}
 
             for testdata in self.testdata.values():
                 for key, variable in testdata.items():
@@ -253,7 +253,7 @@ class TestdataProducer:
             gsleep(0.1)
             self.persist_data()
 
-    def _handle_request_keystore(self, request: Dict[str, Any]) -> Dict[str, Any]:
+    def _handle_request_keystore(self, request: dict[str, Any]) -> dict[str, Any]:
         response = request
         if request['action'] == 'get':
             response['data'] = self.keystore.get(request['key'], None)
@@ -292,9 +292,9 @@ class TestdataProducer:
 
         return response
 
-    def _handle_request_testdata(self, request: Dict[str, Any]) -> Dict[str, Any]:  # noqa: PLR0912
+    def _handle_request_testdata(self, request: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0912
         consumer_identifier = request.get('identifier', '')
-        response: Dict[str, Any] = {
+        response: dict[str, Any] = {
             'action': 'stop',
         }
 
@@ -314,8 +314,8 @@ class TestdataProducer:
 
                 testdata = self.testdata.get(scenario_name, {})
                 response['action'] = 'consume'
-                data: Dict[str, Any] = {'variables': {}}
-                loaded_variable_datatypes: Dict[str, Any] = {}
+                data: dict[str, Any] = {'variables': {}}
+                loaded_variable_datatypes: dict[str, Any] = {}
 
                 for key, variable in testdata.items():
                     if '.' in key and variable != '__on_consumer__':
@@ -372,10 +372,10 @@ class TestdataProducer:
         try:
             while True:
                 try:
-                    recv = cast(Dict[str, Any], self.socket.recv_json(flags=zmq.NOBLOCK))
+                    recv = cast(dict[str, Any], self.socket.recv_json(flags=zmq.NOBLOCK))
                     consumer_identifier = recv.get('identifier', '')
                     self.logger.debug('got request from consumer %s', consumer_identifier)
-                    response: Dict[str, Any]
+                    response: dict[str, Any]
 
                     with self.semaphore:
                         if recv['message'] == 'keystore':

--- a/grizzly/testdata/utils.py
+++ b/grizzly/testdata/utils.py
@@ -7,7 +7,7 @@ from collections import namedtuple
 from os import environ
 from pathlib import Path
 from time import perf_counter as time
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple, cast
+from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
 from jinja2.filters import FILTERS
 from jinja2.meta import find_undeclared_variables
@@ -28,16 +28,16 @@ logger = logging.getLogger(__name__)
 MAGIC_4 = 4
 
 
-def initialize_testdata(grizzly: GrizzlyContext) -> Tuple[TestdataType, Set[str], Dict[str, MessageHandler]]:
+def initialize_testdata(grizzly: GrizzlyContext) -> tuple[TestdataType, set[str], dict[str, MessageHandler]]:
     """Create a structure of testdata per scenario."""
     testdata: TestdataType = {}
     template_variables = get_template_variables(grizzly)
 
     logger.debug('testdata: %r', template_variables)
 
-    initialized_datatypes: Dict[str, Any] = {}
-    external_dependencies: Set[str] = set()
-    message_handlers: Dict[str, MessageHandler] = {}
+    initialized_datatypes: dict[str, Any] = {}
+    external_dependencies: set[str] = set()
+    message_handlers: dict[str, MessageHandler] = {}
 
     for scenario, variables in template_variables.items():
         testdata[scenario] = {}
@@ -61,9 +61,9 @@ def initialize_testdata(grizzly: GrizzlyContext) -> Tuple[TestdataType, Set[str]
     return testdata, external_dependencies, message_handlers
 
 
-def transform(grizzly: GrizzlyContext, data: Dict[str, Any], scenario: Optional[GrizzlyContextScenario] = None, *, objectify: Optional[bool] = True) -> Dict[str, Any]:
+def transform(grizzly: GrizzlyContext, data: dict[str, Any], scenario: Optional[GrizzlyContextScenario] = None, *, objectify: Optional[bool] = True) -> dict[str, Any]:
     """Transform a dictionary with static values to something that can have values which are object."""
-    testdata: Dict[str, Any] = {}
+    testdata: dict[str, Any] = {}
 
     for key, value in data.items():
         module_name, variable_type, variable_name, _ = GrizzlyVariables.get_variable_spec(key)
@@ -99,7 +99,7 @@ def transform(grizzly: GrizzlyContext, data: Dict[str, Any], scenario: Optional[
                     elif scenario.failure_exception is not None:  # noqa: RET506
                         raise scenario.failure_exception
 
-            paths: List[str] = key.split('.')
+            paths: list[str] = key.split('.')
             variable = paths.pop(0)
             struct = unflatten('.'.join(paths), value)
 
@@ -116,7 +116,7 @@ def transform(grizzly: GrizzlyContext, data: Dict[str, Any], scenario: Optional[
     return testdata
 
 
-def _objectify(testdata: Dict[str, Any]) -> Dict[str, Any]:
+def _objectify(testdata: dict[str, Any]) -> dict[str, Any]:
     for variable, attributes in testdata.items():
         if not isinstance(attributes, dict):
             continue
@@ -127,7 +127,7 @@ def _objectify(testdata: Dict[str, Any]) -> Dict[str, Any]:
     return testdata
 
 
-def create_context_variable(grizzly: GrizzlyContext, variable: str, value: str, *, scenario: Optional[GrizzlyContextScenario] = None) -> Dict[str, Any]:
+def create_context_variable(grizzly: GrizzlyContext, variable: str, value: str, *, scenario: Optional[GrizzlyContextScenario] = None) -> dict[str, Any]:
     """Create a variable as a context variable. Handles other separators than `.`."""
     if has_template(value):
         grizzly.scenario.orphan_templates.append(value)

--- a/grizzly/testdata/variables/__init__.py
+++ b/grizzly/testdata/variables/__init__.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, Generic, Optional, Set, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Generic, Optional, TypeVar
 
 from gevent.lock import DummySemaphore, Semaphore
 
@@ -31,7 +31,7 @@ class AbstractAtomicClass:
 
 
 class AtomicVariablePersist(metaclass=ABCMeta):
-    arguments: ClassVar[Dict[str, Any]] = {'persist': bool_type}
+    arguments: ClassVar[dict[str, Any]] = {'persist': bool_type}
 
     @abstractmethod
     def generate_initial_value(self, variable: str) -> str:
@@ -48,17 +48,17 @@ class AtomicVariableSettable(metaclass=ABCMeta):
 
 class AtomicVariable(Generic[T], AbstractAtomicClass):
     __base_type__: Optional[Callable] = None
-    __dependencies__: ClassVar[Set[str]] = set()
-    __message_handlers__: ClassVar[Dict[str, MessageHandler]] = {}
+    __dependencies__: ClassVar[set[str]] = set()
+    __message_handlers__: ClassVar[dict[str, MessageHandler]] = {}
     __on_consumer__ = False
 
     __instance: ClassVar[Optional[AtomicVariable]] = None
 
     _initialized: bool
-    _values: Dict[str, Optional[T]]
+    _values: dict[str, Optional[T]]
     _semaphore: Semaphore = Semaphore()
 
-    arguments: ClassVar[Dict[str, Any]] = {}
+    arguments: ClassVar[dict[str, Any]] = {}
     grizzly: GrizzlyContext
 
     def __new__(cls, *_args: Any, **_kwargs: Any) -> AtomicVariable[T]:

--- a/grizzly/testdata/variables/csv_reader.py
+++ b/grizzly/testdata/variables/csv_reader.py
@@ -59,7 +59,7 @@ from csv import DictReader
 from os import environ
 from pathlib import Path
 from secrets import randbelow
-from typing import Any, ClassVar, Dict, List, Optional, Type, cast
+from typing import Any, ClassVar, Optional, cast
 
 from grizzly.types import bool_type
 from grizzly_extras.arguments import parse_arguments, split_value
@@ -105,14 +105,14 @@ def atomiccsvreader__base_type__(value: str) -> str:
     return value
 
 
-class AtomicCsvReader(AtomicVariable[Dict[str, Any]]):
+class AtomicCsvReader(AtomicVariable[dict[str, Any]]):
     __base_type__ = atomiccsvreader__base_type__
     __initialized: bool = False
 
-    _rows: Dict[str, List[Dict[str, Any]]]
-    _settings: Dict[str, Dict[str, Any]]
+    _rows: dict[str, list[dict[str, Any]]]
+    _settings: dict[str, dict[str, Any]]
     context_root: Path
-    arguments: ClassVar[Dict[str, Any]] = {'repeat': bool_type, 'random': bool_type}
+    arguments: ClassVar[dict[str, Any]] = {'repeat': bool_type, 'random': bool_type}
 
     def __init__(self, variable: str, value: str, *, outer_lock: bool = False) -> None:
         with self.semaphore(outer=outer_lock):
@@ -150,15 +150,15 @@ class AtomicCsvReader(AtomicVariable[Dict[str, Any]]):
             self._settings = {variable: settings}
             self.__initialized = True
 
-    def _create_row_queue(self, value: str) -> List[Dict[str, Any]]:
+    def _create_row_queue(self, value: str) -> list[dict[str, Any]]:
         input_file = self.context_root / value
 
         with input_file.open() as fd:
             reader = DictReader(fd)
-            return [cast(Dict[str, Any], row) for row in reader]
+            return [cast(dict[str, Any], row) for row in reader]
 
     @classmethod
-    def clear(cls: Type[AtomicCsvReader]) -> None:
+    def clear(cls: type[AtomicCsvReader]) -> None:
         super().clear()
 
         instance = cast(AtomicCsvReader, cls.get())
@@ -168,7 +168,7 @@ class AtomicCsvReader(AtomicVariable[Dict[str, Any]]):
             del instance._rows[variable]
             del instance._settings[variable]
 
-    def __getitem__(self, variable: str) -> Optional[Dict[str, Any]]:
+    def __getitem__(self, variable: str) -> Optional[dict[str, Any]]:
         with self.semaphore():
             column: Optional[str] = None
 

--- a/grizzly/testdata/variables/csv_writer.py
+++ b/grizzly/testdata/variables/csv_writer.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 from csv import DictWriter
 from os import environ
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Type, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, cast
 
 from grizzly.types import bool_type, list_type
 from grizzly.types.locust import Environment, MasterRunner, Message
@@ -106,10 +106,10 @@ def atomiccsvwriter_message_handler(environment: Environment, msg: Message, **_k
 class AtomicCsvWriter(AtomicVariable[str], AtomicVariableSettable):
     __base_type__ = atomiccsvwriter__base_type__
     __initialized: bool = False
-    __message_handlers__: ClassVar[Dict[str, MessageHandler]] = {'atomiccsvwriter': atomiccsvwriter_message_handler}
+    __message_handlers__: ClassVar[dict[str, MessageHandler]] = {'atomiccsvwriter': atomiccsvwriter_message_handler}
 
-    _settings: Dict[str, Dict[str, Any]]
-    arguments: ClassVar[Dict[str, Any]] = {'headers': list_type, 'overwrite': bool_type}
+    _settings: dict[str, dict[str, Any]]
+    arguments: ClassVar[dict[str, Any]] = {'headers': list_type, 'overwrite': bool_type}
 
     def __init__(self, variable: str, value: str, *, outer_lock: bool = False) -> None:
         with self.semaphore(outer=outer_lock):
@@ -140,7 +140,7 @@ class AtomicCsvWriter(AtomicVariable[str], AtomicVariableSettable):
             self.__initialized = True
 
     @classmethod
-    def clear(cls: Type[AtomicCsvWriter]) -> None:
+    def clear(cls: type[AtomicCsvWriter]) -> None:
         super().clear()
 
         instance = cast(AtomicCsvWriter, cls.get())

--- a/grizzly/testdata/variables/date.py
+++ b/grizzly/testdata/variables/date.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 from contextlib import suppress
 from datetime import datetime
-from typing import Any, ClassVar, Dict, Optional, Set, Type, Union, cast
+from typing import Any, ClassVar, Optional, Union, cast
 
 from dateutil.parser import ParserError
 from dateutil.parser import parse as dateparse
@@ -98,10 +98,10 @@ def atomicdate__base_type__(value: str) -> str:  # noqa: PLR0912
 class AtomicDate(AtomicVariable[Union[str, datetime]]):
     __base_type__ = atomicdate__base_type__
     __initialized: bool = False
-    _settings: Dict[str, Dict[str, Any]]
-    arguments: ClassVar[Dict[str, Any]] = {'format': str, 'timezone': str, 'offset': int}
+    _settings: dict[str, dict[str, Any]]
+    arguments: ClassVar[dict[str, Any]] = {'format': str, 'timezone': str, 'offset': int}
 
-    _special_variables: ClassVar[Set[str]] = {'now'}
+    _special_variables: ClassVar[set[str]] = {'now'}
 
     def __init__(
         self,
@@ -114,7 +114,7 @@ class AtomicDate(AtomicVariable[Union[str, datetime]]):
             initial_value: str
             timezone: Optional[ZoneInfo] = None
             date_format = '%Y-%m-%d %H:%M:%S'
-            offset: Optional[Dict[str, int]] = None
+            offset: Optional[dict[str, int]] = None
 
             safe_value = self.__class__.__base_type__(value)
 
@@ -154,7 +154,7 @@ class AtomicDate(AtomicVariable[Union[str, datetime]]):
             self.__initialized = True
 
     @classmethod
-    def clear(cls: Type[AtomicDate]) -> None:
+    def clear(cls: type[AtomicDate]) -> None:
         super().clear()
 
         instance = cast(AtomicDate, cls.get())

--- a/grizzly/testdata/variables/directory_contents.py
+++ b/grizzly/testdata/variables/directory_contents.py
@@ -38,7 +38,7 @@ from contextlib import suppress
 from os import environ
 from pathlib import Path
 from secrets import randbelow
-from typing import Any, ClassVar, Dict, List, Optional, Type, cast
+from typing import Any, ClassVar, Optional, cast
 
 from grizzly.types import bool_type
 from grizzly_extras.arguments import parse_arguments, split_value
@@ -83,10 +83,10 @@ class AtomicDirectoryContents(AtomicVariable[str]):
     __base_type__ = atomicdirectorycontents__base_type__
     __initialized: bool = False
 
-    _files: Dict[str, List[str]]
-    _settings: Dict[str, Dict[str, Any]]
+    _files: dict[str, list[str]]
+    _settings: dict[str, dict[str, Any]]
     _requests_context_root: Path
-    arguments: ClassVar[Dict[str, Any]] = {'repeat': bool_type, 'random': bool_type}
+    arguments: ClassVar[dict[str, Any]] = {'repeat': bool_type, 'random': bool_type}
 
     def __init__(
         self,
@@ -128,7 +128,7 @@ class AtomicDirectoryContents(AtomicVariable[str]):
             self.__initialized = True
 
     @classmethod
-    def clear(cls: Type[AtomicDirectoryContents]) -> None:
+    def clear(cls: type[AtomicDirectoryContents]) -> None:
         super().clear()
 
         instance = cast(AtomicDirectoryContents, cls.get())
@@ -138,7 +138,7 @@ class AtomicDirectoryContents(AtomicVariable[str]):
             del instance._files[variable]
             del instance._settings[variable]
 
-    def _create_file_queue(self, directory: str) -> List[str]:
+    def _create_file_queue(self, directory: str) -> list[str]:
         parent_part = len(str(self._requests_context_root)) + 1
         queue = [
             str(path)[parent_part:]

--- a/grizzly/testdata/variables/integer_incrementer.py
+++ b/grizzly/testdata/variables/integer_incrementer.py
@@ -76,7 +76,7 @@ value `35 | step=5, persist=True` will be read from the file and override what i
 from __future__ import annotations
 
 from contextlib import suppress
-from typing import Any, ClassVar, Dict, Optional, Type, Union, cast
+from typing import Any, ClassVar, Optional, Union, cast
 
 from grizzly.types import bool_type
 from grizzly_extras.arguments import parse_arguments, split_value
@@ -130,8 +130,8 @@ class AtomicIntegerIncrementer(AtomicVariable[int], AtomicVariablePersist):
     __base_type__ = atomicintegerincrementer__base_type__
 
     __initialized: bool = False
-    _steps: Dict[str, Any]
-    arguments: ClassVar[Dict[str, Any]] = {'step': int, 'persist': bool_type}
+    _steps: dict[str, Any]
+    arguments: ClassVar[dict[str, Any]] = {'step': int, 'persist': bool_type}
 
     def __init__(self, variable: str, value: Union[str, int], *, outer_lock: bool = False) -> None:
         with self.semaphore(outer=outer_lock):
@@ -173,7 +173,7 @@ class AtomicIntegerIncrementer(AtomicVariable[int], AtomicVariablePersist):
         return f'{value} | {arguments}'
 
     @classmethod
-    def clear(cls: Type[AtomicIntegerIncrementer]) -> None:
+    def clear(cls: type[AtomicIntegerIncrementer]) -> None:
         super().clear()
 
         instance = cast(AtomicIntegerIncrementer, cls.get())

--- a/grizzly/testdata/variables/random_integer.py
+++ b/grizzly/testdata/variables/random_integer.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 from contextlib import suppress
 from secrets import choice
-from typing import Dict, Type, cast
+from typing import cast
 
 from . import AtomicVariable
 
@@ -60,7 +60,7 @@ def atomicrandominteger__base_type__(value: str) -> str:
 class AtomicRandomInteger(AtomicVariable[int]):
     __base_type__ = atomicrandominteger__base_type__
     __initialized: bool = False
-    _max: Dict[str, int]
+    _max: dict[str, int]
 
     def __init__(self, variable: str, value: str, *, outer_lock: bool = False) -> None:
         with self.semaphore(outer=outer_lock):
@@ -79,7 +79,7 @@ class AtomicRandomInteger(AtomicVariable[int]):
             self.__initialized = True
 
     @classmethod
-    def clear(cls: Type[AtomicRandomInteger]) -> None:
+    def clear(cls: type[AtomicRandomInteger]) -> None:
         super().clear()
 
         instance = cast(AtomicRandomInteger, cls.get())

--- a/grizzly/testdata/variables/random_string.py
+++ b/grizzly/testdata/variables/random_string.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 from contextlib import suppress
 from secrets import choice, randbelow
 from string import ascii_letters
-from typing import Any, Callable, ClassVar, Dict, List, Optional, Set, Type, cast
+from typing import Any, Callable, ClassVar, Optional, cast
 from uuid import uuid4
 
 from grizzly.types import bool_type, int_rounded_float_type
@@ -92,13 +92,13 @@ class AtomicRandomString(AtomicVariable[str]):
     __base_type__ = atomicrandomstring__base_type__
     __initialized: bool = False
 
-    _strings: Dict[str, List[str]]
-    arguments: ClassVar[Dict[str, Any]] = {'upper': bool_type, 'count': int_rounded_float_type}
+    _strings: dict[str, list[str]]
+    arguments: ClassVar[dict[str, Any]] = {'upper': bool_type, 'count': int_rounded_float_type}
 
     @staticmethod
-    def get_generators(format_string: str) -> List[Callable[[AtomicRandomString], str]]:
+    def get_generators(format_string: str) -> list[Callable[[AtomicRandomString], str]]:
         """Map format modifiers to generator functions."""
-        formats: List[Callable[[AtomicRandomString], str]] = []
+        formats: list[Callable[[AtomicRandomString], str]] = []
         # first item is either empty, or it's a static character
         for format_modifier in format_string.split('%')[1:]:
             generator_name = format_modifier[0]  # could be static characters in the pattern, only supports one character formatters
@@ -151,8 +151,8 @@ class AtomicRandomString(AtomicVariable[str]):
     def _generate_g(self) -> str:
         return str(uuid4())
 
-    def _generate_strings(self, string_pattern: str, settings: Dict[str, Any]) -> List[str]:
-        generated_strings: Set[str] = set()
+    def _generate_strings(self, string_pattern: str, settings: dict[str, Any]) -> list[str]:
+        generated_strings: set[str] = set()
         generators = self.__class__.get_generators(string_pattern)
 
         string_pattern = string_pattern.replace('%g', '%s')
@@ -172,7 +172,7 @@ class AtomicRandomString(AtomicVariable[str]):
         return list(generated_strings)
 
     @classmethod
-    def clear(cls: Type[AtomicRandomString]) -> None:
+    def clear(cls: type[AtomicRandomString]) -> None:
         super().clear()
 
         instance = cast(AtomicRandomString, cls.get())

--- a/grizzly/types/__init__.py
+++ b/grizzly/types/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from enum import Enum, auto
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union, cast
+from typing import Any, Callable, Optional, TypeVar, Union, cast
 
 from locust.rpc.protocol import Message
 from typing_extensions import Concatenate, ParamSpec
@@ -101,7 +101,7 @@ class RequestDirection(PermutationEnum):
             raise AssertionError(message) from e
 
     @property
-    def methods(self) -> List[RequestMethod]:
+    def methods(self) -> list[RequestMethod]:
         """All RequestMethods that has this request direction."""
         return [method for method in RequestMethod if method.direction == self]
 
@@ -230,11 +230,11 @@ class RequestType(Enum):
         raise AssertionError(message)
 
 
-GrizzlyResponse = Tuple[Optional[Dict[str, Any]], Optional[str]]
+GrizzlyResponse = tuple[Optional[dict[str, Any]], Optional[str]]
 
-TestdataType = Dict[str, Dict[str, Any]]
+TestdataType = dict[str, dict[str, Any]]
 
-HandlerContextType = Union[Dict[str, Any], Optional[Any]]
+HandlerContextType = Union[dict[str, Any], Optional[Any]]
 
 GrizzlyVariableType = Union[str, float, int, bool]
 
@@ -256,7 +256,7 @@ def bool_type(value: str) -> bool:
     raise ValueError(message)
 
 
-def list_type(value: str) -> List[str]:
+def list_type(value: str) -> list[str]:
     """Convert a string representation of a list to an actual list."""
     return [v.strip() for v in value.split(',')]
 

--- a/grizzly/types/behave.py
+++ b/grizzly/types/behave.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from functools import wraps
-from typing import Any, Callable, Dict, List, TypeVar, cast
+from typing import Any, Callable, TypeVar, cast
 
 import behave
 from behave.model import Feature, Row, Scenario, Status, Step, Table
@@ -31,7 +31,7 @@ def error_handler(func: StepFunctionType) -> StepFunctionType:
 
             exception = StepError(e, context.step).with_traceback(e.__traceback__) if isinstance(e, AssertionError) else e
 
-            cast(Dict[str, List[Exception]], context.exceptions).update({
+            cast(dict[str, list[Exception]], context.exceptions).update({
                 context.scenario.name: [*context.exceptions.get(context.scenario.name, []), exception],
             })
 

--- a/grizzly/users/__init__.py
+++ b/grizzly/users/__init__.py
@@ -22,7 +22,7 @@ from logging import Logger
 from os import environ
 from pathlib import Path
 from time import perf_counter
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Set, Type, TypeVar, cast, final
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, TypeVar, cast, final
 
 from locust.user.task import LOCUST_STATE_RUNNING
 from locust.user.users import User, UserMeta
@@ -53,12 +53,12 @@ class GrizzlyUserMeta(UserMeta):
 
 
 class grizzlycontext:
-    context: Dict[str, Any]
+    context: dict[str, Any]
 
-    def __init__(self, *, context: Dict[str, Any]) -> None:
+    def __init__(self, *, context: dict[str, Any]) -> None:
         self.context = context
 
-    def __call__(self, cls: Type[GrizzlyUser]) -> Type[GrizzlyUser]:
+    def __call__(self, cls: type[GrizzlyUser]) -> type[GrizzlyUser]:
         cls.__context__ = merge_dicts(cls.__context__, self.context)
 
         return cls
@@ -70,11 +70,11 @@ class grizzlycontext:
     'metadata': None,
 })
 class GrizzlyUser(User, metaclass=GrizzlyUserMeta):
-    __dependencies__: ClassVar[Set[str]] = set()
+    __dependencies__: ClassVar[set[str]] = set()
     __scenario__: GrizzlyContextScenario  # reference to grizzly scenario this user is part of
-    __context__: ClassVar[Dict[str, Any]] = {}
+    __context__: ClassVar[dict[str, Any]] = {}
 
-    _context: Dict[str, Any]
+    _context: dict[str, Any]
     _context_root: Path
     _scenario: GrizzlyContextScenario  # copy of scenario for this user instance
     _scenario_state: Optional[ScenarioState]
@@ -113,11 +113,11 @@ class GrizzlyUser(User, metaclass=GrizzlyUserMeta):
             self.abort = cast(bool, kwargs.get('abort', False))
 
     @property
-    def metadata(self) -> Dict[str, Any]:
+    def metadata(self) -> dict[str, Any]:
         return self._context.get('metadata', None) or {}
 
     @metadata.setter
-    def metadata(self, value: Dict[str, Any]) -> None:
+    def metadata(self, value: dict[str, Any]) -> None:
         if self._context.get('metadata', None) is None:
             self._context['metadata'] = {}
 
@@ -155,7 +155,7 @@ class GrizzlyUser(User, metaclass=GrizzlyUserMeta):
     @final
     def request(self, request: RequestTask) -> GrizzlyResponse:
         """Perform a request and handle all the common logic that should execute before and after a user request."""
-        metadata: Optional[Dict[str, Any]] = None
+        metadata: Optional[dict[str, Any]] = None
         payload: Optional[Any] = None
         exception: Optional[Exception] = None
         response_length = 0
@@ -266,10 +266,10 @@ class GrizzlyUser(User, metaclass=GrizzlyUserMeta):
         else:
             return request
 
-    def context(self) -> Dict[str, Any]:
+    def context(self) -> dict[str, Any]:
         return self._context
 
-    def add_context(self, context: Dict[str, Any]) -> None:
+    def add_context(self, context: dict[str, Any]) -> None:
         self._context = merge_dicts(self._context, context)
 
     def set_context_variable(self, variable: str, value: Any) -> None:
@@ -279,8 +279,8 @@ class GrizzlyUser(User, metaclass=GrizzlyUserMeta):
         self.logger.debug(message)
 
     @property
-    def context_variables(self) -> Dict[str, Any]:
-        return cast(Dict[str, Any], self._context.get('variables', {}))
+    def context_variables(self) -> dict[str, Any]:
+        return cast(dict[str, Any], self._context.get('variables', {}))
 
 
 from .blobstorage import BlobStorageUser

--- a/grizzly/users/iothub.py
+++ b/grizzly/users/iothub.py
@@ -42,7 +42,7 @@ Then send request "test/blob.file" to endpoint "uploaded_blob_filename"
 from __future__ import annotations
 
 import gzip
-from typing import TYPE_CHECKING, Any, Dict, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 from urllib.parse import parse_qs, urlparse
 
 from azure.iot.device import IoTHubDeviceClient
@@ -101,7 +101,7 @@ class IotHubUser(GrizzlyUser):
             message = f'{self.__class__.__name__} has not implemented {request.method.name}'
             raise NotImplementedError(message)
 
-        storage_info: Optional[Dict[str, Any]] = None
+        storage_info: Optional[dict[str, Any]] = None
         try:
             if not request.source:
                 message = f'Cannot upload empty payload to endpoint {request.endpoint} in IotHubUser'
@@ -109,7 +109,7 @@ class IotHubUser(GrizzlyUser):
 
             filename = request.endpoint
 
-            storage_info = cast(Dict[str, Any], self.iot_client.get_storage_info_for_blob(filename))
+            storage_info = cast(dict[str, Any], self.iot_client.get_storage_info_for_blob(filename))
 
             sas_url = 'https://{}/{}/{}{}'.format(
                 storage_info['hostName'],

--- a/grizzly/users/messagequeue.py
+++ b/grizzly/users/messagequeue.py
@@ -128,7 +128,7 @@ from __future__ import annotations
 import inspect
 import logging
 from contextlib import contextmanager, suppress
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Generator, Optional, Set, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, cast
 from urllib.parse import parse_qs, unquote, urlparse
 
 import zmq.green as zmq
@@ -144,6 +144,8 @@ from grizzly_extras.async_message.utils import async_message_request
 from . import GrizzlyUser, grizzlycontext
 
 if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Generator
+
     from grizzly.tasks import RequestTask
     from grizzly.types.locust import Environment
 
@@ -170,7 +172,7 @@ except:
     },
 })
 class MessageQueueUser(GrizzlyUser):
-    __dependencies__: ClassVar[Set[str]] = {'async-messaged'}
+    __dependencies__: ClassVar[set[str]] = {'async-messaged'}
 
     am_context: AsyncMessageContext
     worker_id: Optional[str]
@@ -305,11 +307,11 @@ class MessageQueueUser(GrizzlyUser):
         super().on_stop()
 
     @contextmanager
-    def _request_context(self, am_request: AsyncMessageRequest) -> Generator[Dict[str, Any], None, None]:
+    def _request_context(self, am_request: AsyncMessageRequest) -> Generator[dict[str, Any], None, None]:
         self.logger.debug('%s request context: %r', inspect.stack()[1][3], am_request)
 
         response: Optional[AsyncMessageResponse] = None
-        context: Dict[str, Any] = {
+        context: dict[str, Any] = {
             'metadata': None,
             'payload': None,
         }
@@ -324,7 +326,7 @@ class MessageQueueUser(GrizzlyUser):
 
     def request_impl(self, request: RequestTask) -> GrizzlyResponse:
         am_context = cast(AsyncMessageContext, merge_dicts(
-            cast(Dict[str, Any], self.am_context),
+            cast(dict[str, Any], self.am_context),
             {
                 'endpoint': request.endpoint,
                 'metadata': request.metadata,

--- a/grizzly/users/messagequeue.py
+++ b/grizzly/users/messagequeue.py
@@ -238,10 +238,21 @@ class MessageQueueUser(GrizzlyUser):
         if header_type == 'none':
             header_type = None
 
+        key_file = auth_context.get('key_file', None)
+
+        if key_file is not None:
+            key_file_path = self._context_root / f'{key_file}.kdb'
+
+            if not key_file_path.exists():
+                message = f'{self.__class__.__name__} key file {key_file} does not exist'
+                raise ValueError(message)
+
+            key_file = key_file_path.resolve().with_suffix('').as_posix()
+
         self.am_context.update({
             'username': username,
             'password': auth_context.get('password', None),
-            'key_file': auth_context.get('key_file', None),
+            'key_file': key_file,
             'cert_label': auth_context.get('cert_label', None) or username,
             'ssl_cipher': auth_context.get('ssl_cipher', None) or 'ECDHE_RSA_AES_256_GCM_SHA384',
             'message_wait': message_context.get('wait', None),

--- a/grizzly/users/messagequeue.py
+++ b/grizzly/users/messagequeue.py
@@ -135,7 +135,8 @@ import zmq.green as zmq
 
 from grizzly.exceptions import StopScenario
 from grizzly.types import GrizzlyResponse, RequestDirection, RequestType
-from grizzly.utils import merge_dicts, zmq_disconnect
+from grizzly.utils import merge_dicts
+from grizzly.utils.protocols import zmq_disconnect
 from grizzly_extras.arguments import get_unsupported_arguments, parse_arguments
 from grizzly_extras.async_message import AsyncMessageContext, AsyncMessageRequest, AsyncMessageResponse
 from grizzly_extras.async_message.utils import async_message_request

--- a/grizzly/users/messagequeue.py
+++ b/grizzly/users/messagequeue.py
@@ -135,7 +135,7 @@ import zmq.green as zmq
 
 from grizzly.exceptions import StopScenario
 from grizzly.types import GrizzlyResponse, RequestDirection, RequestType
-from grizzly.utils import merge_dicts
+from grizzly.utils import merge_dicts, zmq_disconnect
 from grizzly_extras.arguments import get_unsupported_arguments, parse_arguments
 from grizzly_extras.async_message import AsyncMessageContext, AsyncMessageRequest, AsyncMessageResponse
 from grizzly_extras.async_message.utils import async_message_request
@@ -266,6 +266,7 @@ class MessageQueueUser(GrizzlyUser):
                 'context': self.am_context,
             }):
                 self.zmq_client = self.zmq_context.socket(zmq.REQ)
+                self.zmq_client.setsockopt(zmq.LINGER, 0)
                 self.zmq_client.connect(self.zmq_url)
         except Exception as e:
             self.logger.exception('on_start failed')
@@ -285,7 +286,7 @@ class MessageQueueUser(GrizzlyUser):
             pass
 
         with suppress(Exception):
-            self.zmq_client.disconnect(self.zmq_url)
+            zmq_disconnect(self.zmq_client, destroy_context=False)
 
         self.worker_id = None
 

--- a/grizzly/users/restapi.py
+++ b/grizzly/users/restapi.py
@@ -84,7 +84,7 @@ from copy import copy
 from datetime import datetime, timezone
 from hashlib import sha256
 from html.parser import HTMLParser
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Tuple, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, cast
 
 import requests
 from locust.contrib.fasthttp import FastHttpSession
@@ -122,7 +122,7 @@ class HtmlTitleParser(HTMLParser):
     def should_look(self) -> bool:
         return self._look and self.title is None
 
-    def handle_starttag(self, tag: str, _attrs: List[Tuple[str, Optional[str]]]) -> None:
+    def handle_starttag(self, tag: str, _attrs: list[tuple[str, Optional[str]]]) -> None:
         self._look = tag == 'title' and self.title is None
 
     def handle_data(self, data: str) -> None:
@@ -242,7 +242,7 @@ class RestApiUser(GrizzlyUser, AsyncRequests, GrizzlyHttpAuthClient, metaclass=R
 
         request_headers.update({'Content-Type': request.response.content_type.value})
 
-        parameters: Dict[str, Any] = {}
+        parameters: dict[str, Any] = {}
 
         if len(request_headers) > 0:
             parameters.update({'headers': request_headers})
@@ -265,7 +265,7 @@ class RestApiUser(GrizzlyUser, AsyncRequests, GrizzlyHttpAuthClient, metaclass=R
                 parameters['data'] = request.source.encode('utf-8')
 
         # from response...
-        headers: Optional[Dict[str, str]] = None
+        headers: Optional[dict[str, str]] = None
         payload: Optional[str] = None
 
         http_populate_cookiejar(client, self.cookies, url=url)
@@ -303,7 +303,7 @@ class RestApiUser(GrizzlyUser, AsyncRequests, GrizzlyHttpAuthClient, metaclass=R
 
         return (headers, payload)
 
-    def add_context(self, context: Dict[str, Any]) -> None:
+    def add_context(self, context: dict[str, Any]) -> None:
         """If added context contains changes in `auth`, we should cache current `Authorization` token and force re-auth for a new, if the auth
         doesn't exist in the cache.
 

--- a/grizzly/users/servicebus.py
+++ b/grizzly/users/servicebus.py
@@ -87,7 +87,8 @@ import zmq.green as zmq
 from grizzly.tasks import RequestTask
 from grizzly.types import GrizzlyResponse, RequestDirection, RequestMethod, RequestType
 from grizzly.types.locust import Environment, StopUser
-from grizzly.utils import has_parameter, has_template, zmq_disconnect
+from grizzly.utils import has_parameter, has_template
+from grizzly.utils.protocols import zmq_disconnect
 from grizzly_extras.arguments import get_unsupported_arguments, parse_arguments
 from grizzly_extras.async_message import AsyncMessageContext, AsyncMessageRequest, AsyncMessageResponse
 from grizzly_extras.async_message.utils import async_message_request

--- a/grizzly/users/servicebus.py
+++ b/grizzly/users/servicebus.py
@@ -87,7 +87,7 @@ import zmq.green as zmq
 from grizzly.tasks import RequestTask
 from grizzly.types import GrizzlyResponse, RequestDirection, RequestMethod, RequestType
 from grizzly.types.locust import Environment, StopUser
-from grizzly.utils import has_parameter, has_template
+from grizzly.utils import has_parameter, has_template, zmq_disconnect
 from grizzly_extras.arguments import get_unsupported_arguments, parse_arguments
 from grizzly_extras.async_message import AsyncMessageContext, AsyncMessageRequest, AsyncMessageResponse
 from grizzly_extras.async_message.utils import async_message_request
@@ -188,6 +188,7 @@ class ServiceBusUser(GrizzlyUser):
         super().on_start()
 
         self.zmq_client = self.zmq_context.socket(zmq.REQ)
+        self.zmq_client.setsockopt(zmq.LINGER, 0)
         self.zmq_client.connect(self.zmq_url)
 
         for task in self._scenario.tasks:
@@ -204,7 +205,7 @@ class ServiceBusUser(GrizzlyUser):
 
                 self.disconnect(task)
 
-        self.zmq_client.disconnect(self.zmq_url)
+        zmq_disconnect(self.zmq_client, destroy_context=False)
 
         super().on_stop()
 

--- a/grizzly/users/servicebus.py
+++ b/grizzly/users/servicebus.py
@@ -79,7 +79,7 @@ from __future__ import annotations
 
 import logging
 from contextlib import contextmanager, suppress
-from typing import Any, ClassVar, Dict, Generator, Optional, Set, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, cast
 from urllib.parse import parse_qs, urlparse
 
 import zmq.green as zmq
@@ -94,6 +94,9 @@ from grizzly_extras.async_message import AsyncMessageContext, AsyncMessageReques
 from grizzly_extras.async_message.utils import async_message_request
 
 from . import GrizzlyUser, grizzlycontext
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 MAX_LENGTH = 65
 
@@ -111,14 +114,14 @@ MAX_LENGTH = 65
     },
 })
 class ServiceBusUser(GrizzlyUser):
-    __dependencies__: ClassVar[Set[str]] = {'async-messaged'}
+    __dependencies__: ClassVar[set[str]] = {'async-messaged'}
 
     am_context: AsyncMessageContext
     worker_id: Optional[str]
     zmq_context = zmq.Context()
     zmq_client: zmq.Socket
     zmq_url = 'tcp://127.0.0.1:5554'
-    hellos: Set[str]
+    hellos: set[str]
 
     def __init__(self, environment: Environment, *args: Any, **kwargs: Any) -> None:
         super().__init__(environment, *args, **kwargs)
@@ -308,7 +311,7 @@ class ServiceBusUser(GrizzlyUser):
         self.hellos.add(description)
 
     @contextmanager
-    def request_context(self, task: RequestTask, request: AsyncMessageRequest) -> Generator[Dict[str, Any], None, None]:
+    def request_context(self, task: RequestTask, request: AsyncMessageRequest) -> Generator[dict[str, Any], None, None]:
         name = task.name
 
         if len(name) > MAX_LENGTH:
@@ -321,7 +324,7 @@ class ServiceBusUser(GrizzlyUser):
 
         connection = 'sender' if task.method.direction == RequestDirection.TO else 'receiver'
         request['context'].update({'connection': connection})
-        context: Dict[str, Any] = {
+        context: dict[str, Any] = {
             'metadata': None,
             'payload': None,
         }

--- a/grizzly/utils.py
+++ b/grizzly/utils.py
@@ -394,6 +394,12 @@ def async_message_request_wrapper(parent: GrizzlyScenario, client: zmq.Socket, r
     return async_message_request(client, request)
 
 
+def zmq_disconnect(socket: zmq.Socket, *, destroy_context: bool) -> None:
+    socket.close(linger=0)
+    if destroy_context:
+        socket.context.destroy(linger=0)
+
+
 def safe_del(struct: Dict[str, Any], key: str) -> None:
     """Remove a key from a dictionary, but do not fail if it does not exist."""
     with suppress(KeyError):

--- a/grizzly/utils/protocols.py
+++ b/grizzly/utils/protocols.py
@@ -8,7 +8,7 @@ import re
 from datetime import datetime, timezone
 from http.cookiejar import Cookie
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Optional, Protocol, Tuple, cast
+from typing import TYPE_CHECKING, Optional, Protocol, cast
 from urllib.parse import urlparse
 
 from dateutil.parser import ParserError
@@ -31,7 +31,7 @@ class HttpCookieHolder(Protocol):
     cookiejar: CookieJar
 
 
-def http_populate_cookiejar(holder: HttpCookieHolder, cookies: Dict[str, str], *, url: str) -> None:
+def http_populate_cookiejar(holder: HttpCookieHolder, cookies: dict[str, str], *, url: str) -> None:
     parsed = urlparse(url)
     secure = parsed.scheme == 'https'
     domain = parsed.netloc
@@ -99,8 +99,8 @@ def mq_client_logs(context: Context) -> None:
 
     started = cast(datetime, context.started).astimezone(tz=timezone.utc)
 
-    amqerr_log_entries: List[Tuple[datetime, str]] = []
-    amqerr_fdc_files: List[Tuple[datetime, str]] = []
+    amqerr_log_entries: list[tuple[datetime, str]] = []
+    amqerr_fdc_files: list[tuple[datetime, str]] = []
 
     log_directory = Path('~/IBM/MQ/data/errors').expanduser()
 

--- a/grizzly/utils/protocols.py
+++ b/grizzly/utils/protocols.py
@@ -1,0 +1,151 @@
+"""Helper methods for protocols that are used by both users
+and tasks.
+"""
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from http.cookiejar import Cookie
+from pathlib import Path
+from typing import TYPE_CHECKING, Dict, List, Optional, Protocol, Tuple, cast
+from urllib.parse import urlparse
+
+from dateutil.parser import ParserError
+from dateutil.parser import parse as dateparser
+
+from grizzly.utils import _print_table
+from grizzly_extras.async_message.utils import async_message_request
+
+if TYPE_CHECKING:
+    from http.cookiejar import CookieJar
+
+    import zmq.green as zmq
+
+    from grizzly.scenarios import GrizzlyScenario
+    from grizzly.types.behave import Context
+    from grizzly_extras.async_message import AsyncMessageRequest, AsyncMessageResponse
+
+
+class HttpCookieHolder(Protocol):
+    cookiejar: CookieJar
+
+
+def http_populate_cookiejar(holder: HttpCookieHolder, cookies: Dict[str, str], *, url: str) -> None:
+    parsed = urlparse(url)
+    secure = parsed.scheme == 'https'
+    domain = parsed.netloc
+
+    holder.cookiejar.clear()
+
+    for name, value in cookies.items():
+        holder.cookiejar.set_cookie(Cookie(
+            version=0,
+            name=name,
+            value=value,
+            port=None,
+            port_specified=False,
+            domain=domain,
+            domain_specified=True,
+            domain_initial_dot=False,
+            path='/',
+            path_specified=True,
+            secure=secure,
+            expires=None,
+            discard=False,
+            comment=None,
+            comment_url=None,
+            rest={},
+        ))
+
+
+def async_message_request_wrapper(parent: GrizzlyScenario, client: zmq.Socket, request: AsyncMessageRequest) -> AsyncMessageResponse:
+    """Wrap `grizzly_extras.async_message.async_message_request` to make it easier to communicating with `async-messaged` from within `grizzly`."""
+    request_string: Optional[str] = None
+    request_rendered: Optional[str] = None
+
+    try:
+        request_string = json.dumps(request)
+        request_rendered = parent.render(request_string, escape_values=True)
+        request = json.loads(request_rendered)
+    except:
+        parent.user.logger.error('failed to render request:\ntemplate=%r\nrendered=%r', request, request_rendered)  # noqa: TRY400
+        raise
+
+    if request.get('client', None) is None:
+        request.update({'client': id(parent.user)})
+
+    return async_message_request(client, request)
+
+
+def zmq_disconnect(socket: zmq.Socket, *, destroy_context: bool) -> None:
+    socket.close(linger=0)
+    if destroy_context:
+        socket.context.destroy(linger=0)
+
+
+def mq_client_logs(context: Context) -> None:
+    """Check MQ logs (if available) for any errors that occured during a test, and present them in nice ASCII tables.
+
+    ```bash
+    $ pwd && ls -1
+    /home/vscode/IBM/MQ/data/errors
+    AMQ6150.0.FDC
+    AMQERR01.LOG
+    ```
+    """
+    if not hasattr(context, 'started'):
+        return
+
+    started = cast(datetime, context.started).astimezone(tz=timezone.utc)
+
+    amqerr_log_entries: List[Tuple[datetime, str]] = []
+    amqerr_fdc_files: List[Tuple[datetime, str]] = []
+
+    log_directory = Path('~/IBM/MQ/data/errors').expanduser()
+
+    # check errors files
+    if not log_directory.exists():
+        return
+
+    for amqerr_log_file in log_directory.glob('AMQERR*.LOG'):
+        with amqerr_log_file.open() as fd:
+            line: Optional[str] = None
+
+            for line in fd:
+                while line and not re.match(r'^\s+Time\(', line):
+                    try:
+                        line = next(fd)  # noqa: PLW2901
+                    except StopIteration:  # noqa: PERF203
+                        break
+
+                if not line:
+                    break
+
+                try:
+                    time_start = line.index('Time(') + 5
+                    time_end = line.index(')')
+                    time_str = line[time_start:time_end]
+                    time_date = dateparser(time_str)
+
+                    if time_date < started:
+                        continue
+                except (ParserError, ValueError):
+                    continue
+
+                while not line.startswith('AMQ'):
+                    line = next(fd)  # noqa: PLW2901
+
+                amqerr_log_entries.append((time_date, line.strip()))
+
+    for amqerr_fdc_file in log_directory.glob('AMQ*.FDC'):
+        modification_date = datetime.fromtimestamp(amqerr_fdc_file.stat().st_mtime).astimezone(tz=timezone.utc)
+
+        if modification_date < started:
+            continue
+
+        amqerr_fdc_files.append((modification_date, str(amqerr_fdc_file)))
+
+    # present entries created during run
+    _print_table('AMQ error log entries', 'Message', amqerr_log_entries)
+    _print_table('AMQ FDC files', 'File', amqerr_fdc_files)

--- a/grizzly_extras/arguments.py
+++ b/grizzly_extras/arguments.py
@@ -5,12 +5,12 @@ Logic to support grizzly arguments, which are passed in text strings.
 """
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, Tuple, cast
+from typing import Any, Optional, cast
 
 from .text import has_sequence
 
 
-def split_value(value: str, separator: str = '|') -> Tuple[str, str]:
+def split_value(value: str, separator: str = '|') -> tuple[str, str]:
     operators = ["=", "|"]
 
     try:
@@ -29,10 +29,10 @@ def split_value(value: str, separator: str = '|') -> Tuple[str, str]:
     except ValueError:
         values = value.split(separator, 1)
 
-    return cast(Tuple[str, str], tuple([v.strip() for v in values]))
+    return cast(tuple[str, str], tuple([v.strip() for v in values]))
 
 
-def get_unsupported_arguments(valid_arguments: List[str], arguments: Dict[str, Any]) -> List[str]:
+def get_unsupported_arguments(valid_arguments: list[str], arguments: dict[str, Any]) -> list[str]:
     return [argument for argument in arguments if argument not in valid_arguments]
 
 
@@ -43,12 +43,12 @@ def unquote(argument: str) -> str:
     return argument
 
 
-def parse_arguments(arguments: str, separator: str = '=', *, unquote: bool = True) -> Dict[str, Any]:  # noqa: C901, PLR0912, PLR0915
+def parse_arguments(arguments: str, separator: str = '=', *, unquote: bool = True) -> dict[str, Any]:  # noqa: C901, PLR0912, PLR0915
     if separator not in arguments or (arguments.count(separator) > 1 and (arguments.count('"') < 2 and arguments.count("'") < 2) and ', ' not in arguments):
         message = f'incorrect format in arguments: "{arguments}"'
         raise ValueError(message)
 
-    parsed: Dict[str, Any] = {}
+    parsed: dict[str, Any] = {}
     previous_part: Optional[str] = None
     argument_parts = arguments.split(',')
 

--- a/grizzly_extras/async_message/__init__.py
+++ b/grizzly_extras/async_message/__init__.py
@@ -10,11 +10,11 @@ from os import environ
 from pathlib import Path
 from platform import node as hostname
 from time import monotonic as time
-from typing import Any, Callable, Dict, List, Optional, TypedDict, final
+from typing import Any, Callable, Optional, TypedDict, final
 
 from grizzly_extras.transformer import JsonBytesEncoder
 
-__all__: List[str] = []
+__all__: list[str] = []
 
 def _get_log_dir() -> Path:
     grizzly_context_root = environ.get('GRIZZLY_CONTEXT_ROOT', None)
@@ -32,7 +32,7 @@ def _get_log_dir() -> Path:
     return log_dir_root
 
 def configure_logging() -> None:
-    handlers: List[logging.Handler] = [logging.StreamHandler(sys.stderr)]
+    handlers: list[logging.Handler] = [logging.StreamHandler(sys.stderr)]
 
     try:
         log_file = _get_log_dir() / f'async-messaged.{hostname()}.{datetime.now().strftime("%Y%m%dT%H%M%S%f")}.log'
@@ -56,7 +56,7 @@ def configure_logging() -> None:
 configure_logging()
 
 
-AsyncMessageMetadata = Optional[Dict[str, Any]]
+AsyncMessageMetadata = Optional[dict[str, Any]]
 AsyncMessagePayload = Optional[Any]
 
 
@@ -76,7 +76,7 @@ class AsyncMessageContext(TypedDict, total=False):
     content_type: Optional[str]
     heartbeat_interval: Optional[int]
     header_type: Optional[str]
-    metadata: Optional[Dict[str, str]]
+    metadata: Optional[dict[str, str]]
     consume: bool
 
 
@@ -177,7 +177,7 @@ LRU_READY = '\x01'
 SPLITTER_FRAME = b''
 
 
-def register(handlers: Dict[str, AsyncMessageRequestHandler], action: str, *actions: str) -> Callable[[InferredAsyncMessageRequestHandler], InferredAsyncMessageRequestHandler]:
+def register(handlers: dict[str, AsyncMessageRequestHandler], action: str, *actions: str) -> Callable[[InferredAsyncMessageRequestHandler], InferredAsyncMessageRequestHandler]:
     def decorator(func: InferredAsyncMessageRequestHandler) -> InferredAsyncMessageRequestHandler:
         for a in (action, *actions):
             if a in handlers:

--- a/grizzly_extras/async_message/daemon.py
+++ b/grizzly_extras/async_message/daemon.py
@@ -9,7 +9,7 @@ from json import loads as jsonloads
 from signal import SIGINT, SIGTERM, Signals, signal
 from threading import Thread
 from time import sleep
-from typing import TYPE_CHECKING, Dict, List, Optional, Union, cast
+from typing import TYPE_CHECKING, Optional, Union, cast
 from urllib.parse import urlparse
 from uuid import uuid4
 
@@ -70,7 +70,7 @@ def router() -> None:  # noqa: C901, PLR0912, PLR0915
     poller.register(frontend, zmq.POLLIN)
     poller.register(backend, zmq.POLLIN)
 
-    worker_threads: List[Thread] = []
+    worker_threads: list[Thread] = []
 
     def spawn_worker() -> None:
         identity = str(uuid4())
@@ -81,9 +81,9 @@ def router() -> None:  # noqa: C901, PLR0912, PLR0915
         thread.start()
         logger.info('spawned worker %s (%d)', identity, thread.ident)
 
-    workers_available: List[str] = []
+    workers_available: list[str] = []
 
-    client_worker_map: Dict[str, str] = {}
+    client_worker_map: dict[str, str] = {}
 
     spawn_worker()
 

--- a/grizzly_extras/async_message/daemon.py
+++ b/grizzly_extras/async_message/daemon.py
@@ -260,7 +260,7 @@ def worker(context: zmq.Context, identity: str) -> None:  # noqa: PLR0912, PLR09
         worker.close()
     except:  # pragma: no cover
         logger.exception('failed to close worker')
-    logger.debug('stopped')
+    logger.info('stopped')
 
 
 def main() -> int:

--- a/grizzly_extras/async_message/mq/__init__.py
+++ b/grizzly_extras/async_message/mq/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from contextlib import contextmanager, suppress
 from time import perf_counter as time
 from time import sleep
-from typing import Any, Dict, Generator, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 from grizzly_extras.arguments import get_unsupported_arguments, parse_arguments
 from grizzly_extras.async_message import AsyncMessageError, AsyncMessageHandler, AsyncMessageRequest, AsyncMessageRequestHandler, AsyncMessageResponse, register
@@ -18,13 +18,16 @@ except:
 
 from .rfh2 import Rfh2Decoder, Rfh2Encoder
 
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
 __all__ = [
     'AsyncMessageQueueHandler',
     'Rfh2Decoder',
     'Rfh2Encoder',
 ]
 
-handlers: Dict[str, AsyncMessageRequestHandler] = {}
+handlers: dict[str, AsyncMessageRequestHandler] = {}
 
 
 class AsyncMessageQueueHandler(AsyncMessageHandler):
@@ -236,8 +239,8 @@ class AsyncMessageQueueHandler(AsyncMessageHandler):
             content_type = TransformerContentType.from_string(value)
         return content_type
 
-    def _get_safe_message_descriptor(self, md: pymqi.MD) -> Dict[str, Any]:
-        metadata: Dict[str, Any] = md.get()
+    def _get_safe_message_descriptor(self, md: pymqi.MD) -> dict[str, Any]:
+        metadata: dict[str, Any] = md.get()
 
         if 'MsgId' in metadata:
             metadata['MsgId'] = tohex(metadata['MsgId'])

--- a/grizzly_extras/async_message/mq/rfh2.py
+++ b/grizzly_extras/async_message/mq/rfh2.py
@@ -5,7 +5,7 @@ import gzip
 import time
 import xml.etree.ElementTree as XML  # noqa: N814
 from struct import pack, unpack
-from typing import Dict, List, Optional
+from typing import Optional
 
 try:
     import pymqi
@@ -61,7 +61,7 @@ class Rfh2Decoder:
             raise ValueError(msg) from e
 
     def _parse_name_values(self) -> None:
-        self.name_value_parts: List[XML.Element] = []
+        self.name_value_parts: list[XML.Element] = []
         pos = 0
         maxpos = len(self.name_values) - 1
         if maxpos == -1:
@@ -110,7 +110,7 @@ class Rfh2Encoder:
         md.Encoding = Rfh2Encoder.ENCODING
         return md
 
-    def __init__(self, payload: bytes, queue_name: str, encoding: str = 'gzip', tstamp: Optional[str] = None, metadata: Optional[Dict[str, str]] = None) -> None:
+    def __init__(self, payload: bytes, queue_name: str, encoding: str = 'gzip', tstamp: Optional[str] = None, metadata: Optional[dict[str, str]] = None) -> None:
         if encoding != 'gzip':
             msg = 'Only gzip encoding is implemented'
             raise NotImplementedError(msg)

--- a/grizzly_extras/async_message/sb.py
+++ b/grizzly_extras/async_message/sb.py
@@ -2,9 +2,10 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable
 from contextlib import suppress
 from time import perf_counter, sleep, time
-from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, Optional, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union, cast
 from urllib.parse import urlparse
 
 from azure.core.exceptions import ResourceExistsError, ResourceNotFoundError
@@ -36,17 +37,17 @@ __all__ = [
 ]
 
 
-handlers: Dict[str, AsyncMessageRequestHandler] = {}
+handlers: dict[str, AsyncMessageRequestHandler] = {}
 
 GenericCacheValue = Union[ServiceBusSender, ServiceBusReceiver]
-GenericCache = Dict[str, GenericCacheValue]
+GenericCache = dict[str, GenericCacheValue]
 GenericInstance = Callable[..., GenericCacheValue]
 
 
 class AsyncServiceBusHandler(AsyncMessageHandler):
-    _sender_cache: Dict[str, ServiceBusSender]
-    _receiver_cache: Dict[str, ServiceBusReceiver]
-    _arguments: Dict[str, Dict[str, str]]
+    _sender_cache: dict[str, ServiceBusSender]
+    _receiver_cache: dict[str, ServiceBusReceiver]
+    _arguments: dict[str, dict[str, str]]
 
     _client: Optional[ServiceBusClient] = None
     mgmt_client: Optional[ServiceBusAdministrationClient] = None
@@ -95,11 +96,11 @@ class AsyncServiceBusHandler(AsyncMessageHandler):
                 self.logger.debug('closing management client')
                 self.mgmt_client.close()
 
-    def get_sender_instance(self, arguments: Dict[str, str]) -> ServiceBusSender:
+    def get_sender_instance(self, arguments: dict[str, str]) -> ServiceBusSender:
         endpoint_type = arguments['endpoint_type']
         endpoint_name = arguments['endpoint']
 
-        sender_arguments: Dict[str, str] = {'client_identifier': self.worker}
+        sender_arguments: dict[str, str] = {'client_identifier': self.worker}
 
         sender_type: Callable[..., ServiceBusSender]
 
@@ -118,13 +119,13 @@ class AsyncServiceBusHandler(AsyncMessageHandler):
 
         return sender_type(**sender_arguments)
 
-    def get_receiver_instance(self, arguments: Dict[str, str]) -> ServiceBusReceiver:
+    def get_receiver_instance(self, arguments: dict[str, str]) -> ServiceBusReceiver:
         endpoint_type = arguments['endpoint_type']
         endpoint_name = arguments['endpoint']
         subscription_name = arguments.get('subscription')
         message_wait = arguments.get('wait')
 
-        receiver_arguments: Dict[str, Any] = {
+        receiver_arguments: dict[str, Any] = {
             'client_identifier': self.worker,
         }
         receiver_type: Callable[..., ServiceBusReceiver]
@@ -145,12 +146,12 @@ class AsyncServiceBusHandler(AsyncMessageHandler):
         return receiver_type(**receiver_arguments)
 
     @classmethod
-    def from_message(cls, message: Optional[ServiceBusMessage]) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
-        def to_dict(obj: Optional[DictMixin]) -> Dict[str, Any]:
+    def from_message(cls, message: Optional[ServiceBusMessage]) -> tuple[Optional[dict[str, Any]], Optional[str]]:
+        def to_dict(obj: Optional[DictMixin]) -> dict[str, Any]:
             if obj is None:
                 return {}
 
-            result: Dict[str, Any] = {}
+            result: dict[str, Any] = {}
 
             for key, value in obj.items():
                 result[key] = value
@@ -181,7 +182,7 @@ class AsyncServiceBusHandler(AsyncMessageHandler):
         return metadata, payload
 
     @classmethod
-    def get_endpoint_arguments(cls, instance_type: str, endpoint: str) -> Dict[str, str]:
+    def get_endpoint_arguments(cls, instance_type: str, endpoint: str) -> dict[str, str]:
         arguments = parse_arguments(endpoint, ':')
 
         if 'queue' not in arguments and 'topic' not in arguments:
@@ -555,7 +556,7 @@ class AsyncServiceBusHandler(AsyncMessageHandler):
         self.logger.info('handling request towards %s', cache_endpoint)
 
         message: Optional[ServiceBusMessage] = None
-        metadata: Optional[Dict[str, Any]] = None
+        metadata: Optional[dict[str, Any]] = None
         payload = request.get('payload', None)
         client = request.get('client', -1)
 

--- a/grizzly_extras/async_message/sb.py
+++ b/grizzly_extras/async_message/sb.py
@@ -12,6 +12,7 @@ from azure.servicebus import ServiceBusClient, ServiceBusMessage, ServiceBusRece
 from azure.servicebus._pyamqp import ReceiveClient
 from azure.servicebus.amqp import AmqpMessageBodyType
 from azure.servicebus.management import ServiceBusAdministrationClient, SqlRuleFilter, TopicProperties
+from websocket._exceptions import WebSocketConnectionClosedException
 
 from grizzly_extras.arguments import get_unsupported_arguments, parse_arguments
 from grizzly_extras.azure.aad import AuthMethod, AzureAadCredential
@@ -674,6 +675,16 @@ class AsyncServiceBusHandler(AsyncMessageHandler):
                         raise StopIteration
 
                     break
+                except WebSocketConnectionClosedException as e:
+                    if retry < 3:
+                        self.logger.exception('connection closed')
+                        self._hello(request, force=True)
+                        receiver = self._receiver_cache[cache_endpoint]
+                        message = None
+                        continue
+
+                    error_message = 'could not reconnect on last retry'
+                    raise AsyncMessageError(error_message) from e
                 except StopIteration:
                     delta = perf_counter() - wait_start
 

--- a/grizzly_extras/async_message/sb.py
+++ b/grizzly_extras/async_message/sb.py
@@ -678,7 +678,7 @@ class AsyncServiceBusHandler(AsyncMessageHandler):
                 except ServiceBusError as e:
                     if any(msg in str(e) for msg in ['Connection to remote host was lost', 'socket is already closed']):
                         if retry < 3:
-                            self.logger.exception('connection unexpectedly closed')
+                            self.logger.warning('connection unexpectedly closed, reconnecting', exc_info=True)
                             self._hello(request, force=True)
                             receiver = self._receiver_cache[cache_endpoint]
                             message = None

--- a/grizzly_extras/azure/aad.py
+++ b/grizzly_extras/azure/aad.py
@@ -17,7 +17,7 @@ from os import environ
 from pathlib import Path
 from secrets import token_urlsafe
 from threading import Thread
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Tuple, Type, TypedDict, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, TypedDict, cast
 from urllib.parse import parse_qs, urlparse
 from uuid import uuid4
 
@@ -76,7 +76,7 @@ class FormPostParser(HTMLParser):
 
         return self._payload
 
-    def handle_starttag(self, tag: str, attrs: List[Tuple[str, Optional[str]]]) -> None:
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, Optional[str]]]) -> None:
         if tag == 'form':
             for attr, value in attrs:
                 if attr == 'action':
@@ -152,7 +152,7 @@ class AzureAadWebserver:
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
+        exc_type: Optional[type[BaseException]],
         exc: Optional[BaseException],
         traceback: Optional[TracebackType],
     ) -> bool:
@@ -184,7 +184,7 @@ class AzureAadCredential(TokenCredential):
     _access_token: AccessToken | None
     _webserver: AzureAadWebserver
     _refreshed: bool
-    _token_payload: Optional[Dict[str, Any]]
+    _token_payload: Optional[dict[str, Any]]
 
     def __init__(  # noqa: PLR0913
         self,
@@ -353,7 +353,7 @@ class AzureAadCredential(TokenCredential):
                 message = f'no config found in response from {response.url}'
                 raise ValueError(message)
 
-            return cast(Dict[str, Any], json.loads(f'{{{match.group(1)}}}'))
+            return cast(dict[str, Any], json.loads(f'{{{match.group(1)}}}'))
 
         def update_state(
             state: dict[str, str], response: requests.Response,
@@ -391,7 +391,7 @@ class AzureAadCredential(TokenCredential):
             message = 'neither initialize or redirect URIs has been set'
             raise AzureAadError(message)
 
-        headers_ua: Dict[str, str] = {
+        headers_ua: dict[str, str] = {
             'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 Edg/124.0.0.0',
         }
 
@@ -411,12 +411,12 @@ class AzureAadCredential(TokenCredential):
             retries = Retry(total=3, connect=3, read=3, status=0, backoff_factor=0.1)
             session.mount('https://', HTTPAdapter(max_retries=retries))
 
-            headers: Dict[str, str]
-            payload: Dict[str, Any]
+            headers: dict[str, str]
+            payload: dict[str, Any]
             code_verifier: Optional[str] = None
             code_challenge: Optional[str] = None
-            data: Dict[str, Any]
-            state: Dict[str, str] = {
+            data: dict[str, Any]
+            state: dict[str, str] = {
                 'hpgact': '',
                 'hpgid': '',
                 'sFT': '',
@@ -442,7 +442,7 @@ class AzureAadCredential(TokenCredential):
 
                 url = f'{provider_url}/authorize'
 
-                params: Dict[str, List[str]] = {
+                params: dict[str, list[str]] = {
                     'response_type': ['id_token'],
                     'client_id': [client_id],
                     'redirect_uri': [redirect_uri],
@@ -577,7 +577,7 @@ class AzureAadCredential(TokenCredential):
                 message = f'user auth request 2: {response.url} had unexpected status code {response.status_code}'
                 raise AzureAadFlowError(message)
 
-            data = cast(Dict[str, Any], json.loads(response.text))
+            data = cast(dict[str, Any], json.loads(response.text))
             if 'error' in data:
                 error = data['error']
                 message = f'error response from {url}: code={error["code"]}, message={error["message"]}'

--- a/grizzly_extras/dummy_pymqi.py
+++ b/grizzly_extras/dummy_pymqi.py
@@ -3,8 +3,6 @@ This is used if `pymqi` is not installed, to get around typing errors.
 """
 from __future__ import annotations
 
-from typing import Type
-
 
 class MD:
     pass
@@ -22,6 +20,6 @@ class QueueManager:
     pass
 
 
-def raise_for_error(cls: Type[object]) -> None:
-    message = f'{cls.__name__} could not import pymqi, have you installed IBM MQ dependencies?'
+def raise_for_error(cls: type[object]) -> None:
+    message = f'{cls.__name__} could not import pymqi, have you installed IBM MQ dependencies and set environment variable LD_LIBRARY_PATH?'
     raise NotImplementedError(message)

--- a/grizzly_extras/text.py
+++ b/grizzly_extras/text.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from enum import Enum, EnumMeta
-from typing import Any, Callable, Optional, Tuple
+from typing import Any, Callable, Optional
 
 
 class permutation:
@@ -32,9 +32,9 @@ class permutation:
     See {@pylink grizzly_extras.text.PermutationEnum.__vector__} for an explanation of possible values and their meaning.
     """
 
-    vector: Optional[Tuple[bool, bool]]
+    vector: Optional[tuple[bool, bool]]
 
-    def __init__(self, *, vector: Optional[Tuple[bool, bool]]) -> None:
+    def __init__(self, *, vector: Optional[tuple[bool, bool]]) -> None:
         self.vector = vector
 
     def __call__(self, func: Callable[[str], Any]) -> Callable[[str], Any]:
@@ -55,7 +55,7 @@ class PermutationEnum(Enum, metaclass=PermutationMeta):
     [`grizzly-ls`](https://github.com/Biometria-se/grizzly-lsp) can make educated suggestions on possible step expressions.
     """
 
-    __vector__: Optional[Tuple[bool, bool]]
+    __vector__: Optional[tuple[bool, bool]]
     """
     This class variable represents `(x, y)` dimensions on how the values can expand in a step expression.
 
@@ -137,7 +137,7 @@ class PermutationEnum(Enum, metaclass=PermutationMeta):
     """
 
     @classmethod
-    def get_vector(cls) -> Optional[Tuple[bool, bool]]:
+    def get_vector(cls) -> Optional[tuple[bool, bool]]:
         return getattr(cls, '__vector__', None)
 
     @classmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 readme = "README.md"
 license = {text = 'MIT'}
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "locust ==2.29.2.dev26",
     "azure-core ==1.30.1",
@@ -25,7 +25,6 @@ dependencies = [
     "lxml ==5.1.0",
     "opencensus-ext-azure ==1.1.13",
     "python-dateutil ==2.9.0.post0",
-    "backports.zoneinfo ==0.2.1;python_version<'3.9'",
     "pyzmq ==25.1.2",
     "PyYAML ==6.0.1",
     "setproctitle ==1.3.3",
@@ -41,10 +40,10 @@ classifiers = [
     "Natural Language :: English",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython"
 ]
 keywords = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 license = {text = 'MIT'}
 requires-python = ">=3.8"
 dependencies = [
-    "locust @ git+https://git@github.com/mgor/locust.git@v2.24.1_grizzly",
+    "locust ==2.29.2.dev26",
     "azure-core ==1.30.1",
     "azure-servicebus ==7.12.1",
     "azure-storage-blob ==12.19.1",
@@ -32,7 +32,8 @@ dependencies = [
     "pyotp ==2.9.0",
     "tzdata >=2022.1",
     "websocket-client ==1.7.0",
-    "jinja2-simple-tags ==0.6.1"
+    "jinja2-simple-tags ==0.6.1",
+    "roundrobin ==0.0.4"
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -104,7 +105,7 @@ docs = [
     "databind ==4.5.1",
     "pytablewriter ==1.2.0",
     "pip-licenses ==4.3.4",
-    "requests ==2.31.0",
+    "requests ==2.32.3",
     "mkdocs ==1.5.3",
     "mkdocs-material ==9.5.15",
     "packaging ==24.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 license = {text = 'MIT'}
 requires-python = ">=3.8"
 dependencies = [
-    "locust >=2.24.0,<2.25.0",
+    "locust @ git+https://git@github.com/mgor/locust.git@v2.24.1_grizzly",
     "azure-core ==1.30.1",
     "azure-servicebus ==7.12.1",
     "azure-storage-blob ==12.19.1",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,9 @@ import pytest
 from .fixtures import (
     AtomicVariableCleanupFixture,
     BehaveFixture,
+    CwdFixture,
     End2EndFixture,
+    EnvFixture,
     GrizzlyFixture,
     LocustFixture,
     NoopZmqFixture,
@@ -89,6 +91,14 @@ def _e2e_fixture(tmp_path_factory: TempPathFactory, webserver: Webserver, reques
         yield fixture
 
 
+def _env_fixture() -> Generator[EnvFixture, None, None]:
+    yield EnvFixture()
+
+
+def _cwd_fixture() -> Generator[CwdFixture, None, None]:
+    yield CwdFixture()
+
+
 cleanup = pytest.fixture()(_atomicvariable_cleanup)
 locust_fixture = pytest.fixture()(_locust_fixture)
 behave_fixture = pytest.fixture()(_behave_fixture)
@@ -98,3 +108,5 @@ noop_zmq = pytest.fixture()(_noop_zmq)
 response_context_manager_fixture = pytest.fixture()(_response_context_manager)
 webserver = pytest.fixture(scope='session')(_webserver)
 e2e_fixture = pytest.fixture(scope='session', params=[False, True] if E2E_RUN_DIST else None)(_e2e_fixture)
+env_fixture = pytest.fixture()(_env_fixture)
+cwd_fixture = pytest.fixture()(_cwd_fixture)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from os import environ
-from typing import TYPE_CHECKING, Generator, List
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -21,6 +21,8 @@ from .fixtures import (
 from .webserver import Webserver
 
 if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Generator
+
     from _pytest.config import Config
     from _pytest.fixtures import SubRequest
     from _pytest.tmpdir import TempPathFactory
@@ -41,7 +43,7 @@ def pytest_configure(config: Config) -> None:
 
 
 # also, add markers for each test function that starts with test_e2e_, if we're running everything
-def pytest_collection_modifyitems(items: List[pytest.Function]) -> None:
+def pytest_collection_modifyitems(items: list[pytest.Function]) -> None:
     for item in items:
         if item.originalname.startswith('test_e2e_') and item.get_closest_marker('timeout') is None:
             item.add_marker(pytest.mark.timeout(PYTEST_TIMEOUT))

--- a/tests/e2e/steps/background/test_setup.py
+++ b/tests/e2e/steps/background/test_setup.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 @pytest.mark.parametrize('url', [
     'influxdb://grizzly:password@localhost/grizzly-statistics?Testplan=grizzly-statistics',
-    'insights://localhost/?Testplan=grizzly-statistics&InstrumentationKey=asdfasdf=',
+    'insights://localhost/?Testplan=grizzly-statistics&InstrumentationKey=asdfasdf',
     'influxdb://$conf::statistics.username$:$conf::statistics.password$@localhost/$conf::statistics.database$?Testplan=grizzly-statistics',
 ])
 def test_e2e_step_setup_save_statistics(e2e_fixture: End2EndFixture, url: str) -> None:

--- a/tests/e2e/steps/background/test_setup.py
+++ b/tests/e2e/steps/background/test_setup.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import inspect
-from typing import TYPE_CHECKING, Any, Dict, List, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 
@@ -20,7 +20,7 @@ if TYPE_CHECKING:  # pragma: no cover
     'influxdb://$conf::statistics.username$:$conf::statistics.password$@localhost/$conf::statistics.database$?Testplan=grizzly-statistics',
 ])
 def test_e2e_step_setup_save_statistics(e2e_fixture: End2EndFixture, url: str) -> None:
-    env_conf: Dict[str, Any] = {
+    env_conf: dict[str, Any] = {
         'configuration': {
             'statistics': {
                 'username': 'grizzly',
@@ -43,7 +43,7 @@ def test_e2e_step_setup_save_statistics(e2e_fixture: End2EndFixture, url: str) -
 
         assert grizzly.setup.statistics_url == test_url, f'{grizzly.setup.statistics_url} != {test_url}'
 
-    table: List[Dict[str, str]] = [
+    table: list[dict[str, str]] = [
         {
             'url': url,
             'statistics.username': env_conf['configuration']['statistics']['username'],
@@ -81,7 +81,7 @@ def test_e2e_step_setup_log_level(e2e_fixture: End2EndFixture, level: str) -> No
 
         assert grizzly.setup.log_level == test_level, f'{grizzly.setup.log_level} != {test_level}'
 
-    table: List[Dict[str, str]] = [{
+    table: list[dict[str, str]] = [{
         'level': level,
     }]
 
@@ -113,7 +113,7 @@ def test_e2e_step_setup_run_time(e2e_fixture: End2EndFixture, timespan: str) -> 
 
         assert grizzly.setup.timespan == timespan, f'{grizzly.setup.timespan} != {timespan}'
 
-    table: List[Dict[str, str]] = [{
+    table: list[dict[str, str]] = [{
         'timespan': timespan,
     }]
 
@@ -154,7 +154,7 @@ def test_e2e_step_setup_global_context_variable(e2e_fixture: End2EndFixture, nam
 
     value = value.replace('localhost', e2e_fixture.host)
 
-    table: List[Dict[str, str]] = [{
+    table: list[dict[str, str]] = [{
         'expected': expected.replace('localhost', e2e_fixture.host),
     }]
 
@@ -208,7 +208,7 @@ def test_e2e_step_setup_message_type_callback(
 {source}
 """)
 
-    table: List[Dict[str, str]] = [{
+    table: list[dict[str, str]] = [{
         'direction': f'{from_node}_{to_node}',
         'message_type': message_type,
     }]

--- a/tests/e2e/steps/background/test_shapes.py
+++ b/tests/e2e/steps/background/test_shapes.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from contextlib import suppress
-from typing import TYPE_CHECKING, Dict, List, Optional, cast
+from typing import TYPE_CHECKING, Optional, cast
 
 import pytest
 
@@ -28,7 +28,7 @@ def test_e2e_step_shapes_user_count(e2e_fixture: End2EndFixture, count: str) -> 
         assert grizzly.setup.user_count == user_count, f'{grizzly.setup.user_count} != {user_count}'
         assert grizzly.setup.dispatcher_class == WeightedUsersDispatcher
 
-    table: List[Dict[str, str]] = [
+    table: list[dict[str, str]] = [
         {
             'user_count': str(count),
         },
@@ -41,8 +41,8 @@ def test_e2e_step_shapes_user_count(e2e_fixture: End2EndFixture, count: str) -> 
 
     e2e_fixture.add_validator(validator, table=table)
 
-    background: List[str] = []
-    testdata: Optional[Dict[str, str]] = None
+    background: list[str] = []
+    testdata: Optional[dict[str, str]] = None
 
     if has_template(count):
         background.append('Then ask for value of variable "user_count"')
@@ -76,7 +76,7 @@ def test_e2e_step_shapes_spawn_rate(e2e_fixture: End2EndFixture, rate: str) -> N
 
         assert grizzly.setup.spawn_rate == spawn_rate, f'{grizzly.setup.spawn_rate} != {spawn_rate}'
 
-    table: List[Dict[str, str]] = [
+    table: list[dict[str, str]] = [
         {
             'spawn_rate': str(rate),
         },
@@ -84,8 +84,8 @@ def test_e2e_step_shapes_spawn_rate(e2e_fixture: End2EndFixture, rate: str) -> N
 
     e2e_fixture.add_validator(validator, table=table)
 
-    background: List[str] = []
-    testdata: Optional[Dict[str, str]] = None
+    background: list[str] = []
+    testdata: Optional[dict[str, str]] = None
 
     if has_template(rate):
         background.append('Then ask for value of variable "spawn_rate"')

--- a/tests/e2e/steps/scenario/test_response.py
+++ b/tests/e2e/steps/scenario/test_response.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from itertools import product
-from typing import TYPE_CHECKING, Any, Dict, List, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from grizzly.context import GrizzlyContext
 from grizzly.types import ResponseTarget
@@ -47,8 +47,8 @@ def test_e2e_step_response_save_matches(e2e_fixture: End2EndFixture) -> None:
             assert handler.match_with == 'foo.*$', f'{handler.match_with} != foo.*$'
             assert handler.expected_matches == '1', f'{handler.expected_matches} != 1'
 
-    table: List[Dict[str, str]] = []
-    scenario: List[str] = []
+    table: list[dict[str, str]] = []
+    scenario: list[str] = []
 
     index = 0
     for target in targets:
@@ -113,8 +113,8 @@ def test_e2e_step_response_save_optional(e2e_fixture: End2EndFixture) -> None:
             assert handler.expected_matches == f'{{{{ expected_matches_{index} }}}}', f'{handler.expected_matches} != 1'
             assert handler.default_value == f'foo_{index}'
 
-    table: List[Dict[str, str]] = []
-    scenario: List[str] = []
+    table: list[dict[str, str]] = []
+    scenario: list[str] = []
 
     index = 0
     for target in targets:
@@ -184,8 +184,8 @@ def test_e2e_step_response_save(e2e_fixture: End2EndFixture) -> None:
             assert handler.expected_matches == f'{{{{ expected_matches_{index} }}}}', f'{handler.expected_matches} != 1'
             assert handler.default_value is None
 
-    table: List[Dict[str, str]] = []
-    scenario: List[str] = []
+    table: list[dict[str, str]] = []
+    scenario: list[str] = []
 
     index = 0
     for target in targets:
@@ -277,8 +277,8 @@ def test_e2e_step_response_validate(e2e_fixture: End2EndFixture) -> None:
             assert handler.match_with == 'foo[bar]?', f'{handler.match_with} != foo[bar]?'
             assert handler.expected_matches == '1', f'{handler.expected_matches} != 1'
 
-    table: List[Dict[str, str]] = []
-    scenario: List[str] = []
+    table: list[dict[str, str]] = []
+    scenario: list[str] = []
 
     for target, condition in parameterize:
         table.append({
@@ -327,8 +327,8 @@ def test_e2e_step_allow_status_codes(e2e_fixture: End2EndFixture) -> None:
 
         assert len(grizzly.scenario.orphan_templates) == 0, 'unexpected number of orphan templates'
 
-    table: List[Dict[str, str]] = []
-    scenario: List[str] = []
+    table: list[dict[str, str]] = []
+    scenario: list[str] = []
 
     for status_code in status_codes:
         table.append({'status_codes': status_code})
@@ -413,8 +413,8 @@ def test_e2e_step_response_content_type(e2e_fixture: End2EndFixture) -> None:
             assert request.name == f'test-get-{index}', f'{request.name} != test-get-{index}'
             assert request.response.content_type == TransformerContentType.from_string(data['content_type'])
 
-    table: List[Dict[str, str]] = []
-    scenario: List[str] = []
+    table: list[dict[str, str]] = []
+    scenario: list[str] = []
 
     for index, content_type in enumerate(content_types):
         table.append({'content_type': content_type})

--- a/tests/e2e/steps/scenario/test_setup.py
+++ b/tests/e2e/steps/scenario/test_setup.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import textwrap
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any, Dict, List, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 
@@ -30,7 +30,7 @@ def test_e2e_step_setup_set_context_variable(e2e_fixture: End2EndFixture) -> Non
         from grizzly.utils import merge_dicts
 
         grizzly = cast(GrizzlyContext, context.grizzly)
-        expected_total: Dict[str, Any] = {}
+        expected_total: dict[str, Any] = {}
         first_row = next(iter(context.table)).as_dict()
         expected_host = first_row['expected']
 
@@ -55,8 +55,8 @@ def test_e2e_step_setup_set_context_variable(e2e_fixture: End2EndFixture) -> Non
         assert actual == expected_total, f'{actual!s} != {expected!s}'
         assert grizzly.scenario.context.get('host', None) == f'http://{expected_host}'  # added by fixture
 
-    table: List[Dict[str, str]] = [{'expected': e2e_fixture.host}]
-    scenario: List[str] = []
+    table: list[dict[str, str]] = [{'expected': e2e_fixture.host}]
+    scenario: list[str] = []
 
     for name, value, expected in testdata:
         table.append({'expected': expected})
@@ -91,7 +91,7 @@ def test_e2e_step_setup_iterations(e2e_fixture: End2EndFixture, iterations: str)
 
         assert grizzly.scenario.iterations == iterations, f'{grizzly.scenario.iterations} != {iterations}'
 
-    table: List[Dict[str, str]] = [{
+    table: list[dict[str, str]] = [{
         'iterations': iterations,
     }]
 
@@ -133,7 +133,7 @@ def test_e2e_step_setup_pace(e2e_fixture: End2EndFixture, pace: str) -> None:
         if has_template(pace):
             assert grizzly.scenario.orphan_templates == [pace], f'{pace} not in {grizzly.scenario.orphan_templates}'
 
-    table: List[Dict[str, str]] = [{
+    table: list[dict[str, str]] = [{
         'pace': pace,
     }]
 

--- a/tests/e2e/steps/scenario/test_tasks.py
+++ b/tests/e2e/steps/scenario/test_tasks.py
@@ -107,10 +107,6 @@ def test_e2e_step_task_request_text_with_name_to_endpoint(e2e_fixture: End2EndFi
 
     assert 'HOOK-ERROR in after_feature: RuntimeError: locust test failed' in result
     expected_parts = ['SEND 001 test-send: ', 'NotImplementedError(\'SEND is not implemented for RestApiUser_001\')']
-    if e2e_fixture._distributed:
-        expected_parts.insert(1, '"')
-        expected_parts.append('"')
-
     expected = ''.join(expected_parts)
 
     assert expected in result
@@ -195,10 +191,6 @@ def test_e2e_step_task_request_file_with_name_endpoint(e2e_fixture: End2EndFixtu
     assert rc == 1
     assert 'HOOK-ERROR in after_feature: RuntimeError: locust test failed' in result
     expected_parts = ['SEND 001 test-send: ', 'NotImplementedError(\'SEND is not implemented for RestApiUser_001\')']
-    if e2e_fixture._distributed:
-        expected_parts.insert(1, '"')
-        expected_parts.append('"')
-
     expected = ''.join(expected_parts)
 
     assert expected in result

--- a/tests/e2e/steps/scenario/test_tasks.py
+++ b/tests/e2e/steps/scenario/test_tasks.py
@@ -334,7 +334,7 @@ def test_e2e_step_task_wait_seconds(e2e_fixture: End2EndFixture) -> None:
 
         task = tasks[0]
         assert isinstance(task, ExplicitWaitTask)
-        assert task.time_expression == '13.37'
+        assert task.time_expression == '1.37'
 
         task = tasks[1]
         assert isinstance(task, ExplicitWaitTask)
@@ -349,13 +349,13 @@ def test_e2e_step_task_wait_seconds(e2e_fixture: End2EndFixture) -> None:
     feature_file = e2e_fixture.test_steps(
         scenario=[
             'And ask for value of variable "wait_time"',
-            'Then wait for "13.37" seconds',
+            'Then wait for "1.37" seconds',
             'Then wait for "0.123" seconds',
             'Then wait for "{{ wait_time }}" seconds',
         ],
     )
 
-    rc, _ = e2e_fixture.execute(feature_file, testdata={'wait_time': '126'})
+    rc, _ = e2e_fixture.execute(feature_file, testdata={'wait_time': '2.25'})
 
     assert rc == 0
 
@@ -992,19 +992,19 @@ def test_e2e_step_task_request_wait(e2e_fixture: End2EndFixture) -> None:
         task = grizzly.scenario.tasks()[0]
 
         assert isinstance(task, WaitBetweenTask), f'{type(task)} is not expected TaskWaitTask'
-        assert task.min_time == '15'
-        assert task.max_time == '18'
+        assert task.min_time == '1'
+        assert task.max_time == '3'
 
         task = grizzly.scenario.tasks()[1]
 
         assert isinstance(task, WaitBetweenTask), f'{type(task)} is not expected TaskWaitTask'
-        assert task.min_time == '1.4'
-        assert task.max_time == '1.7'
+        assert task.min_time == '0.4'
+        assert task.max_time == '0.7'
 
         task = grizzly.scenario.tasks()[2]
 
         assert isinstance(task, WaitBetweenTask), f'{type(task)} is not expected TaskWaitTask'
-        assert task.min_time == '15'
+        assert task.min_time == '1'
         assert task.max_time is None
 
         task = grizzly.scenario.tasks()[3]
@@ -1022,24 +1022,24 @@ def test_e2e_step_task_request_wait(e2e_fixture: End2EndFixture) -> None:
         task = grizzly.scenario.tasks()[5]
 
         assert isinstance(task, WaitBetweenTask), f'{type(task)} is not expected TaskWaitTask'
-        assert task.min_time == '37.13'
+        assert task.min_time == '0.13'
         assert task.max_time is None
 
     e2e_fixture.add_validator(validate_request_wait)
 
     feature_file = e2e_fixture.test_steps(
         scenario=[
-            'Given wait "15..18" seconds between tasks',
-            'And value for variable "wait_time" is "13.37"',
-            'And wait "1.4..1.7" seconds between tasks',
-            'Given wait "15" seconds between tasks',
+            'Given wait "1..3" seconds between tasks',
+            'And value for variable "wait_time" is "1.37"',
+            'And wait "0.4..0.7" seconds between tasks',
+            'Given wait "1" seconds between tasks',
             'And wait "1.4" seconds between tasks',
             'And wait "{{ wait_time }}" seconds between tasks',
             'And wait "$conf::wait.time$" seconds between tasks',
         ],
     )
 
-    rc, _ = e2e_fixture.execute(feature_file, env_conf={'configuration': {'wait': {'time': 37.13}}})
+    rc, _ = e2e_fixture.execute(feature_file, env_conf={'configuration': {'wait': {'time': 0.13}}})
 
     assert rc == 0
 

--- a/tests/e2e/steps/scenario/test_tasks.py
+++ b/tests/e2e/steps/scenario/test_tasks.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from json import dumps as jsondumps
 from pathlib import Path
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, Dict, List, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from grizzly.context import GrizzlyContext
 
@@ -489,7 +489,7 @@ def test_e2e_step_task_client_get_endpoint(e2e_fixture: End2EndFixture) -> None:
             sorted(actual_templates) == sorted(['{{ endpoint }}/api/echo?bar=foo', '{{ endpoint_payload }} {{ endpoint_metadata }}'])
         ), f"{actual_templates} != ['{{{{ endpoint }}}}', '{{{{ endpoint_payload }}}} {{{{ endpoint_metadata}}}}']"
 
-    table: List[Dict[str, str]] = [{
+    table: list[dict[str, str]] = [{
         'e2e_fixture.host': e2e_fixture.host,
     }]
 
@@ -611,7 +611,7 @@ def test_e2e_step_task_client_get_endpoint_until(e2e_fixture: End2EndFixture) ->
         assert task._short_name == 'Http'
         assert task.get_templates() == []
 
-    table: List[Dict[str, str]] = [{
+    table: list[dict[str, str]] = [{
         'e2e_fixture.host': e2e_fixture.host,
     }]
 
@@ -635,7 +635,7 @@ def test_e2e_step_task_client_get_endpoint_until(e2e_fixture: End2EndFixture) ->
         ],
     )
 
-    env_conf: Dict[str, Dict[str, Dict[str, str]]] = {
+    env_conf: dict[str, dict[str, dict[str, str]]] = {
         'configuration': {
             'test': {
                 'host': f'http://{e2e_fixture.host}',

--- a/tests/e2e/steps/scenario/test_user.py
+++ b/tests/e2e/steps/scenario/test_user.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from secrets import choice
-from typing import TYPE_CHECKING, Dict, List, cast
+from typing import TYPE_CHECKING, cast
 
 import pytest
 
@@ -50,7 +50,7 @@ def test_e2e_step_user_type_count_tag(e2e_fixture: End2EndFixture, user_type: st
     user_tag = choice(['foo', 'bar', 'hello', 'world'])
     grammar = choice(['user', 'users'])
 
-    table: List[Dict[str, str]] = [{
+    table: list[dict[str, str]] = [{
         'user_type': user_type,
         'user_count': str(user_count),
         'tag': user_tag,
@@ -104,7 +104,7 @@ def test_e2e_step_user_type_with_weight(e2e_fixture: End2EndFixture, user_type: 
 
     weight = choice(range(1, 20))
 
-    table: List[Dict[str, str]] = [{
+    table: list[dict[str, str]] = [{
         'user_type': user_type,
         'weight': str(weight),
         'host': host,
@@ -152,7 +152,7 @@ def test_e2e_step_user_type(e2e_fixture: End2EndFixture, user_type: str, host: s
 
     host = host.replace('localhost', e2e_fixture.host)
 
-    table: List[Dict[str, str]] = [{
+    table: list[dict[str, str]] = [{
         'user_type': user_type,
         'host': host,
     }]

--- a/tests/e2e/test_auth.py
+++ b/tests/e2e/test_auth.py
@@ -57,7 +57,7 @@ def test_e2e_auth_user_token(e2e_fixture: End2EndFixture) -> None:
             'id': 'dummy-client-id',
             'secret': 'dummy-client-secret',
         },
-        'token': 'foobar',
+        'token': 'header.foobar.signature',
         'headers': {
             'x-subscription': 'foobar',
         },

--- a/tests/e2e/test_auth.py
+++ b/tests/e2e/test_auth.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, List, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 
@@ -67,7 +67,7 @@ def test_e2e_auth_user_token(e2e_fixture: End2EndFixture) -> None:
         if e2e_fixture.webserver.auth is None:
             return ''
 
-        steps: List[str] = []
+        steps: list[str] = []
         for key, value in e2e_fixture.webserver.auth.get('headers', {}).items():
             steps.append(f'And metadata "{key}" is "{value}"')
 

--- a/tests/e2e/test_example.py
+++ b/tests/e2e/test_example.py
@@ -13,106 +13,101 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 def test_e2e_example(e2e_fixture: End2EndFixture) -> None:  # noqa: PLR0915
-    try:
-        result: Optional[str] = None
+    result: Optional[str] = None
 
-        with Path('example/environments/example.yaml').open() as env_yaml_file:
-            env_conf = yaml.full_load(env_yaml_file)
+    with Path('example/environments/example.yaml').open() as env_yaml_file:
+        env_conf = yaml.full_load(env_yaml_file)
 
-            for name in ['dog', 'cat', 'book']:
-                env_conf['configuration']['facts'][name]['host'] = f'http://{e2e_fixture.host}'
+        for name in ['dog', 'cat', 'book']:
+            env_conf['configuration']['facts'][name]['host'] = f'http://{e2e_fixture.host}'
 
-        if e2e_fixture._distributed:
-            # copy examples
-            source = (Path(__file__) / '..' / '..' / '..' / 'example').resolve()
-            example_root = e2e_fixture.root.parent / 'test-example'
-            copytree(source, example_root, dirs_exist_ok=True)
+    if e2e_fixture._distributed:
+        # copy examples
+        source = (Path(__file__) / '..' / '..' / '..' / 'example').resolve()
+        example_root = e2e_fixture.root.parent / 'test-example'
+        copytree(source, example_root, dirs_exist_ok=True)
 
-            with (Path(example_root) / 'features' / 'steps' / 'steps.py').open('a') as fd:
-                fd.write(
-                    e2e_fixture.step_start_webserver.format('/srv/grizzly'),
-                )
+        with (Path(example_root) / 'features' / 'steps' / 'steps.py').open('a') as fd:
+            fd.write(
+                e2e_fixture.step_start_webserver.format('/srv/grizzly'),
+            )
 
-            # create steps/webserver.py
-            webserver_source = e2e_fixture.test_tmp_dir.parent / 'tests' / 'webserver.py'
-            webserver_destination = example_root / 'features' / 'steps' / 'webserver.py'
-            webserver_destination.write_text(webserver_source.read_text())
+        # create steps/webserver.py
+        webserver_source = e2e_fixture.test_tmp_dir.parent / 'tests' / 'webserver.py'
+        webserver_destination = example_root / 'features' / 'steps' / 'webserver.py'
+        webserver_destination.write_text(webserver_source.read_text())
 
-            root = (Path(__file__) / '..' / '..' / '..').resolve()
-            feature_file_root = str(example_root).replace(f'{root}/', '')
-            feature_file = f'{feature_file_root}/features/example.feature'
-            feature_file_contents = Path(feature_file).read_text().split('\n')
+        root = (Path(__file__) / '..' / '..' / '..').resolve()
+        feature_file_root = str(example_root).replace(f'{root}/', '')
+        feature_file = f'{feature_file_root}/features/example.feature'
+        feature_file_contents = Path(feature_file).read_text().split('\n')
 
-            index = feature_file_contents.index('  Scenario: dog facts api')
-            # should go last in "Background"-section
-            feature_file_contents.insert(index - 1, f'    Then start webserver on master port "{e2e_fixture.webserver.port}"')
+        index = feature_file_contents.index('  Scenario: dog facts api')
+        # should go last in "Background"-section
+        feature_file_contents.insert(index - 1, f'    Then start webserver on master port "{e2e_fixture.webserver.port}"')
 
-            with Path(feature_file).open('w') as fd:
-                fd.truncate(0)
-                fd.write('\n'.join(feature_file_contents))
-        else:
-            example_root = Path.cwd() / 'example'
+        with Path(feature_file).open('w') as fd:
+            fd.truncate(0)
+            fd.write('\n'.join(feature_file_contents))
+    else:
+        example_root = Path.cwd() / 'example'
 
-        feature_file = 'features/example.feature'
+    feature_file = 'features/example.feature'
 
-        # use test-example project stucture, but with original project name (image)
-        original_root = e2e_fixture.root
-        e2e_fixture._root = example_root
+    # use test-example project stucture, but with original project name (image)
+    original_root = e2e_fixture.root
+    e2e_fixture._root = example_root
 
-        code, output = e2e_fixture.execute(feature_file, env_conf=env_conf, project_name=original_root.name)
+    code, output = e2e_fixture.execute(feature_file, env_conf=env_conf, project_name=original_root.name)
 
-        result = ''.join(output)
+    result = ''.join(output)
 
-        # restore original root
-        e2e_fixture._root = original_root
+    # restore original root
+    e2e_fixture._root = original_root
 
-        assert code == 0
-        assert 'ERROR' not in result
-        assert 'WARNING' not in result
-        assert '1 feature passed, 0 failed, 0 skipped' in result
-        assert '3 scenarios passed, 0 failed, 0 skipped' in result
-        assert 'steps passed, 0 failed, 0 skipped, 0 undefined' in result
+    assert code == 0
+    assert 'ERROR' not in result
+    assert 'WARNING' not in result
+    assert '1 feature passed, 0 failed, 0 skipped' in result
+    assert '3 scenarios passed, 0 failed, 0 skipped' in result
+    assert 'steps passed, 0 failed, 0 skipped, 0 undefined' in result
 
-        assert 'ident   iter  status   description' in result
-        assert '001      2/2  passed   dog facts api' in result
-        assert '002      1/1  passed   cat facts api' in result
-        assert '003      1/1  passed   book api' in result
-        assert '------|-----|--------|---------------|' in result
+    assert 'ident   iter  status   description' in result
+    assert '001      2/2  passed   dog facts api' in result
+    assert '002      1/1  passed   cat facts api' in result
+    assert '003      1/1  passed   book api' in result
+    assert '------|-----|--------|---------------|' in result
 
-        assert 'executing custom.User.request for 002 get-cat-facts and /facts?limit=' in result
+    assert 'executing custom.User.request for 002 get-cat-facts and /facts?limit=' in result
 
-        assert 'sending "client_server" from CLIENT' in result
-        assert "received from CLIENT" in result
-        assert "AtomicCustomVariable.foobar='foobar'" in result
+    assert 'sending "client_server" from CLIENT' in result
+    assert "received from CLIENT" in result
+    assert "AtomicCustomVariable.foobar='foobar'" in result
 
-        # check debugging and that task index -> step expression is correct
-        # dog facts api
-        assert 'executing task 1 of 3: iterator' in result
-        assert (
-            'executing task 2 of 3: Then get request with name "get-dog-facts" from endpoint '
-            '"/api/v1/resources/dogs?number={{ AtomicRandomInteger.dog_facts_count }}'
-        ) in result
-        assert 'executing task 3 of 3: pace' in result
+    # check debugging and that task index -> step expression is correct
+    # dog facts api
+    assert 'executing task 1 of 3: iterator' in result
+    assert (
+        'executing task 2 of 3: Then get request with name "get-dog-facts" from endpoint '
+        '"/api/v1/resources/dogs?number={{ AtomicRandomInteger.dog_facts_count }}'
+    ) in result
+    assert 'executing task 3 of 3: pace' in result
 
-        # cat facts api
-        assert 'executing task 1 of 5: iterator' in result
-        assert 'executing task 2 of 5: Then get request with name "get-cat-facts" from endpoint "/facts?limit={{ AtomicRandomInteger.cat_facts_count }}"' in result
-        assert 'executing task 3 of 5: And send message "{\'client\': \'server\'}"' in result
-        assert 'executing task 4 of 5: Then log message "foo={{ foo | touppercase }}, bar={{ bar | touppercase }}"' in result
-        assert 'executing task 5 of 5: pace' in result
+    # cat facts api
+    assert 'executing task 1 of 5: iterator' in result
+    assert 'executing task 2 of 5: Then get request with name "get-cat-facts" from endpoint "/facts?limit={{ AtomicRandomInteger.cat_facts_count }}"' in result
+    assert 'executing task 3 of 5: And send message "{\'client\': \'server\'}"' in result
+    assert 'executing task 4 of 5: Then log message "foo={{ foo | touppercase }}, bar={{ bar | touppercase }}"' in result
+    assert 'executing task 5 of 5: pace' in result
 
-        assert 'foo=BAR, bar=BAR' in result
+    assert 'foo=BAR, bar=BAR' in result
 
-        # book api
-        assert 'executing task 1 of 5: iterator' in result
-        assert 'executing task 2 of 5: Then get request with name "1-get-book" from endpoint "/books/{{ AtomicCsvReader.books.book }}.json | content_type=json"' in result
-        assert 'executing task 3 of 5: Then get request with name "2-get-author" from endpoint "{{ author_endpoint }}.json | content_type=json"' in result
-        assert 'executing task 4 of 5: Then log message "AtomicCustomVariable.foobar=\'{{ steps.custom.AtomicCustomVariable.foobar }}\'"' in result
-        assert 'executing task 5 of 5: pace' in result
-    except:
-        if result is not None:
-            print(result)
-        raise
+    # book api
+    assert 'executing task 1 of 5: iterator' in result
+    assert 'executing task 2 of 5: Then get request with name "1-get-book" from endpoint "/books/{{ AtomicCsvReader.books.book }}.json | content_type=json"' in result
+    assert 'executing task 3 of 5: Then get request with name "2-get-author" from endpoint "{{ author_endpoint }}.json | content_type=json"' in result
+    assert 'executing task 4 of 5: Then log message "AtomicCustomVariable.foobar=\'{{ steps.custom.AtomicCustomVariable.foobar }}\'"' in result
+    assert 'executing task 5 of 5: pace' in result
 
 def test_e2e_example_dry_run(e2e_fixture: End2EndFixture) -> None:  # noqa: PLR0915
     try:

--- a/tests/e2e/test_iteration_pace.py
+++ b/tests/e2e/test_iteration_pace.py
@@ -78,7 +78,4 @@ def test_e2e_iteration_pace(e2e_fixture: End2EndFixture) -> None:
 
     assert rc == 1
     assert 'HOOK-ERROR in after_feature: RuntimeError: locust test failed' in result
-    if e2e_fixture._distributed:
-        assert "1                  PACE 001 RequestTask: \"RuntimeError('pace falling behind')\"" in result  # ?!?!?!
-    else:
-        assert "1                  PACE 001 RequestTask: RuntimeError('pace falling behind')" in result
+    assert "1                  PACE 001 RequestTask: RuntimeError('pace falling behind')" in result

--- a/tests/e2e/test_iteration_pace.py
+++ b/tests/e2e/test_iteration_pace.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, Dict, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from grizzly.context import GrizzlyContext
 
@@ -41,7 +41,7 @@ def test_e2e_iteration_pace(e2e_fixture: End2EndFixture) -> None:
 
     start_webserver_step = f'Then start webserver on master port "{e2e_fixture.webserver.port}"\n\n' if e2e_fixture._distributed else ''
 
-    env_conf: Dict[str, Dict[str, Dict[str, str]]] = {
+    env_conf: dict[str, dict[str, dict[str, str]]] = {
         'configuration': {
             'test': {
                 'host': f'http://{e2e_fixture.host}',

--- a/tests/e2e/test_until.py
+++ b/tests/e2e/test_until.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, Dict, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from grizzly.context import GrizzlyContext
 
@@ -43,7 +43,7 @@ def test_e2e_until(e2e_fixture: End2EndFixture) -> None:
 
     start_webserver_step = f'Then start webserver on master port "{e2e_fixture.webserver.port}"\n\n' if e2e_fixture._distributed else ''
 
-    env_conf: Dict[str, Dict[str, Dict[str, str]]] = {
+    env_conf: dict[str, dict[str, dict[str, str]]] = {
         'configuration': {
             'test': {
                 'host': f'http://{e2e_fixture.host}',

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -8,7 +8,7 @@ from cProfile import Profile
 from getpass import getuser
 from hashlib import sha1
 from json import dumps as jsondumps
-from os import environ
+from os import chdir, environ
 from pathlib import Path
 from shutil import rmtree
 from tempfile import NamedTemporaryFile
@@ -108,6 +108,62 @@ class LocustFixture:
         rmtree(self._test_context_root)
 
         return True
+
+
+class EnvFixture:
+    key: str
+    value: str
+
+    def __call__(self, key: str, value: str) -> Self:
+        self.key = key
+        self.value = value
+
+        return self
+
+    def __enter__(self) -> Self:
+        environ[self.key] = self.value
+
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> Literal[True]:
+        with suppress(KeyError):
+            del environ[self.key]
+
+        return True
+
+
+class CwdFixture:
+    cwd: Path
+    old_cwd: Path
+
+    def __call__(self, cwd: Path) -> Self:
+        self.cwd = cwd
+
+        return self
+
+    def __enter__(self) -> Self:
+        self.old_cwd = Path.cwd()
+
+        chdir(self.cwd)
+
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> Literal[True]:
+
+        chdir(self.old_cwd)
+
+        return True
+
 
 
 class BehaveFixture:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from shutil import rmtree
 from tempfile import NamedTemporaryFile
 from textwrap import dedent, indent
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Tuple, Type, cast
+from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, cast
 from urllib.parse import urlparse
 
 import yaml
@@ -98,7 +98,7 @@ class LocustFixture:
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
+        exc_type: Optional[type[BaseException]],
         exc: Optional[BaseException],
         traceback: Optional[TracebackType],
     ) -> Literal[True]:
@@ -127,7 +127,7 @@ class EnvFixture:
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
+        exc_type: Optional[type[BaseException]],
         exc: Optional[BaseException],
         traceback: Optional[TracebackType],
     ) -> Literal[True]:
@@ -155,7 +155,7 @@ class CwdFixture:
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
+        exc_type: Optional[type[BaseException]],
         exc: Optional[BaseException],
         traceback: Optional[TracebackType],
     ) -> Literal[True]:
@@ -207,7 +207,7 @@ class BehaveFixture:
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
+        exc_type: Optional[type[BaseException]],
         exc: Optional[BaseException],
         traceback: Optional[TracebackType],
     ) -> Literal[True]:
@@ -260,7 +260,7 @@ class RequestTaskFixture:
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
+        exc_type: Optional[type[BaseException]],
         exc: Optional[BaseException],
         traceback: Optional[TracebackType],
     ) -> Literal[True]:
@@ -297,8 +297,8 @@ class GrizzlyFixture:
     def __call__(
         self,
         host: str = '',
-        user_type: Optional[Type[GrizzlyUser]] = None,
-        scenario_type: Optional[Type[GrizzlyScenario]] = None,
+        user_type: Optional[type[GrizzlyUser]] = None,
+        scenario_type: Optional[type[GrizzlyScenario]] = None,
         *,
         no_tasks: Optional[bool] = False,
     ) -> GrizzlyScenario:
@@ -340,7 +340,7 @@ class GrizzlyFixture:
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
+        exc_type: Optional[type[BaseException]],
         exc: Optional[BaseException],
         traceback: Optional[TracebackType],
     ) -> Literal[True]:
@@ -364,7 +364,7 @@ class GrizzlyFixture:
 
 class ResponseContextManagerFixture:
     # borrowed from geventhttpclient.client._build_request
-    def _build_request(self, method: str, request_url: str, body: Optional[str] = '', headers: Optional[Dict[str, Any]] = None) -> str:  # noqa: ARG002
+    def _build_request(self, method: str, request_url: str, body: Optional[str] = '', headers: Optional[dict[str, Any]] = None) -> str:  # noqa: ARG002
         parsed = urlparse(request_url)
 
         request = method + ' ' + parsed.path + ' HTTP/1.1\r\n'
@@ -379,12 +379,12 @@ class ResponseContextManagerFixture:
         self,
         status_code: int,
         response_body: Optional[Any] = None,
-        response_headers: Optional[Dict[str, Any]] = None,
+        response_headers: Optional[dict[str, Any]] = None,
         request_method: Optional[str] = None,
         request_body: Optional[Any] = None,
-        request_headers: Optional[Dict[str, Any]] = None,
+        request_headers: Optional[dict[str, Any]] = None,
         url: Optional[str] = None,
-        **kwargs: Dict[str, Any],
+        **kwargs: dict[str, Any],
     ) -> FastResponseContextManager:
         name = kwargs['name']
 
@@ -449,7 +449,7 @@ class ResponseContextManagerFixture:
 class NoopZmqFixture:
     _mocker: MockerFixture
 
-    _mocks: Dict[str, MagicMock]
+    _mocks: dict[str, MagicMock]
 
     def __init__(self, mocker: MockerFixture) -> None:
         self._mocker = mocker
@@ -508,13 +508,13 @@ BehaveKeyword = Literal['Then', 'Given', 'And', 'When']
 class End2EndValidator:
     name: str
     implementation: Any
-    table: Optional[List[Dict[str, str]]]
+    table: Optional[list[dict[str, str]]]
 
     def __init__(
         self,
         name: str,
         implementation: Callable[[BehaveContext], None],
-        table: Optional[List[Dict[str, str]]] = None,
+        table: Optional[list[dict[str, str]]] = None,
     ) -> None:
         self.name = name
         self.implementation = implementation
@@ -522,7 +522,7 @@ class End2EndValidator:
 
     @property
     def expression(self) -> str:
-        lines: List[str] = [f'Then run validator {self.name}_{self.implementation.__name__}']
+        lines: list[str] = [f'Then run validator {self.name}_{self.implementation.__name__}']
         if self.table is not None and len(self.table) > 0:
             lines.append(f'  | {" | ".join(list(self.table[0].keys()))} |')
             lines.extend([f'  | {" | ".join(list(row.values()))} |' for row in self.table])
@@ -564,12 +564,12 @@ def step_start_webserver(context: Context, port: int) -> None:
 """
 
     _tmp_path_factory: TempPathFactory
-    _env: Dict[str, str]
-    _validators: Dict[Optional[str], List[End2EndValidator]]
+    _env: dict[str, str]
+    _validators: dict[Optional[str], list[End2EndValidator]]
     _distributed: bool
 
-    _after_features: Dict[str, Callable[[BehaveContext, Feature], None]]
-    _before_features: Dict[str, Callable[[BehaveContext, Feature], None]]
+    _after_features: dict[str, Callable[[BehaveContext, Feature], None]]
+    _before_features: dict[str, Callable[[BehaveContext, Feature], None]]
 
     _root: Optional[Path]
 
@@ -762,7 +762,7 @@ def step_start_webserver(context: Context, port: int) -> None:
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
+        exc_type: Optional[type[BaseException]],
         exc: Optional[BaseException],
         traceback: Optional[TracebackType],
     ) -> Literal[True]:
@@ -797,7 +797,7 @@ def step_start_webserver(context: Context, port: int) -> None:
         implementation: Callable[[BehaveContext], None],
         /,
         scenario: Optional[str] = None,
-        table: Optional[List[Dict[str, str]]] = None,
+        table: Optional[list[dict[str, str]]] = None,
     ) -> None:
         callee = inspect.stack()[1].function
 
@@ -814,9 +814,9 @@ def step_start_webserver(context: Context, port: int) -> None:
         callee = inspect.stack()[1].function
         self._before_features[callee] = implementation
 
-    def test_steps(self, /, scenario: Optional[List[str]] = None, background: Optional[List[str]] = None, identifier: Optional[str] = None) -> str:
+    def test_steps(self, /, scenario: Optional[list[str]] = None, background: Optional[list[str]] = None, identifier: Optional[str] = None) -> str:
         callee = inspect.stack()[1].function
-        contents: List[str] = ['Feature:']
+        contents: list[str] = ['Feature:']
         add_user_count_step = True
         add_user_type_step = True
         add_spawn_rate_step = True
@@ -881,7 +881,7 @@ def step_start_webserver(context: Context, port: int) -> None:
 
         scenario: Optional[str] = None
         indentation = '    '
-        modified_feature_lines: List[str] = []
+        modified_feature_lines: list[str] = []
         offset = 0  # number of added steps
 
         for nr, line in enumerate(feature_lines):
@@ -925,7 +925,7 @@ def step_start_webserver(context: Context, port: int) -> None:
 
         # add step implementations
         with steps_file.open('a') as fd:
-            added_validators: List[str] = []
+            added_validators: list[str] = []
             for validators in self._validators.values():
                 for validator in validators:
                     # write expression and step implementation to steps/steps.py
@@ -937,7 +937,7 @@ def step_start_webserver(context: Context, port: int) -> None:
 
         # add after_feature hook, always write all of 'em
         with environment_file.open('w') as fd:
-            fd.write('from typing import Any, Tuple, Dict, cast\n\n')
+            fd.write('from typing import Any, cast\n\n')
             fd.write('from grizzly.types.behave import Context, Feature\n')
             fd.write('from grizzly.context import GrizzlyContext\n')
             fd.write(
@@ -945,7 +945,7 @@ def step_start_webserver(context: Context, port: int) -> None:
                 'after_feature as grizzly_after_feature, before_scenario, after_scenario, before_step\n\n',
             )
 
-            fd.write('def before_feature(context: Context, feature: Feature, *args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> None:\n')
+            fd.write('def before_feature(context: Context, feature: Feature, *args: tuple[Any, ...], **kwargs: dict[str, Any]) -> None:\n')
             if len(self._before_features) > 0:
                 for feature_name in self._before_features:
                     fd.write(f'    if feature.name == "{feature_name}":\n')
@@ -962,7 +962,7 @@ def step_start_webserver(context: Context, port: int) -> None:
 
                 fd.write(source + '\n\n')
 
-            fd.write('def after_feature(context: Context, feature: Feature, *args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> None:\n')
+            fd.write('def after_feature(context: Context, feature: Feature, *args: tuple[Any, ...], **kwargs: dict[str, Any]) -> None:\n')
             fd.write('    grizzly_after_feature(context, feature)\n\n')
             if len(self._after_features) > 0:
                 for feature_name in self._after_features:
@@ -984,12 +984,12 @@ def step_start_webserver(context: Context, port: int) -> None:
     def execute(
         self,
         feature_file: str,
-        env_conf: Optional[Dict[str, Any]] = None,
-        testdata: Optional[Dict[str, str]] = None,
+        env_conf: Optional[dict[str, Any]] = None,
+        testdata: Optional[dict[str, str]] = None,
         project_name: Optional[str] = None,
         *,
         dry_run: bool = False,
-    ) -> Tuple[int, List[str]]:
+    ) -> tuple[int, list[str]]:
         env_conf_fd: Any
         if env_conf is not None:
             prefix = Path(feature_file).stem

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -11,8 +11,9 @@ from abc import ABCMeta
 from contextlib import suppress
 from copy import deepcopy
 from pathlib import Path
+from re import Pattern
 from types import MethodType, TracebackType
-from typing import Any, Callable, Dict, Generator, List, Optional, Pattern, Set, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 from unittest.mock import MagicMock
 
 from geventhttpclient.response import HTTPSocketPoolResponse
@@ -27,6 +28,9 @@ from grizzly.types import GrizzlyResponse, RequestMethod
 from grizzly.types.locust import Environment, Message
 from grizzly.users import GrizzlyUser
 
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
 
 class AtomicCustomVariable(AtomicVariable[str]):
     pass
@@ -35,7 +39,7 @@ class AtomicCustomVariable(AtomicVariable[str]):
 message_callback_not_a_method = True
 
 
-def ANY(*cls: Type, message: Optional[str] = None) -> object:  # noqa: N802
+def ANY(*cls: type, message: Optional[str] = None) -> object:  # noqa: N802
     """Compare equal to everything, as long as it is of the same type."""
     class WrappedAny(metaclass=ABCMeta):  # noqa: B024
         def __eq__(self, other: object) -> bool:
@@ -52,7 +56,7 @@ def ANY(*cls: Type, message: Optional[str] = None) -> object:  # noqa: N802
 
         def __repr__(self) -> str:
             c = cls[0] if len(cls) == 1 else cls
-            representation: List[str] = [f'<ANY({c})', '>']
+            representation: list[str] = [f'<ANY({c})', '>']
 
             if message is not None:
                 representation.insert(-1, f", message='{message}'")
@@ -64,7 +68,7 @@ def ANY(*cls: Type, message: Optional[str] = None) -> object:  # noqa: N802
 
     return WrappedAny()
 
-def SOME(cls: Type, **values: Any) -> object:  # noqa: N802
+def SOME(cls: type, **values: Any) -> object:  # noqa: N802
     class WrappedSome:
         def __eq__(self, other: object) -> bool:
             if issubclass(cls, dict):
@@ -83,7 +87,7 @@ def SOME(cls: Type, **values: Any) -> object:  # noqa: N802
             return f'<SOME({cls}, {info})>'
 
     if len(values) < 1:
-        raise AttributeError(name='values', obj=str(Type))
+        raise AttributeError(name='values', obj=str(type))
     return WrappedSome()
 
 
@@ -183,9 +187,9 @@ class TestTask(GrizzlyTask):
 class TestExceptionTask(GrizzlyTask):
     __test__ = False
 
-    error_type: Type[Exception]
+    error_type: type[Exception]
 
-    def __init__(self, error_type: Type[Exception]) -> None:
+    def __init__(self, error_type: type[Exception]) -> None:
         self.error_type = error_type
 
     def __call__(self) -> grizzlytask:
@@ -196,7 +200,7 @@ class TestExceptionTask(GrizzlyTask):
         return task
 
 
-def check_arguments(kwargs: Dict[str, Any]) -> Tuple[bool, List[str]]:
+def check_arguments(kwargs: dict[str, Any]) -> tuple[bool, list[str]]:
     expected = ['request_type', 'name', 'response_time', 'response_length', 'context', 'exception']
     actual = list(kwargs.keys())
     expected.sort()
@@ -207,7 +211,7 @@ def check_arguments(kwargs: Dict[str, Any]) -> Tuple[bool, List[str]]:
     return actual == expected, diff
 
 
-def get_property_decorated_attributes(target: Any) -> Set[str]:
+def get_property_decorated_attributes(target: Any) -> set[str]:
     return {
         name
             for name, _ in inspect.getmembers(
@@ -222,8 +226,8 @@ def get_property_decorated_attributes(target: Any) -> Set[str]:
     }
 
 
-def run_command(command: List[str], env: Optional[Dict[str, str]] = None, cwd: Optional[str] = None) -> Tuple[int, List[str]]:
-    output: List[str] = []
+def run_command(command: list[str], env: Optional[dict[str, str]] = None, cwd: Optional[str] = None) -> tuple[int, list[str]]:
+    output: list[str] = []
     if env is None:
         env = os.environ.copy()
 
@@ -290,7 +294,7 @@ tee = '├── '
 last = '└── '
 
 
-def tree(dir_path: Path, prefix: str = '', ignore: Optional[List[str]] = None) -> Generator[str, None, None]:
+def tree(dir_path: Path, prefix: str = '', ignore: Optional[list[str]] = None) -> Generator[str, None, None]:
     """Recursive generator.
 
     Given a directory Path object will yield a visual tree structure line by line
@@ -332,7 +336,7 @@ class regex:
         return self._regex.pattern
 
 
-def create_mocked_fast_response_context_manager(*, content: str, headers: Optional[Dict[str, str]] = None, status_code: int = 200) -> FastResponseContextManager:
+def create_mocked_fast_response_context_manager(*, content: str, headers: Optional[dict[str, str]] = None, status_code: int = 200) -> FastResponseContextManager:
     ghc_response = MagicMock(spec=HTTPSocketPoolResponse)
     ghc_response.get_code.return_value = status_code
     ghc_response._headers_index = headers or {}

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import inspect
 import os
 import re
+import signal
 import stat
 import subprocess
 from abc import ABCMeta
@@ -256,7 +257,10 @@ def run_command(command: List[str], env: Optional[Dict[str, str]] = None, cwd: O
         with suppress(Exception):
             process.kill()
 
-    process.wait()
+        process.wait()
+
+        with suppress(Exception):
+            os.killpg(os.getpgid(process.pid), signal.SIGKILL)
 
     return process.returncode, output
 

--- a/tests/unit/test_grizzly/auth/test_aad.py
+++ b/tests/unit/test_grizzly/auth/test_aad.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta, timezone
 from enum import Enum
 from itertools import product
 from json import dumps as jsondumps
-from typing import TYPE_CHECKING, Any, Dict, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 from urllib.parse import urlparse
 
 import pytest
@@ -207,7 +207,7 @@ class TestAzureAadCredential:
                 REQUEST_5_NO_COOKIE = 501
 
             def mock_request_session(inject_error: Optional[Error] = None) -> None:  # noqa: PLR0915, C901
-                def request(self: requests.Session, method: str, url: str, name: Optional[str] = None, **kwargs: Dict[str, Any]) -> requests.Response:  # noqa: ARG001, PLR0915, C901, PLR0912
+                def request(self: requests.Session, method: str, url: str, name: Optional[str] = None, **kwargs: dict[str, Any]) -> requests.Response:  # noqa: ARG001, PLR0915, C901, PLR0912
                     response = Response()
                     response.status_code = 200
                     response.url = url
@@ -249,7 +249,7 @@ class TestAzureAadCredential:
 
                         response.headers['x-ms-request-id'] = 'aaaa-bbbb-cccc-dddd'
                     elif method == 'POST' and url.endswith('/GetCredentialType'):
-                        data: Dict[str, Any] = {
+                        data: dict[str, Any] = {
                             'FlowToken': 'xxxxxxxxxxxxxxxxxxx',
                             'apiCanary': 'zzzzzzzzzzzz',
                         }
@@ -755,7 +755,7 @@ class TestAzureAadCredential:
             with pytest.raises(AzureAadFlowError, match='fake error message'):
                 credential.get_oauth_token(resource='asdf', **pkcs)
 
-            data: Dict[str, str] = {}
+            data: dict[str, str] = {}
             if pkcs == {}:
                 data.update({
                     'scope': 'asdf',
@@ -789,7 +789,7 @@ class TestAzureAadCredential:
             assert credential.get_oauth_token(resource='asdf', **pkcs) == SOME(AccessToken, token=access_token.token)
 
             data = {}
-            headers: Dict[str, str] = {}
+            headers: dict[str, str] = {}
             if pkcs == {}:
                 data.update({'scope': 'asdf', 'tenant': 'example.com'})
             else:

--- a/tests/unit/test_grizzly/events/test_request_logger.py
+++ b/tests/unit/test_grizzly/events/test_request_logger.py
@@ -5,7 +5,7 @@ from contextlib import suppress
 from os import environ
 from pathlib import Path
 from shutil import rmtree
-from typing import TYPE_CHECKING, Callable, List
+from typing import TYPE_CHECKING, Callable
 
 import pytest
 
@@ -18,8 +18,8 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 @pytest.fixture()
-def get_log_files() -> Callable[[], List[Path]]:
-    def wrapped() -> List[Path]:
+def get_log_files() -> Callable[[], list[Path]]:
+    def wrapped() -> list[Path]:
         logs_root = Path(environ['GRIZZLY_CONTEXT_ROOT']) / 'logs'
         log_dir = environ.get('GRIZZLY_LOG_DIR', None)
         if log_dir is not None:
@@ -72,7 +72,7 @@ class TestRequestLogger:
         assert RequestLogger._remove_secrets_attribute('hello world') == 'hello world'
 
     @pytest.mark.usefixtures('get_log_files')
-    def test___call__(self, grizzly_fixture: GrizzlyFixture, get_log_files: Callable[[], List[Path]]) -> None:
+    def test___call__(self, grizzly_fixture: GrizzlyFixture, get_log_files: Callable[[], list[Path]]) -> None:
         parent = grizzly_fixture()
         parent.user.host = 'mq://mq.example.org?QueueManager=QMGR01&Channel=SYS.CONN'
 

--- a/tests/unit/test_grizzly/events/test_response_handler.py
+++ b/tests/unit/test_grizzly/events/test_response_handler.py
@@ -7,7 +7,7 @@ from json import dumps as jsondumps
 from json import loads as jsonloads
 from os import environ
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, List, Tuple
+from typing import TYPE_CHECKING, Callable
 
 import pytest
 from jinja2.filters import FILTERS
@@ -31,8 +31,8 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 @pytest.fixture()
-def get_log_files() -> Callable[[], List[Path]]:
-    def wrapped() -> List[Path]:
+def get_log_files() -> Callable[[], list[Path]]:
+    def wrapped() -> list[Path]:
         logs_root = Path(environ['GRIZZLY_CONTEXT_ROOT']) / 'logs'
         log_dir = environ.get('GRIZZLY_LOG_DIR', None)
         if log_dir is not None:
@@ -51,7 +51,7 @@ class TestResponseHandlerAction:
 
         def __call__(
             self,
-            input_context: Tuple[TransformerContentType, HandlerContextType],
+            input_context: tuple[TransformerContentType, HandlerContextType],
             user: GrizzlyUser,
         ) -> None:
             """Use super-class implementation."""
@@ -690,7 +690,7 @@ class TestResponseHandler:
         )
         request_logger_mock.reset_mock()
 
-    def test_response_handler_failure(self, grizzly_fixture: GrizzlyFixture, get_log_files: Callable[[], List[Path]]) -> None:
+    def test_response_handler_failure(self, grizzly_fixture: GrizzlyFixture, get_log_files: Callable[[], list[Path]]) -> None:
         parent = grizzly_fixture(user_type=RestApiUser)
 
         assert isinstance(parent.user, RestApiUser)

--- a/tests/unit/test_grizzly/listeners/test___init__.py
+++ b/tests/unit/test_grizzly/listeners/test___init__.py
@@ -5,7 +5,7 @@ import logging
 from contextlib import suppress
 from os import environ
 from secrets import choice
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, cast
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple, cast
 
 import pytest
 from locust.stats import RequestStats, StatsError
@@ -123,8 +123,8 @@ def test_init_master(caplog: LogCaptureFixture, grizzly_fixture: GrizzlyFixture)
 
         init_function(runner)
 
-        assert grizzly.state.locust.custom_messages == cast(Dict[str, Callable], {
-            'test_message': callback,
+        assert grizzly.state.locust.custom_messages == cast(Dict[str, Tuple[Callable, bool]], {
+            'test_message': (callback, False),
         })
     finally:
         if runner is not None:
@@ -149,8 +149,8 @@ def test_init_worker(grizzly_fixture: GrizzlyFixture) -> None:
         init_function(runner)
 
         assert environ.get('TESTDATA_PRODUCER_ADDRESS', None) == 'tcp://localhost:5555'
-        assert runner.custom_messages == cast(Dict[str, Callable], {
-            'grizzly_worker_quit': grizzly_worker_quit,
+        assert runner.custom_messages == cast(Dict[str, Tuple[Callable, bool]], {
+            'grizzly_worker_quit': (grizzly_worker_quit, False),
         })
 
         def callback(environment: Environment, msg: Message, *_args: Any, **_kwargs: Any) -> None:  # noqa: ARG001
@@ -166,9 +166,9 @@ def test_init_worker(grizzly_fixture: GrizzlyFixture) -> None:
 
         init_function(runner)
 
-        assert grizzly.state.locust.custom_messages == cast(Dict[str, Callable], {
-            'grizzly_worker_quit': grizzly_worker_quit,
-            'test_message_ack': callback_ack,
+        assert grizzly.state.locust.custom_messages == cast(Dict[str, Tuple[Callable, bool]], {
+            'grizzly_worker_quit': (grizzly_worker_quit, False),
+            'test_message_ack': (callback_ack, False),
         })
     finally:
         if runner is not None:
@@ -212,9 +212,9 @@ def test_init_local(grizzly_fixture: GrizzlyFixture) -> None:
 
         init_function(runner)
 
-        assert grizzly.state.locust.custom_messages == cast(Dict[str, Callable], {
-            'test_message': callback,
-            'test_message_ack': callback_ack,
+        assert grizzly.state.locust.custom_messages == cast(Dict[str, Tuple[Callable, bool]], {
+            'test_message': (callback, False),
+            'test_message_ack': (callback_ack, False),
         })
     finally:
         if runner is not None:

--- a/tests/unit/test_grizzly/listeners/test___init__.py
+++ b/tests/unit/test_grizzly/listeners/test___init__.py
@@ -5,7 +5,7 @@ import logging
 from contextlib import suppress
 from os import environ
 from secrets import choice
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple, cast
+from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
 import pytest
 from locust.stats import RequestStats, StatsError
@@ -123,7 +123,7 @@ def test_init_master(caplog: LogCaptureFixture, grizzly_fixture: GrizzlyFixture)
 
         init_function(runner)
 
-        assert grizzly.state.locust.custom_messages == cast(Dict[str, Tuple[Callable, bool]], {
+        assert grizzly.state.locust.custom_messages == cast(dict[str, tuple[Callable, bool]], {
             'test_message': (callback, False),
         })
     finally:
@@ -149,7 +149,7 @@ def test_init_worker(grizzly_fixture: GrizzlyFixture) -> None:
         init_function(runner)
 
         assert environ.get('TESTDATA_PRODUCER_ADDRESS', None) == 'tcp://localhost:5555'
-        assert runner.custom_messages == cast(Dict[str, Tuple[Callable, bool]], {
+        assert runner.custom_messages == cast(dict[str, tuple[Callable, bool]], {
             'grizzly_worker_quit': (grizzly_worker_quit, False),
         })
 
@@ -166,7 +166,7 @@ def test_init_worker(grizzly_fixture: GrizzlyFixture) -> None:
 
         init_function(runner)
 
-        assert grizzly.state.locust.custom_messages == cast(Dict[str, Tuple[Callable, bool]], {
+        assert grizzly.state.locust.custom_messages == cast(dict[str, tuple[Callable, bool]], {
             'grizzly_worker_quit': (grizzly_worker_quit, False),
             'test_message_ack': (callback_ack, False),
         })
@@ -212,7 +212,7 @@ def test_init_local(grizzly_fixture: GrizzlyFixture) -> None:
 
         init_function(runner)
 
-        assert grizzly.state.locust.custom_messages == cast(Dict[str, Tuple[Callable, bool]], {
+        assert grizzly.state.locust.custom_messages == cast(dict[str, tuple[Callable, bool]], {
             'test_message': (callback, False),
             'test_message_ack': (callback_ack, False),
         })

--- a/tests/unit/test_grizzly/listeners/test___init__.py
+++ b/tests/unit/test_grizzly/listeners/test___init__.py
@@ -236,6 +236,11 @@ def test_init_statistics_listener(mocker: MockerFixture, locust_fixture: LocustF
         return_value=None,
     )
 
+    mocker.patch(
+        'grizzly.listeners.influxdb.InfluxDbListener.run_user_count',
+        return_value=None,
+    )
+
     # ApplicationInsight -- short circuit
     mocker.patch(
         'grizzly.listeners.appinsights.AzureLogHandler',

--- a/tests/unit/test_grizzly/listeners/test___init__.py
+++ b/tests/unit/test_grizzly/listeners/test___init__.py
@@ -236,11 +236,6 @@ def test_init_statistics_listener(mocker: MockerFixture, locust_fixture: LocustF
         return_value=None,
     )
 
-    mocker.patch(
-        'grizzly.listeners.influxdb.InfluxDbListener.run_user_count',
-        return_value=None,
-    )
-
     # ApplicationInsight -- short circuit
     mocker.patch(
         'grizzly.listeners.appinsights.AzureLogHandler',

--- a/tests/unit/test_grizzly/listeners/test_appinsights.py
+++ b/tests/unit/test_grizzly/listeners/test_appinsights.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import pytest
 
@@ -70,14 +70,14 @@ class TestAppInsightsListener:
 
         def generate_logger_info(
             request_type: str, name: str, response_time: float, response_length: int, exception: Optional[Any] = None,
-        ) -> Callable[[logging.Handler, str, Dict[str, Any]], None]:
+        ) -> Callable[[logging.Handler, str, dict[str, Any]], None]:
             result = 'Success' if exception is None else 'Failure'
             expected_message = f'{result}: {request_type} {name} Response time: {int(round(response_time, 0))} Number of Threads: {""}'
 
             if exception is not None:
                 expected_message = f'{expected_message} Exception: {exception!s}'
 
-            def logger_info(_: logging.Handler, msg: str, extra: Dict[str, Any]) -> None:
+            def logger_info(_: logging.Handler, msg: str, extra: dict[str, Any]) -> None:
                 assert msg == expected_message
                 assert extra is not None
                 custom_dimensions = extra.get('custom_dimensions')

--- a/tests/unit/test_grizzly/listeners/test_influxdb.py
+++ b/tests/unit/test_grizzly/listeners/test_influxdb.py
@@ -7,7 +7,7 @@ import socket
 from datetime import datetime, timezone
 from json import dumps as jsondumps
 from platform import node as get_hostname
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import pytest
 from influxdb.exceptions import InfluxDBClientError
@@ -94,11 +94,11 @@ class TestInfluxDb:
 
     def test_read(self, mocker: MockerFixture) -> None:
         class ResultContainer:
-            raw: Dict[str, Any]
+            raw: dict[str, Any]
 
         influx = InfluxDb('https://influx.example.com', 1337, 'testdb').connect()
 
-        def test_query(table: str, columns: List[str]) -> None:
+        def test_query(table: str, columns: list[str]) -> None:
             def query(_instance: InfluxDBClient, _query: str) -> ResultContainer:
                 results = ResultContainer()
                 results.raw = {
@@ -150,10 +150,10 @@ class TestInfluxDb:
 
         influx.write([])
 
-        def generate_write_error(content: Dict[str, Any], code: Optional[int] = 500) -> None:
+        def generate_write_error(content: dict[str, Any], code: Optional[int] = 500) -> None:
             raw_content = jsondumps(content)
 
-            def write_error(_instance: InfluxDBClient, _values: List[Dict[str, Any]]) -> None:
+            def write_error(_instance: InfluxDBClient, _values: list[dict[str, Any]]) -> None:
                 raise InfluxDBClientError(raw_content, code)
 
             mocker.patch(
@@ -174,7 +174,7 @@ class TestInfluxDb:
             influx.write([])
 
 
-class TestInfluxDbListener:
+class TestInfluxDblistener:
     @pytest.mark.usefixtures('patch_influxdblistener')
     def test___init__(self, locust_fixture: LocustFixture, patch_influxdblistener: Callable[[], None]) -> None:
         with pytest.raises(AssertionError, match='hostname not found in'):
@@ -296,7 +296,7 @@ class TestInfluxDbListener:
         finally:
             listener._finished = False
 
-        def write(_: InfluxDb, events: List[Dict[str, Any]]) -> None:
+        def write(_: InfluxDb, events: list[dict[str, Any]]) -> None:
             assert len(events) == 1
             event = events[-1]
             assert event.get('measurement', None) == 'request'

--- a/tests/unit/test_grizzly/listeners/test_influxdb.py
+++ b/tests/unit/test_grizzly/listeners/test_influxdb.py
@@ -223,58 +223,6 @@ class TestInfluxDbListener:
         assert listener._description == 'unittesting'
 
     @pytest.mark.usefixtures('patch_influxdblistener')
-    def test_run_user_count(self, locust_fixture: LocustFixture, patch_influxdblistener: Callable[[], None], mocker: MockerFixture) -> None:
-        patch_influxdblistener()
-
-        gsleep_spy = mocker.patch('gevent.sleep', return_value=None)
-        mocker.patch(
-            'locust.runners.Runner.user_classes_count',
-            new_callable=mocker.PropertyMock,
-            side_effect=[{}, {'User1': 2, 'User2': 3}, {'User1': 2, 'User2': 3}],
-        )
-        mocker.patch(
-            'grizzly.listeners.influxdb.InfluxDbListener.finished',
-            new_callable=mocker.PropertyMock,
-            side_effect=[False, True, True, False, False, False, True, True],
-        )
-
-        listener = InfluxDbListener(
-            locust_fixture.environment,
-            'https://influx.test.com:1337/testdb?Testplan=unittest-plan&TargetEnvironment=local&ProfileName=unittest-profile&Description=unittesting',
-        )
-
-        write_spy = mocker.patch.object(listener.connection, 'write', return_value=None)
-
-        listener.run_user_count()
-
-        write_spy.assert_not_called()
-        gsleep_spy.assert_not_called()
-
-        listener.run_user_count()
-
-        gsleep_spy.assert_called_once_with(5.0)
-        gsleep_spy.reset_mock()
-
-        assert write_spy.call_count == 2
-        for i in range(2):
-            args, _ = write_spy.call_args_list[i]
-            assert len(args) == 1
-            assert len(args[0]) == 2
-            for j in range(2):
-                assert args[0][j].get('measurement', None) == 'user_count'
-                assert args[0][j].get('tags', None) == {
-                    'environment': 'local',
-                    'testplan': 'unittest-plan',
-                    'hostname': get_hostname(),
-                    'user_class': f'User{j+1}',
-                    'description': 'unittesting',
-                    'profile': 'unittest-profile',
-                }
-                assert args[0][j].get('fields', None) == {
-                    'user_count': 2 + j,
-                }
-
-    @pytest.mark.usefixtures('patch_influxdblistener')
     def test_run_events(self, locust_fixture: LocustFixture, patch_influxdblistener: Callable[[], None], mocker: MockerFixture) -> None:
         patch_influxdblistener()
 

--- a/tests/unit/test_grizzly/scenarios/test_iterator.py
+++ b/tests/unit/test_grizzly/scenarios/test_iterator.py
@@ -5,7 +5,7 @@ import logging
 from contextlib import suppress
 from os import environ
 from types import FunctionType
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Optional
 from unittest.mock import ANY
 
 import pytest
@@ -43,7 +43,7 @@ class TestIterationScenario:
 
         @templatingfilter
         def sarcasm(value: str) -> str:
-            sarcastic_value: List[str] = []
+            sarcastic_value: list[str] = []
             for index, c in enumerate(value):
                 if index % 2 == 0:
                     sarcastic_value.append(c.upper())
@@ -186,8 +186,8 @@ class TestIterationScenario:
 
         parent.consumer = TestdataConsumer(parent, identifier='test')
 
-        def mock_request(data: Optional[Dict[str, Any]]) -> None:
-            def testdata_request(self: TestdataConsumer, scenario: str) -> Optional[Dict[str, Any]]:  # noqa: ARG001
+        def mock_request(data: Optional[dict[str, Any]]) -> None:
+            def testdata_request(self: TestdataConsumer, scenario: str) -> Optional[dict[str, Any]]:  # noqa: ARG001
                 if data is None or data == {}:
                     return None
 
@@ -517,7 +517,7 @@ class TestIterationScenario:
         # always assume that spawning is complete in unit test
         parent.grizzly.state.spawning_complete = True
 
-        side_effects: List[Optional[InterruptTaskSet]] = [
+        side_effects: list[Optional[InterruptTaskSet]] = [
             InterruptTaskSet(reschedule=False),
             InterruptTaskSet(reschedule=True),
         ]

--- a/tests/unit/test_grizzly/scenarios/test_iterator.py
+++ b/tests/unit/test_grizzly/scenarios/test_iterator.py
@@ -132,39 +132,35 @@ class TestIterationScenario:
         assert isinstance(last_task, FunctionType)
         assert last_task.__name__ == 'pace'
 
-    def test_on_event_handlers(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
+    def test_on_event_handlers(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture, caplog: LogCaptureFixture) -> None:
         try:
             parent = grizzly_fixture(scenario_type=IteratorScenario)
 
-            def TestdataConsumer__init__(self: TestdataConsumer, scenario: GrizzlyScenario, address: str, identifier: str) -> None:  # noqa: N802, ARG001
-                pass
-
             mocker.patch(
                 'grizzly.testdata.communication.TestdataConsumer.__init__',
-                TestdataConsumer__init__,
+                return_value=None,
             )
 
-            def TestdataConsumer_on_stop(self: TestdataConsumer) -> None:  # noqa: N802, ARG001
-                raise StopUser
-
-            mocker.patch(
+            consumer_stop_mock = mocker.patch(
                 'grizzly.testdata.communication.TestdataConsumer.stop',
-                TestdataConsumer_on_stop,
+                return_value=None,
             )
 
             assert parent is not None
 
             mocker.patch.object(parent, 'prefetch', return_value=None)
 
-            with pytest.raises(StopUser):
+            with pytest.raises(StopUser), caplog.at_level(logging.ERROR):
                 parent.on_start()
+
+            assert caplog.messages == ['no address to testdata producer specified']
 
             environ['TESTDATA_PRODUCER_ADDRESS'] = 'localhost:5555'
 
             parent.on_start()
 
-            with pytest.raises(StopUser):
-                parent.on_stop()
+            parent.on_stop()
+            consumer_stop_mock.assert_called_once_with()
         finally:
             with suppress(KeyError):
                 del environ['TESTDATA_PRODUCER_ADDRESS']
@@ -627,7 +623,7 @@ class TestIterationScenario:
             parent.run()
 
         assert on_start.call_count == 7
-        assert on_stop.call_count == 1
+        assert on_stop.call_count == 0
         assert get_next_task.call_count == 1
         assert schedule_task.call_count == 0
         assert execute_next_task.call_count == 0
@@ -638,7 +634,7 @@ class TestIterationScenario:
             parent.run()
 
         assert on_start.call_count == 8
-        assert on_stop.call_count == 2
+        assert on_stop.call_count == 0
         assert get_next_task.call_count == 2
         assert schedule_task.call_count == 0
         assert execute_next_task.call_count == 0
@@ -654,7 +650,7 @@ class TestIterationScenario:
 
         assert parent._task_index == 20
         assert on_start.call_count == 9
-        assert on_stop.call_count == 2
+        assert on_stop.call_count == 1
         assert get_next_task.call_count == 2
         assert schedule_task.call_count == 1
         assert execute_next_task.call_count == 1
@@ -690,34 +686,18 @@ class TestIterationScenario:
             parent.run()
 
         on_stop.reset_mock()
-
-        # problems in on_stop, in handling of InterruptTaskSet
         caplog.clear()
-        on_start.side_effect = None
-        on_start.return_value = None
-        on_stop.side_effect = [RuntimeError]
-        get_next_task.side_effect = [InterruptTaskSet(reschedule=False)]
-
-        with caplog.at_level(logging.ERROR), pytest.raises(RescheduleTask):
-            parent.run()
-
-        on_stop.assert_called_once_with()
-        assert caplog.messages == ['on_stop failed']
-        caplog.clear()
-
-        on_stop.reset_mock()
 
         # problems in on_stop, in handling of StopScenario
         parent.user._scenario_state = ScenarioState.RUNNING
-        on_stop.side_effect = [RuntimeError]
+        on_stop.side_effect = None
+        on_stop.return_value = None
         get_next_task.side_effect = [StopScenario]
 
         with caplog.at_level(logging.ERROR), pytest.raises(StopUser):
             parent.run()
 
         on_stop.assert_called_once_with()
-        assert caplog.messages == ['on_stop failed']
-        caplog.clear()
 
     def test_run_tasks(self, grizzly_fixture: GrizzlyFixture, caplog: LogCaptureFixture, mocker: MockerFixture) -> None:
         class TestErrorTask(TestTask):

--- a/tests/unit/test_grizzly/scenarios/test_iterator.py
+++ b/tests/unit/test_grizzly/scenarios/test_iterator.py
@@ -697,7 +697,7 @@ class TestIterationScenario:
         with caplog.at_level(logging.ERROR), pytest.raises(StopUser):
             parent.run()
 
-        on_stop.assert_called_once_with()
+        on_stop.assert_not_called()
 
     def test_run_tasks(self, grizzly_fixture: GrizzlyFixture, caplog: LogCaptureFixture, mocker: MockerFixture) -> None:
         class TestErrorTask(TestTask):

--- a/tests/unit/test_grizzly/scenarios/test_iterator.py
+++ b/tests/unit/test_grizzly/scenarios/test_iterator.py
@@ -697,7 +697,7 @@ class TestIterationScenario:
         with caplog.at_level(logging.ERROR), pytest.raises(StopUser):
             parent.run()
 
-        on_stop.assert_not_called()
+        on_stop.assert_called_once_with()
 
     def test_run_tasks(self, grizzly_fixture: GrizzlyFixture, caplog: LogCaptureFixture, mocker: MockerFixture) -> None:
         class TestErrorTask(TestTask):

--- a/tests/unit/test_grizzly/steps/scenario/tasks/test_until.py
+++ b/tests/unit/test_grizzly/steps/scenario/tasks/test_until.py
@@ -1,7 +1,7 @@
 """Unit tests of grizzly.steps.scenario.tasks.until."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, cast
+from typing import TYPE_CHECKING, cast
 
 import pytest
 
@@ -49,7 +49,7 @@ def test_step_task_request_with_name_endpoint_until(behave_fixture: BehaveFixtur
 
     assert len(grizzly.scenario.tasks()) == 1
 
-    rows: List[Row] = []
+    rows: list[Row] = []
     rows.append(Row(['endpoint'], ['{{ variable }}']))
     rows.append(Row(['endpoint'], ['foo']))
     rows.append(Row(['endpoint'], ['bar']))
@@ -58,9 +58,9 @@ def test_step_task_request_with_name_endpoint_until(behave_fixture: BehaveFixtur
     step_task_request_with_name_endpoint_until(behave, RequestMethod.GET, 'test', '/api/{{ endpoint }} | content_type=json', '$.`this`[?status="{{ endpoint }}"]')
 
     assert len(grizzly.scenario.tasks()) == 4
-    tasks = cast(List[UntilRequestTask], grizzly.scenario.tasks())
+    tasks = cast(list[UntilRequestTask], grizzly.scenario.tasks())
 
-    templates: List[str] = []
+    templates: list[str] = []
 
     assert tasks[-1].request.endpoint == '/api/bar'
     assert tasks[-1].condition == '$.`this`[?status="bar"]'

--- a/tests/unit/test_grizzly/steps/scenario/tasks/test_write_file.py
+++ b/tests/unit/test_grizzly/steps/scenario/tasks/test_write_file.py
@@ -1,10 +1,13 @@
 """Unit tests of grizzly.steps.scenario.tasks.write_file."""
 from __future__ import annotations
 
+from base64 import b64encode
+from contextlib import suppress
+from os import environ
 from typing import TYPE_CHECKING, cast
 
 from grizzly.context import GrizzlyContext
-from grizzly.steps import step_task_write_file
+from grizzly.steps import step_task_write_file, step_task_write_temp_file
 from grizzly.tasks import WriteFileTask
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -27,3 +30,28 @@ def test_step_task_write_file(behave_fixture: BehaveFixture) -> None:
     assert isinstance(task, WriteFileTask)
     assert task.file_name == 'output/output.txt'
     assert task.content == '{{ hello }}'
+    assert not task.temp_file
+
+
+def test_step_task_write_temp_file(behave_fixture: BehaveFixture) -> None:
+    try:
+        environ['TEST_ENV'] = b64encode(b'foobar').decode()
+        behave = behave_fixture.context
+        grizzly = cast(GrizzlyContext, behave.grizzly)
+        grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
+
+        grizzly.scenario.tasks.clear()
+
+        step_task_write_temp_file(behave, '$env::TEST_ENV$', 'output/output.txt')
+
+        assert len(grizzly.scenario.tasks()) == 1
+
+        task = grizzly.scenario.tasks()[-1]
+
+        assert isinstance(task, WriteFileTask)
+        assert task.file_name == 'output/output.txt'
+        assert task.content == 'foobar'
+        assert task.temp_file
+    finally:
+        with suppress(Exception):
+            del environ['TEST_ENV']

--- a/tests/unit/test_grizzly/steps/scenario/test_response.py
+++ b/tests/unit/test_grizzly/steps/scenario/test_response.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from itertools import product
-from typing import TYPE_CHECKING, Callable, Dict, List, cast
+from typing import TYPE_CHECKING, Callable, cast
 
 import pytest
 from parse import compile
@@ -84,7 +84,7 @@ def test_step_response_save(grizzly_fixture: GrizzlyFixture, response_target: Re
     behave = grizzly_fixture.behave.context
     grizzly = grizzly_fixture.grizzly
     request = cast(RequestTask, grizzly.scenario.tasks()[0])
-    kwargs: Dict[str, Any] = {
+    kwargs: dict[str, Any] = {
         'context': behave,
         'target': response_target,
         'expression': '$.test.value',
@@ -215,7 +215,7 @@ def test_step_response_allow_status_codes_table(behave_fixture: BehaveFixture) -
 
     assert behave.exceptions == {behave.scenario.name: [ANY(AssertionError, message='step table is missing')]}
 
-    rows: List[Row] = []
+    rows: list[Row] = []
     rows.append(Row(['test'], ['-200,400']))
     rows.append(Row(['test'], ['302']))
     behave.table = Table(['test'], rows=rows)

--- a/tests/unit/test_grizzly/steps/test__helpers.py
+++ b/tests/unit/test_grizzly/steps/test__helpers.py
@@ -6,7 +6,7 @@ import os
 import shutil
 from itertools import product
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional, cast
+from typing import TYPE_CHECKING, Optional, cast
 
 import pytest
 
@@ -143,7 +143,7 @@ def test_add_request_task(grizzly_fixture: GrizzlyFixture, tmp_path_factory: Tem
         test_template = test_context / 'template.j2.json'
         test_template.write_text('{{ hello_world }}')
 
-        rows: List[Row] = []
+        rows: list[Row] = []
         rows.append(Row(['test'], ['-200,400']))
         rows.append(Row(['test'], ['302']))
         behave.table = Table(['test'], rows=rows)

--- a/tests/unit/test_grizzly/tasks/clients/test_http.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_http.py
@@ -83,7 +83,7 @@ class TestHttpClientTask:
             response.status_code = 200
 
             requests_get_spy = mocker.patch(
-                'grizzly.tasks.clients.http.requests.get',
+                'grizzly.tasks.clients.http.Session.get',
                 side_effect=[response, RuntimeError, RuntimeError, RuntimeError, RuntimeError, response, response, response, response],
             )
 
@@ -121,8 +121,6 @@ class TestHttpClientTask:
             requests_get_spy.assert_called_once_with(
                 'http://example.org',
                 headers={'x-grizzly-user': f'HttpClientTestTask::{id(task_factory)}'},
-                cookies={},
-                timeout=60,
             )
             requests_get_spy.reset_mock()
 
@@ -169,8 +167,6 @@ class TestHttpClientTask:
             requests_get_spy.assert_called_once_with(
                 'http://example.org',
                 headers={'x-grizzly-user': f'HttpClientTestTask::{id(task_factory)}'},
-                cookies={},
-                timeout=60,
             )
             requests_get_spy.reset_mock()
 
@@ -205,8 +201,6 @@ class TestHttpClientTask:
             requests_get_spy.assert_called_once_with(
                 'http://example.org',
                 headers={'x-grizzly-user': f'HttpClientTestTask::{id(task_factory)}'},
-                cookies={},
-                timeout=60,
             )
             requests_get_spy.reset_mock()
 
@@ -234,8 +228,6 @@ class TestHttpClientTask:
             requests_get_spy.assert_called_once_with(
                 'http://example.org',
                 headers={'x-grizzly-user': f'HttpClientTestTask::{id(task_factory)}'},
-                cookies={},
-                timeout=60,
             )
             requests_get_spy.reset_mock()
 
@@ -265,8 +257,6 @@ class TestHttpClientTask:
                 'https://example.org/api/test',
                 verify=True,
                 headers={'x-grizzly-user': f'HttpClientTestTask::{id(task_factory)}'},
-                cookies={},
-                timeout=60,
             )
             requests_get_spy.reset_mock()
             request_fire_spy.assert_called_once()
@@ -286,8 +276,6 @@ class TestHttpClientTask:
                 'https://example.org/api/test',
                 verify=False,
                 headers={'x-grizzly-user': f'HttpClientTestTask::{id(task_factory)}'},
-                cookies={},
-                timeout=60,
             )
             requests_get_spy.reset_mock()
             request_fire_spy.assert_called_once()
@@ -313,8 +301,6 @@ class TestHttpClientTask:
                 'https://example.org/api/test',
                 verify=True,
                 headers={'x-grizzly-user': f'HttpClientTestTask::{id(task_factory)}', 'x-test-header': 'foobar'},
-                cookies={},
-                timeout=60,
             )
             requests_get_spy.reset_mock()
             request_fire_spy.assert_called_once()

--- a/tests/unit/test_grizzly/tasks/clients/test_messagequeue.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_messagequeue.py
@@ -7,7 +7,7 @@ import sys
 from contextlib import suppress
 from os import environ
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import pytest
 import zmq.green as zmq
@@ -54,7 +54,7 @@ class TestMessageQueueClientTaskNoPymqi:
 
         assert process.returncode == 1
         assert "mq.pymqi.__name__='grizzly_extras.dummy_pymqi'" in output
-        assert 'NotImplementedError: MessageQueueClientTask could not import pymqi, have you installed IBM MQ dependencies?' in output
+        assert 'NotImplementedError: MessageQueueClientTask could not import pymqi, have you installed IBM MQ dependencies and set environment variable LD_LIBRARY_PATH?' in output
 
 
 @pytest.mark.skipif(pymqi.__name__ == 'grizzly_extras.dummy_pymqi', reason='needs native IBM MQ libraries')
@@ -317,7 +317,7 @@ class TestMessageQueueClientTask:
                 send_json_mock = mocker.patch.object(client, 'send_json')
                 recv_json_mock.side_effect = [ZMQAgain, None]
 
-                meta: Dict[str, Any] = {}
+                meta: dict[str, Any] = {}
                 with pytest.raises(AsyncMessageError, match='no response'):
                     task_factory.connect(111111, client, meta)
                 assert meta.get('response_length') == 0
@@ -438,7 +438,7 @@ class TestMessageQueueClientTask:
 
             task = task_factory()
 
-            messages: List[Any] = [{'success': True, 'message': 'hello there', 'worker': 'dddd-eeee-ffff-9999'}, ZMQAgain, None]
+            messages: list[Any] = [{'success': True, 'message': 'hello there', 'worker': 'dddd-eeee-ffff-9999'}, ZMQAgain, None]
             recv_json_mock.side_effect = messages
 
             task(parent)
@@ -636,7 +636,7 @@ class TestMessageQueueClientTask:
                 destination=None,
             )
             zmq_context = task_factory._zmq_context
-            messages: List[Any] = [{'success': True, 'message': 'hello there', 'worker': 'dddd-eeee-ffff-9999'}, {'success': True, 'payload': source}]
+            messages: list[Any] = [{'success': True, 'message': 'hello there', 'worker': 'dddd-eeee-ffff-9999'}, {'success': True, 'payload': source}]
             recv_json_mock.side_effect = messages
 
             task = task_factory()

--- a/tests/unit/test_grizzly/tasks/clients/test_servicebus.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_servicebus.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 from json import dumps as jsondumps
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -614,7 +614,7 @@ class TestServiceBusClientTask:
         state = task.get_state(parent)
         state.client = client_mock
         action_mock = mocker.MagicMock()
-        meta_mock: Dict[str, Any] = {}
+        meta_mock: dict[str, Any] = {}
         action_mock.__enter__.return_value = meta_mock
         context_mock = mocker.patch.object(task, 'action', return_value=action_mock)
 

--- a/tests/unit/test_grizzly/tasks/clients/test_servicebus.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_servicebus.py
@@ -327,6 +327,7 @@ class TestServiceBusClientTask:
         client_mock = mocker.MagicMock()
 
         async_message_request_mock = mocker.patch('grizzly.utils.async_message_request')
+        zmq_disconnect_mock = mocker.patch('grizzly.tasks.clients.servicebus.zmq_disconnect')
 
         ServiceBusClientTask.__scenario__ = grizzly_fixture.grizzly.scenario
         task = ServiceBusClientTask(
@@ -353,8 +354,7 @@ class TestServiceBusClientTask:
             'action': 'DISCONNECT',
             'context': state.context,
         })
-        client_mock.setsockopt.assert_called_once_with(zmq.LINGER, 0)
-        client_mock.close.assert_called_once_with()
+        zmq_disconnect_mock.assert_called_once_with(client_mock, destroy_context=False)
 
         assert task._state == {}
 

--- a/tests/unit/test_grizzly/tasks/clients/test_servicebus.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_servicebus.py
@@ -6,7 +6,6 @@ from json import dumps as jsondumps
 from typing import TYPE_CHECKING, Any, Dict
 
 import pytest
-import zmq.green as zmq
 
 from grizzly.tasks.clients import ServiceBusClientTask
 from grizzly.types import RequestDirection
@@ -291,7 +290,7 @@ class TestServiceBusClientTask:
 
         noop_zmq('grizzly.tasks.clients.servicebus')
 
-        async_message_request_mock = mocker.patch('grizzly.utils.async_message_request')
+        async_message_request_mock = mocker.patch('grizzly.utils.protocols.async_message_request')
 
         grizzly_fixture.grizzly.state.configuration.update({'sbns.key.secret': 'fooBARfoo'})
 
@@ -326,7 +325,7 @@ class TestServiceBusClientTask:
 
         client_mock = mocker.MagicMock()
 
-        async_message_request_mock = mocker.patch('grizzly.utils.async_message_request')
+        async_message_request_mock = mocker.patch('grizzly.utils.protocols.async_message_request')
         zmq_disconnect_mock = mocker.patch('grizzly.tasks.clients.servicebus.zmq_disconnect')
 
         ServiceBusClientTask.__scenario__ = grizzly_fixture.grizzly.scenario
@@ -366,7 +365,7 @@ class TestServiceBusClientTask:
 
         client_mock = mocker.MagicMock()
 
-        async_message_request_mock = mocker.patch('grizzly.utils.async_message_request', return_value={'message': 'foobar!'})
+        async_message_request_mock = mocker.patch('grizzly.utils.protocols.async_message_request', return_value={'message': 'foobar!'})
 
         ServiceBusClientTask.__scenario__ = grizzly_fixture.grizzly.scenario
         task = ServiceBusClientTask(
@@ -485,7 +484,7 @@ class TestServiceBusClientTask:
 
         client_mock = mocker.MagicMock()
 
-        async_message_request_mock = mocker.patch('grizzly.utils.async_message_request', return_value={'message': 'hello world!'})
+        async_message_request_mock = mocker.patch('grizzly.utils.protocols.async_message_request', return_value={'message': 'hello world!'})
 
         cls_task = type('ServiceBusClientTaskTest', (ServiceBusClientTask,), {'__scenario__': grizzly_fixture.grizzly.scenario})
 
@@ -603,7 +602,7 @@ class TestServiceBusClientTask:
 
         client_mock = mocker.MagicMock()
 
-        async_message_request_mock = mocker.patch('grizzly.utils.async_message_request', return_value={'message': 'foobar!'})
+        async_message_request_mock = mocker.patch('grizzly.utils.protocols.async_message_request', return_value={'message': 'foobar!'})
 
         cls_task = type('ServiceBusClientTaskTest', (ServiceBusClientTask,), {'__scenario__': grizzly_fixture.grizzly.scenario})
 

--- a/tests/unit/test_grizzly/tasks/test___init__.py
+++ b/tests/unit/test_grizzly/tasks/test___init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from contextlib import suppress
 from os import environ
-from typing import TYPE_CHECKING, Any, Dict, List, Tuple
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -29,10 +29,10 @@ if TYPE_CHECKING:  # pragma: no cover
 @template('string_template', 'list_template', 'dict_template')
 class DummyTask(GrizzlyTask):
     string_template: str
-    list_template: List[str]
-    dict_template: Dict[str, str]
+    list_template: list[str]
+    dict_template: dict[str, str]
 
-    def __init__(self, *args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.string_template = '{{ string_template }}'
         self.list_template = ['{{ list_template_1 }}', '{{ list_template_2 }}', '{{ list_template_3 }}']

--- a/tests/unit/test_grizzly/tasks/test_async_group.py
+++ b/tests/unit/test_grizzly/tasks/test_async_group.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 from os import environ
-from typing import TYPE_CHECKING, List, cast
+from typing import TYPE_CHECKING, cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -36,7 +36,7 @@ class TestAsyncRequestGroup:
 
     def test_add(self) -> None:
         task_factory = AsyncRequestGroupTask(name='test')
-        requests = cast(List[RequestTask], task_factory.tasks)
+        requests = cast(list[RequestTask], task_factory.tasks)
         assert len(requests) == 0
 
         task_factory.add(RequestTask(RequestMethod.GET, name='test', endpoint='/api/test'))
@@ -72,7 +72,7 @@ class TestAsyncRequestGroup:
         parent = grizzly_fixture()
 
         task_factory = AsyncRequestGroupTask(name='test-async-group')
-        requests = cast(List[RequestTask], task_factory.tasks)
+        requests = cast(list[RequestTask], task_factory.tasks)
         task = task_factory()
 
         with pytest.raises(NotImplementedError, match='tests.helpers.TestUser_001 does not inherit AsyncRequests'):

--- a/tests/unit/test_grizzly/tasks/test_request.py
+++ b/tests/unit/test_grizzly/tasks/test_request.py
@@ -1,7 +1,7 @@
 """Unit tests of grizzly.tasks.request."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING
 
 import pytest
 from jinja2 import Template
@@ -34,7 +34,7 @@ class TestRequestTaskHandlers:
         assert len(handlers.payload) == 0
 
         class TestResponseHandlerAction(ResponseHandlerAction):
-            def __call__(self, input_context: Tuple[TransformerContentType, HandlerContextType], user: GrizzlyUser) -> None:
+            def __call__(self, input_context: tuple[TransformerContentType, HandlerContextType], user: GrizzlyUser) -> None:
                 super().__call__(input_context, user)
 
         handler = TestResponseHandlerAction(expression='', match_with='')

--- a/tests/unit/test_grizzly/tasks/test_until.py
+++ b/tests/unit/test_grizzly/tasks/test_until.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from json import dumps as jsondumps
 from logging import ERROR
-from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Type
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -67,9 +67,9 @@ class TestUntilRequestTask:
         grizzly_fixture: GrizzlyFixture,
         mocker: MockerFixture,
         caplog: LogCaptureFixture,
-        meta_request_task_type: Type[GrizzlyMetaRequestTask],
-        meta_args: Tuple[Any, ...],
-        meta_kwargs: Dict[str, Any],
+        meta_request_task_type: type[GrizzlyMetaRequestTask],
+        meta_args: tuple[Any, ...],
+        meta_kwargs: dict[str, Any],
     ) -> None:
         parent = grizzly_fixture()
 
@@ -145,7 +145,7 @@ class TestUntilRequestTask:
         assert time_spy.call_count == 2
         assert request_spy.call_count == 3
         assert gsleep_spy.call_count == 3
-        call_args_list: List[Tuple[float]] = []
+        call_args_list: list[tuple[float]] = []
         for args_list in gsleep_spy.call_args_list:
             args, _ = args_list
             call_args_list.append(args)
@@ -422,9 +422,9 @@ class TestUntilRequestTask:
         self,
         grizzly_fixture: GrizzlyFixture,
         mocker: MockerFixture,
-        meta_request_task_type: Type[GrizzlyMetaRequestTask],
-        meta_args: Tuple[Any, ...],
-        meta_kwargs: Dict[str, Any],
+        meta_request_task_type: type[GrizzlyMetaRequestTask],
+        meta_args: tuple[Any, ...],
+        meta_kwargs: dict[str, Any],
     ) -> None:
         parent = grizzly_fixture()
 
@@ -449,9 +449,9 @@ class TestUntilRequestTask:
         self,
         grizzly_fixture: GrizzlyFixture,
         mocker: MockerFixture,
-        meta_request_task_type: Type[GrizzlyMetaRequestTask],
-        meta_args: Tuple[Any, ...],
-        meta_kwargs: Dict[str, Any],
+        meta_request_task_type: type[GrizzlyMetaRequestTask],
+        meta_args: tuple[Any, ...],
+        meta_kwargs: dict[str, Any],
     ) -> None:
         parent = grizzly_fixture()
 

--- a/tests/unit/test_grizzly/test_context.py
+++ b/tests/unit/test_grizzly/test_context.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import shutil
 from contextlib import suppress
 from os import environ
-from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 from unittest.mock import ANY
 
 import pytest
@@ -137,7 +137,7 @@ class TestGrizzlyContextSetup:
         grizzly = cast(GrizzlyContext, behave.grizzly)
         grizzly_setup = grizzly.setup
 
-        expected_properties: Dict[str, Optional[Tuple[Any, Any]]] = {
+        expected_properties: dict[str, Optional[tuple[Any, Any]]] = {
             'log_level': ('INFO', 'DEBUG'),
             'user_count': (None, 10),
             'spawn_rate': (None, 2),

--- a/tests/unit/test_grizzly/test_locust.py
+++ b/tests/unit/test_grizzly/test_locust.py
@@ -9,7 +9,7 @@ from os import environ
 from secrets import choice
 from socket import error as socket_error
 from types import FunctionType
-from typing import TYPE_CHECKING, Any, List, Type, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import gevent
 import pytest
@@ -232,8 +232,8 @@ def test_setup_locust_scenarios(behave_fixture: BehaveFixture, noop_zmq: NoopZmq
     (60, [14, 25, 5, 8, 4, 4]),
     (70, [17, 29, 5, 9, 5, 5]),
 ])
-def test_setup_locust_scenarios_user_distribution(behave_fixture: BehaveFixture, user_count: int, user_distribution: List[int]) -> None:
-    distribution: List[int] = [25, 42, 8, 13, 6, 6]
+def test_setup_locust_scenarios_user_distribution(behave_fixture: BehaveFixture, user_count: int, user_distribution: list[int]) -> None:
+    distribution: list[int] = [25, 42, 8, 13, 6, 6]
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
     grizzly.setup.user_count = user_count
@@ -368,7 +368,7 @@ def test_setup_environment_listeners(behave_fixture: BehaveFixture, mocker: Mock
 
     grizzly = cast(GrizzlyContext, behave.grizzly)
     grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
-    user_classes: List[Type[User]] = []
+    user_classes: list[type[User]] = []
     environment = Environment(
         user_classes=user_classes,
         shape_class=None,

--- a/tests/unit/test_grizzly/test_locust_dispatch.py
+++ b/tests/unit/test_grizzly/test_locust_dispatch.py
@@ -8,7 +8,7 @@ import time
 import unittest
 import warnings
 from operator import attrgetter
-from typing import Any, Dict, Iterator, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from locust import User
 from locust.runners import WorkerNode
@@ -17,6 +17,9 @@ from parameterized import parameterized_class
 from grizzly.locust import FixedUsersDispatcher, UsersDispatcher
 from grizzly.users import GrizzlyUser
 from tests.helpers import ANY
+
+if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Iterator
 
 _TOLERANCE = 0.025
 
@@ -2230,7 +2233,7 @@ class TestLargeScale(UsersDispatcherTestCase):
             else:
                 distribute_users = users_dispatcher._distribute_users(target_user_count=target_user_count_1m)
 
-            users_on_workers = cast(Dict[str, Dict[str, int]], distribute_users[0])
+            users_on_workers = cast(dict[str, dict[str, int]], distribute_users[0])
             delta = time.perf_counter() - ts
 
             # Because tests are run with coverage, the code will be slower.

--- a/tests/unit/test_grizzly/testdata/test___init__.py
+++ b/tests/unit/test_grizzly/testdata/test___init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from contextlib import suppress
 from os import environ
 from shutil import rmtree
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING, Optional
 
 import pytest
 
@@ -281,7 +281,7 @@ value1,value2
         ('tests.helpers.AtomicCustomVariable.foo.bar', ('tests.helpers', 'AtomicCustomVariable', 'foo', 'bar'), 'tests.helpers.AtomicCustomVariable.foo'),
         ('a.custom.struct', (None, None, 'a.custom.struct', None), 'a.custom.struct'),
     ])
-    def test_get_variable_spec_and_initialization_value(self, value: str, expected_spec: Tuple[Optional[str], Optional[str], str, Optional[str]], expected_init_value: str) -> None:
+    def test_get_variable_spec_and_initialization_value(self, value: str, expected_spec: tuple[Optional[str], Optional[str], str, Optional[str]], expected_init_value: str) -> None:
         assert GrizzlyVariables.get_variable_spec(value) == expected_spec
         assert GrizzlyVariables.get_initialization_value(value) == expected_init_value
 

--- a/tests/unit/test_grizzly/testdata/test_communication.py
+++ b/tests/unit/test_grizzly/testdata/test_communication.py
@@ -6,7 +6,7 @@ import logging
 from contextlib import suppress
 from os import environ, sep
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, cast
+from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
 import gevent
 import pytest
@@ -123,7 +123,7 @@ value3,value4
             with context.socket(zmq.REQ) as socket:
                 socket.connect(address)
 
-                def request_testdata() -> Dict[str, Any]:
+                def request_testdata() -> dict[str, Any]:
                     socket.send_json({
                         'message': 'testdata',
                         'scenario': grizzly.scenario.class_name,
@@ -131,9 +131,9 @@ value3,value4
 
                     gevent.sleep(0.1)
 
-                    return cast(Dict[str, Any], socket.recv_json())
+                    return cast(dict[str, Any], socket.recv_json())
 
-                def request_keystore(action: str, key: str, value: Optional[Any] = None) -> Dict[str, Any]:
+                def request_keystore(action: str, key: str, value: Optional[Any] = None) -> dict[str, Any]:
                     request = {
                         'message': 'keystore',
                         'action': action,
@@ -147,9 +147,9 @@ value3,value4
 
                     gevent.sleep(0.1)
 
-                    return cast(Dict[str, Any], socket.recv_json())
+                    return cast(dict[str, Any], socket.recv_json())
 
-                message: Dict[str, Any] = request_testdata()
+                message: dict[str, Any] = request_testdata()
                 assert message['action'] == 'consume'
                 data = message['data']
                 assert 'variables' in data
@@ -341,7 +341,7 @@ value3,value4
             with context.socket(zmq.REQ) as socket:
                 socket.connect(address)
 
-                def get_message_from_producer() -> Dict[str, Any]:
+                def get_message_from_producer() -> dict[str, Any]:
                     socket.send_json({
                         'message': 'testdata',
                         'scenario': grizzly.scenario.class_name,
@@ -349,9 +349,9 @@ value3,value4
 
                     gevent.sleep(0.1)
 
-                    return cast(Dict[str, Any], socket.recv_json())
+                    return cast(dict[str, Any], socket.recv_json())
 
-                message: Dict[str, Any] = get_message_from_producer()
+                message: dict[str, Any] = get_message_from_producer()
                 assert message['action'] == 'stop'
 
                 producer_thread.join(timeout=1)
@@ -631,7 +631,7 @@ class TestTestdataConsumer:
     def test_testdata(self, mocker: MockerFixture, grizzly_fixture: GrizzlyFixture, noop_zmq: NoopZmqFixture, caplog: LogCaptureFixture) -> None:
         noop_zmq('grizzly.testdata.communication')
 
-        def mock_recv_json(data: Dict[str, Any], action: Optional[str] = 'consume') -> None:
+        def mock_recv_json(data: dict[str, Any], action: Optional[str] = 'consume') -> None:
             mocker.patch(
                 'grizzly.testdata.communication.zmq.Socket.recv_json',
                 side_effect=[
@@ -788,11 +788,11 @@ class TestTestdataConsumer:
 
         consumer = TestdataConsumer(parent, identifier='test')
 
-        def echo(value: Dict[str, Any]) -> Dict[str, Any]:
+        def echo(value: dict[str, Any]) -> dict[str, Any]:
             return value
 
-        def echo_add_data(data: Any) -> Callable[[Dict[str, Any]], Dict[str, Any]]:
-            def wrapped(request: Dict[str, Any]) -> Dict[str, Any]:
+        def echo_add_data(data: Any) -> Callable[[dict[str, Any]], dict[str, Any]]:
+            def wrapped(request: dict[str, Any]) -> dict[str, Any]:
                 response = request.copy()
                 response.update({'data': data})
                 return response

--- a/tests/unit/test_grizzly/testdata/test_utils.py
+++ b/tests/unit/test_grizzly/testdata/test_utils.py
@@ -6,7 +6,7 @@ from json import dumps as jsondumps
 from json import loads as jsonloads
 from os import environ, sep
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 from jinja2.filters import FILTERS
@@ -396,7 +396,7 @@ write this "hello "{{ test }}"!"
 
 
 def test__objectify() -> None:
-    testdata: Dict[str, Any] = {
+    testdata: dict[str, Any] = {
         'AtomicIntegerIncrementer': {
             'test': 1337,
         },
@@ -499,7 +499,7 @@ def test_transform(behave_fixture: BehaveFixture, cleanup: AtomicVariableCleanup
 
     try:
         grizzly = cast(GrizzlyContext, behave.grizzly)
-        data: Dict[str, Any] = {
+        data: dict[str, Any] = {
             'AtomicIntegerIncrementer.test': 1337,
             'test': 1338,
             'AtomicCsvReader.input.test1': 'hello',

--- a/tests/unit/test_grizzly/testdata/variables/test_integer_incrementer.py
+++ b/tests/unit/test_grizzly/testdata/variables/test_integer_incrementer.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import threading
 from contextlib import suppress
 from json import dumps as jsondumps
-from typing import TYPE_CHECKING, List, Set
+from typing import TYPE_CHECKING
 
 import gevent
 import pytest
@@ -168,7 +168,7 @@ class TestAtomicIntegerIncrementer:
 
             t = AtomicIntegerIncrementer('thread_var', start_value)
 
-            values: Set[int] = set()
+            values: set[int] = set()
 
             def func1() -> None:
                 for _ in range(num_iterations):
@@ -178,7 +178,7 @@ class TestAtomicIntegerIncrementer:
                     assert value not in values
                     values.add(value)
 
-            threads: List[threading.Thread] = []
+            threads: list[threading.Thread] = []
             for _ in range(num_threads):
                 thread = threading.Thread(target=func1)
                 threads.append(thread)
@@ -202,7 +202,7 @@ class TestAtomicIntegerIncrementer:
 
             t = AtomicIntegerIncrementer('greenlet_var', start_value)
 
-            values: Set[int] = set()
+            values: set[int] = set()
 
             def exception_handler(greenlet: gevent.Greenlet) -> None:
                 message = f'func1 did not validate for {greenlet}'
@@ -216,7 +216,7 @@ class TestAtomicIntegerIncrementer:
                     assert value not in values
                     values.add(value)
 
-            greenlets: List[Greenlet] = []
+            greenlets: list[Greenlet] = []
             for _ in range(num_threads):
                 greenlet = gevent.spawn(func1)
                 greenlet.link_exception(exception_handler)

--- a/tests/unit/test_grizzly/testdata/variables/test_random_string.py
+++ b/tests/unit/test_grizzly/testdata/variables/test_random_string.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, List, Set
+from typing import TYPE_CHECKING
 
 import gevent
 import pytest
@@ -129,7 +129,7 @@ class TestAtomicRandomString:
                 message = f'func1 did not validate for {greenlet}'
                 raise RuntimeError(message)
 
-            values: Set[str] = set()
+            values: set[str] = set()
 
             def func1() -> None:
                 for _ in range(num_iterations):
@@ -138,7 +138,7 @@ class TestAtomicRandomString:
                     assert value not in values
                     values.add(value)
 
-            greenlets: List[Greenlet] = []
+            greenlets: list[Greenlet] = []
             for _ in range(num_greenlets):
                 greenlet = gevent.spawn(func1)
                 greenlet.link_exception(exception_handler)

--- a/tests/unit/test_grizzly/users/test_iothub.py
+++ b/tests/unit/test_grizzly/users/test_iothub.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any, Tuple, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 from azure.iot.device import IoTHubDeviceClient
@@ -26,7 +26,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 CONNECTION_STRING = 'HostName=some.hostname.nu;DeviceId=my_device;SharedAccessKey=xxxyyyzzz='
 
-IoTHubScenarioFixture = Tuple[IotHubUser, GrizzlyContextScenario, Environment]
+IoTHubScenarioFixture = tuple[IotHubUser, GrizzlyContextScenario, Environment]
 
 
 class MockedIotHubDeviceClient(IoTHubDeviceClient):

--- a/tests/unit/test_grizzly/users/test_messagequeue.py
+++ b/tests/unit/test_grizzly/users/test_messagequeue.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 from contextlib import suppress
 from os import environ
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Tuple, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, cast
 
 import pytest
 from zmq.error import Again as ZMQAgain
@@ -31,7 +31,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from grizzly_extras.async_message import AsyncMessageResponse
     from tests.fixtures import GrizzlyFixture, NoopZmqFixture
 
-MqScenarioFixture = Tuple[MessageQueueUser, GrizzlyContextScenario, Environment]
+MqScenarioFixture = tuple[MessageQueueUser, GrizzlyContextScenario, Environment]
 
 
 @pytest.fixture()
@@ -81,12 +81,12 @@ class TestMessageQueueUserNoPymqi:
 
         assert process.returncode == 1
         assert "mq.pymqi.__name__='grizzly_extras.dummy_pymqi'" in output
-        assert 'NotImplementedError: MessageQueueUser could not import pymqi, have you installed IBM MQ dependencies?' in output
+        assert 'NotImplementedError: MessageQueueUser could not import pymqi, have you installed IBM MQ dependencies and set environment variable LD_LIBRARY_PATH?' in output
 
 
 @pytest.mark.skipif(pymqi.__name__ == 'grizzly_extras.dummy_pymqi', reason='needs native IBM MQ libraries')
 class TestMessageQueueUser:
-    real_stuff: ClassVar[Dict[str, str]] = {
+    real_stuff: ClassVar[dict[str, str]] = {
         'username': '',
         'password': '',
         'key_file': '',
@@ -646,7 +646,7 @@ class TestMessageQueueUser:
         args, kwargs = send_json_spy.call_args_list[0]
         assert len(args) == 1
         assert kwargs == {}
-        ctx: Dict[str, str] = args[0]['context']
+        ctx: dict[str, str] = args[0]['context']
         assert ctx['endpoint'] == request.endpoint
 
         # Test with specifying queue: prefix as endpoint

--- a/tests/unit/test_grizzly/users/test_messagequeue.py
+++ b/tests/unit/test_grizzly/users/test_messagequeue.py
@@ -193,14 +193,16 @@ class TestMessageQueueUser:
         with pytest.raises(ValueError, match='MessageQueueUser_001 key file /my/key does not exist'):
             user = test_cls(environment=environment)
 
-        (grizzly_fixture.test_context / 'key.kdb').touch()
-        test_cls.__context__['auth'].update({'key_file': 'key'})
+        kdb_file = (grizzly_fixture.test_context / 'requests' / 'key.kdb')
+        kdb_file.parent.mkdir(exist_ok=True)
+        kdb_file.touch()
+        test_cls.__context__['auth'].update({'key_file': 'requests/key'})
         user = test_cls(environment=environment)
 
         assert user.am_context.get('connection', None) == 'mq.example.com(1415)'
         assert user.am_context.get('queue_manager', None) == 'QMGR01'
         assert user.am_context.get('channel', None) == 'Kanal1'
-        assert user.am_context.get('key_file', None) == (grizzly_fixture.test_context / 'key').as_posix()
+        assert user.am_context.get('key_file', None) == kdb_file.with_suffix('').as_posix()
         assert user.am_context.get('ssl_cipher', None) == 'rot13'
         assert user.am_context.get('cert_label', None) == 'some_label'
 

--- a/tests/unit/test_grizzly/users/test_messagequeue.py
+++ b/tests/unit/test_grizzly/users/test_messagequeue.py
@@ -118,7 +118,7 @@ class TestMessageQueueUser:
 
     def test_on_stop(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture, noop_zmq: NoopZmqFixture) -> None:
         noop_zmq('grizzly.users.messagequeue')
-        disconnect_mock = noop_zmq.get_mock('zmq.Socket.disconnect')
+        zmq_disconnect_mock = mocker.patch('grizzly.users.messagequeue.zmq_disconnect')
 
         parent = grizzly_fixture(host='mq://mq.example.com:1337/?QueueManager=QMGR01&Channel=Kanal1', user_type=MessageQueueUser)
 
@@ -141,7 +141,7 @@ class TestMessageQueueUser:
         request_context_spy.assert_called_once_with({'action': 'DISC', 'worker': 'foobar', 'client': id(parent.user), 'context': parent.user.am_context})
         request_context_spy.return_value.__enter__.assert_called_once_with()
         request_context_spy.return_value.__enter__.return_value.update.assert_not_called()
-        disconnect_mock.assert_called_once_with(parent.user.zmq_url)
+        zmq_disconnect_mock.assert_called_once_with(parent.user.zmq_client, destroy_context=False)
 
     def test_create(self, grizzly_fixture: GrizzlyFixture) -> None:
         parent = grizzly_fixture(host='mq://mq.example.com:1415?Channel=Kanal1&QueueManager=QMGR01', user_type=MessageQueueUser)

--- a/tests/unit/test_grizzly/users/test_restapi.py
+++ b/tests/unit/test_grizzly/users/test_restapi.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 from hashlib import sha256
 from time import time
-from typing import TYPE_CHECKING, Any, Callable, Dict, cast
+from typing import TYPE_CHECKING, Any, Callable, cast
 
 import gevent
 import pytest
@@ -317,7 +317,7 @@ class TestRestApiUser:
 
         assert parent.user.request(request) == ({'x-bar': 'foo'}, '{"foo": "bar"}')
 
-        expected_parameters: Dict[str, Any] = {
+        expected_parameters: dict[str, Any] = {
             'headers': request.metadata,
         }
 

--- a/tests/unit/test_grizzly/users/test_servicebus.py
+++ b/tests/unit/test_grizzly/users/test_servicebus.py
@@ -73,7 +73,7 @@ class TestServiceBusUser:
 
         assert issubclass(test_cls, ServiceBusUser)
 
-        zmq_client_disconnect_spy = mocker.patch('grizzly.users.servicebus.zmq.Socket.disconnect', return_value=None)
+        zmq_client_disconnect_spy = mocker.patch('grizzly.users.servicebus.zmq_disconnect', return_value=None)
         disconnect_spy = mocker.patch('grizzly.users.servicebus.ServiceBusUser.disconnect', return_value=None)
         mocker.patch('grizzly.users.servicebus.ServiceBusUser.say_hello', return_value=None)
 
@@ -85,7 +85,7 @@ class TestServiceBusUser:
 
         user.on_stop()
 
-        zmq_client_disconnect_spy.assert_called_once_with(ServiceBusUser.zmq_url)
+        zmq_client_disconnect_spy.assert_called_once_with(user.zmq_client, destroy_context=False)
         assert user.zmq_client.type == zmq.REQ
         assert disconnect_spy.call_count == 0
 

--- a/tests/unit/test_grizzly/utils/__init__.py
+++ b/tests/unit/test_grizzly/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Commence initialization of module."""

--- a/tests/unit/test_grizzly/utils/test___init__.py
+++ b/tests/unit/test_grizzly/utils/test___init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from os import environ
 from types import FunctionType
-from typing import TYPE_CHECKING, Type, cast
+from typing import TYPE_CHECKING, cast
 
 import pytest
 from locust import TaskSet
@@ -53,7 +53,7 @@ class TestModuleLoader:
             user_class_name = 'RestApiUser'
             for user_package in ['', 'grizzly.users.', 'grizzly.users.restapi.']:
                 user_class_name_value = f'{user_package}{user_class_name}'
-                user_class = cast(Type[GrizzlyUser], ModuleLoader[GrizzlyUser].load('grizzly.users', user_class_name_value))  # type: ignore[redundant-cast]
+                user_class = cast(type[GrizzlyUser], ModuleLoader[GrizzlyUser].load('grizzly.users', user_class_name_value))  # type: ignore[redundant-cast]
                 user_class.__scenario__ = test_context.scenario
                 user_class.host = test_context.scenario.context['host']
                 assert user_class.__module__ == 'grizzly.users.restapi'
@@ -123,7 +123,7 @@ def test_create_user_class_type(behave_fixture: BehaveFixture) -> None:  # noqa:
     user_class_type_1.host = 'http://localhost:8000'
 
     assert issubclass(user_class_type_1, (RestApiUser, GrizzlyUser))
-    user_class_type_1 = cast(Type[RestApiUser], user_class_type_1)
+    user_class_type_1 = cast(type[RestApiUser], user_class_type_1)
     assert user_class_type_1.__name__ == f'grizzly.users.RestApiUser_{scenario.identifier}'
     assert user_class_type_1.weight == 1
     assert user_class_type_1.fixed_count == 0
@@ -220,7 +220,7 @@ def test_create_user_class_type(behave_fixture: BehaveFixture) -> None:  # noqa:
     user_class_type_2.host = 'http://localhost:8001'
 
     assert issubclass(user_class_type_2, (RestApiUser, GrizzlyUser))
-    user_class_type_2 = cast(Type[RestApiUser], user_class_type_2)
+    user_class_type_2 = cast(type[RestApiUser], user_class_type_2)
     assert user_class_type_2.__name__ == f'RestApiUser_{scenario.identifier}'
     assert user_class_type_2.weight == 1
     assert user_class_type_2.fixed_count == 100

--- a/tests/unit/test_grizzly/utils/test___init__.py
+++ b/tests/unit/test_grizzly/utils/test___init__.py
@@ -1,9 +1,7 @@
 """Unit tests of grizzly.utils."""
 from __future__ import annotations
 
-import logging
-from datetime import datetime, timedelta, timezone
-from os import environ, utime
+from os import environ
 from types import FunctionType
 from typing import TYPE_CHECKING, Type, cast
 
@@ -17,8 +15,6 @@ from grizzly.types import RequestMethod
 from grizzly.users import GrizzlyUser, RestApiUser
 from grizzly.utils import (
     ModuleLoader,
-    async_message_request_wrapper,
-    check_mq_client_logs,
     create_scenario_class_type,
     create_user_class_type,
     fail_direct,
@@ -34,13 +30,8 @@ from grizzly.utils import (
 )
 
 if TYPE_CHECKING:  # pragma: no cover
-    from _pytest.logging import LogCaptureFixture
-    from _pytest.tmpdir import TempPathFactory
-    from pytest_mock import MockerFixture
-
     from grizzly.types.behave import Context
-    from grizzly_extras.async_message import AsyncMessageRequest
-    from tests.fixtures import BehaveFixture, GrizzlyFixture
+    from tests.fixtures import BehaveFixture
 
 
 class TestModuleLoader:
@@ -474,226 +465,6 @@ def test_parse_timespan() -> None:
         'minutes': 5,
         'seconds': -6,
     }
-
-
-def test_check_mq_client_logs(behave_fixture: BehaveFixture, tmp_path_factory: TempPathFactory, mocker: MockerFixture, caplog: LogCaptureFixture) -> None:  # noqa: PLR0915
-    context = behave_fixture.context
-    test_context = tmp_path_factory.mktemp('test_context')
-
-    amq_error_dir = test_context / 'IBM' / 'MQ' / 'data' / 'errors'
-    amq_error_dir.mkdir(parents=True, exist_ok=True)
-
-    test_logger = logging.getLogger('test_grizzly_print_stats')
-
-    mocker.patch('grizzly.utils.Path.expanduser', return_value=amq_error_dir)
-    mocker.patch('grizzly.locust.stats_logger', test_logger)
-
-    # context.started not set
-    with caplog.at_level(logging.INFO):
-        check_mq_client_logs(context)
-
-    assert len(caplog.messages) == 0
-
-    # no error files
-    context.started = datetime.now().astimezone()
-    with caplog.at_level(logging.INFO):
-        check_mq_client_logs(context)
-
-    assert len(caplog.messages) == 0
-
-    # one AMQERR*.LOG file, previous run
-    amqerr_log_file_1 = amq_error_dir / 'AMQERR01.LOG'
-    amqerr_log_file_1.write_text("""10/13/22 06:13:07 - Process(6437.52) User(mqm) Program(amqrmppa)
-                    Host(mq.example.io) Installation(Installation1)
-                    VRMF(9.2.1.0) QMgr(QM1)
-                    Time(2022-10-13T06:13:07.215Z)
-                    CommentInsert1(CLIENT.CONN)
-                    CommentInsert2(1111)
-                    CommentInsert3(1.2.3.4)
-
-AMQ9999E: Channel 'CLIENT.CONN' to host '1.2.3.4' ended abnormally.
-
-EXPLANATION:
------ amqccisa.c : 10957 ------------------------------------------------------
-""")
-
-    with caplog.at_level(logging.INFO):
-        check_mq_client_logs(context)
-
-    assert len(caplog.messages) == 0
-
-    entry_date_1 = (datetime.now() + timedelta(hours=1)).astimezone(tz=timezone.utc)
-
-    # one AMQERR*.LOG file, one entry
-    with amqerr_log_file_1.open('a') as fd:
-        fd.write(f"""{entry_date_1.strftime('%m/%d/%y %H:%M:%S')} - Process(6437.52) User(mqm) Program(amqrmppa)
-                    Host(mq.example.io) Installation(Installation1)
-                    VRMF(9.2.1.0) QMgr(QM1)
-                    Time({entry_date_1.strftime('%Y-%m-%dT%H:%M:%S.000Z')})
-                    CommentInsert1(CLIENT.CONN)
-                    CommentInsert2(1111)
-                    CommentInsert3(1.2.3.4)
-
-AMQ9999E: Channel 'CLIENT.CONN' to host '1.2.3.4' ended abnormally.
-
-EXPLANATION:
------ amqccisa.c : 10957 ------------------------------------------------------
-""")
-
-    with caplog.at_level(logging.INFO):
-        check_mq_client_logs(context)
-
-    assert len(caplog.messages) == 6
-
-    assert caplog.messages[0] == 'AMQ error log entries:'
-    assert caplog.messages[1].strip() == 'Timestamp (UTC)      Message'
-    assert caplog.messages[3].strip() == f"{entry_date_1.strftime('%Y-%m-%d %H:%M:%S')}  AMQ9999E: Channel 'CLIENT.CONN' to host '1.2.3.4' ended abnormally."
-    assert (
-        caplog.messages[2]
-        == caplog.messages[4]
-        == (
-            '--------------------|-----------------------------------------------------------------'
-            '----------------------------------------------------------------------------'
-        )
-    )
-    assert caplog.messages[5] == ''
-
-    caplog.clear()
-
-    # two AMQERR files, one with no data, one FDC file, old
-    old_date = entry_date_1 - timedelta(hours=2)
-
-    amqerr_log_file_2 = amq_error_dir / 'AMQERR99.LOG'
-    amqerr_log_file_2.touch()
-
-    amqerr_fdc_file_1 = amq_error_dir / 'AMQ6150.0.FDC'
-    amqerr_fdc_file_1.touch()
-    utime(amqerr_fdc_file_1, (old_date.timestamp(), old_date.timestamp()))
-
-    with caplog.at_level(logging.INFO):
-        check_mq_client_logs(context)
-
-    assert len(caplog.messages) == 6
-
-    assert caplog.messages[0] == 'AMQ error log entries:'
-    assert caplog.messages[1].strip() == 'Timestamp (UTC)      Message'
-    assert caplog.messages[3].strip() == f"{entry_date_1.strftime('%Y-%m-%d %H:%M:%S')}  AMQ9999E: Channel 'CLIENT.CONN' to host '1.2.3.4' ended abnormally."
-    assert (
-        caplog.messages[2]
-        == caplog.messages[4]
-        == (
-            '--------------------|-----------------------------------------------------------------'
-            '----------------------------------------------------------------------------'
-        )
-    )
-    assert caplog.messages[5] == ''
-
-    caplog.clear()
-
-    # two AMQERR files, both with valid data. three FDC files, one old
-    entry_date_2 = entry_date_1 + timedelta(minutes=23)
-    amqerr_log_file_2.write_text(f"""{entry_date_2.strftime('%m/%d/%y %H:%M:%S')} - Process(6437.52) User(mqm) Program(amqrmppa)
-                    Host(mq.example.io) Installation(Installation1)
-                    VRMF(9.2.1.0) QMgr(QM1)
-                    Time({entry_date_2.strftime('%Y-%m-%dT%H:%M:%S.000Z')})
-                    CommentInsert1(CLIENT.CONN)
-                    CommentInsert2(1111)
-                    CommentInsert3(1.2.3.4)
-
-AMQ1234E: dude, what did you do?!
-
-EXPLANATION:
------ amqccisa.c : 10957 ------------------------------------------------------
-""")
-    amqerr_fdc_file_2 = amq_error_dir / 'AMQ1234.1.FDC'
-    amqerr_fdc_file_2.touch()
-    utime(amqerr_fdc_file_2, (entry_date_2.timestamp(), entry_date_2.timestamp()))
-
-    amqerr_fdc_file_3 = amq_error_dir / 'AMQ4321.9.FDC'
-    amqerr_fdc_file_3.touch()
-    entry_date_3 = entry_date_2 + timedelta(minutes=73)
-    utime(amqerr_fdc_file_3, (entry_date_3.timestamp(), entry_date_3.timestamp()))
-
-    with caplog.at_level(logging.INFO):
-        check_mq_client_logs(context)
-
-    assert len(caplog.messages) == 14
-
-    assert caplog.messages.index('AMQ error log entries:') == 0
-    assert caplog.messages.index('AMQ FDC files:') == 7
-
-    amqerr_log_entries = caplog.messages[0:6]
-    assert len(amqerr_log_entries) == 6
-
-    assert amqerr_log_entries[1].strip() == 'Timestamp (UTC)      Message'
-    assert (
-        amqerr_log_entries[2]
-        == amqerr_log_entries[5]
-        == (
-            '--------------------|-----------------------------------------------------------------'
-            '----------------------------------------------------------------------------'
-        )
-    )
-    assert amqerr_log_entries[3].strip() == f"{entry_date_1.strftime('%Y-%m-%d %H:%M:%S')}  AMQ9999E: Channel 'CLIENT.CONN' to host '1.2.3.4' ended abnormally."
-    assert amqerr_log_entries[4].strip() == f'{entry_date_2.strftime("%Y-%m-%d %H:%M:%S")}  AMQ1234E: dude, what did you do?!'
-
-    amqerr_fdc_files = caplog.messages[7:-1]
-    assert len(amqerr_fdc_files) == 6
-
-    assert amqerr_fdc_files[1].strip() == 'Timestamp (UTC)      File'
-    assert (
-        amqerr_fdc_files[2]
-        == amqerr_fdc_files[5]
-        == (
-            '--------------------|-----------------------------------------------------------------'
-            '----------------------------------------------------------------------------'
-        )
-    )
-
-    assert amqerr_fdc_files[3].strip() == f'{entry_date_2.strftime("%Y-%m-%d %H:%M:%S")}  {amqerr_fdc_file_2}'
-    assert amqerr_fdc_files[4].strip() == f'{entry_date_3.strftime("%Y-%m-%d %H:%M:%S")}  {amqerr_fdc_file_3}'
-
-
-def test_async_message_request_wrapper(grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
-    parent = grizzly_fixture()
-
-    async_message_request_mock = mocker.patch('grizzly.utils.async_message_request', return_value=None)
-    client_mock = mocker.MagicMock()
-
-    # nothing to render
-    request: AsyncMessageRequest = {
-        'context': {
-            'endpoint': 'hello world',
-        },
-    }
-
-    async_message_request_wrapper(parent, client_mock, request)
-
-    request.update({'client': id(parent.user)})
-
-    async_message_request_mock.assert_called_once_with(client_mock, request)
-    async_message_request_mock.reset_mock()
-
-    del request['client']
-
-    # template to render, variable not set
-    request = {
-        'context': {
-            'endpoint': 'hello {{ world }}!',
-        },
-    }
-
-    async_message_request_wrapper(parent, client_mock, request)
-
-    async_message_request_mock.assert_called_once_with(client_mock, {'context': {'endpoint': 'hello !'}, 'client': id(parent.user)})
-    async_message_request_mock.reset_mock()
-
-    # template to render, variable set
-    parent.user._context['variables'].update({'world': 'foobar'})
-
-    async_message_request_wrapper(parent, client_mock, request)
-
-    async_message_request_mock.assert_called_once_with(client_mock, {'context': {'endpoint': 'hello foobar!'}, 'client': id(parent.user)})
 
 
 def test_safe_del() -> None:

--- a/tests/unit/test_grizzly/utils/test_protocols.py
+++ b/tests/unit/test_grizzly/utils/test_protocols.py
@@ -7,6 +7,7 @@ from http.cookiejar import Cookie, CookieJar
 from os import utime
 from typing import TYPE_CHECKING
 
+import pytest
 import zmq.green as zmq
 
 from grizzly.utils.protocols import (
@@ -283,12 +284,10 @@ def test_http_populate_cookiejar() -> None:
 
     assert len(monster.cookiejar) == len(cookies)
 
-    for cookie, (name, value) in zip(monster.cookiejar, cookies.items()):
+    for cookie in monster.cookiejar:
         assert cookie == SOME(
             Cookie,
             version=0,
-            name=name,
-            value=value,
             port=None,
             port_specified=False,
             domain='example.net',
@@ -303,6 +302,18 @@ def test_http_populate_cookiejar() -> None:
             comment_url=None,
             _rest={},
         )
+
+    # order cannot be guaranteed
+    for name, value in cookies.items():
+        found = False
+
+        for cookie in monster.cookiejar:
+            if cookie.name == name and cookie.value == value:
+                found = True
+                break
+
+        if not found:
+            pytest.fail(f'cookie {name}={value} not found')
 
 
 def test_zmq_disconnect(mocker: MockerFixture) -> None:

--- a/tests/unit/test_grizzly/utils/test_protocols.py
+++ b/tests/unit/test_grizzly/utils/test_protocols.py
@@ -1,0 +1,321 @@
+"""Unit tests of grizzly.protocols."""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from http.cookiejar import Cookie, CookieJar
+from os import utime
+from typing import TYPE_CHECKING
+
+import zmq.green as zmq
+
+from grizzly.utils.protocols import (
+    async_message_request_wrapper,
+    http_populate_cookiejar,
+    mq_client_logs,
+    zmq_disconnect,
+)
+from tests.helpers import SOME
+
+if TYPE_CHECKING:  # pragma: no cover
+    from _pytest.logging import LogCaptureFixture
+    from _pytest.tmpdir import TempPathFactory
+    from pytest_mock import MockerFixture
+
+    from grizzly_extras.async_message import AsyncMessageRequest
+    from tests.fixtures import BehaveFixture, GrizzlyFixture
+
+
+def test_check_mq_client_logs(behave_fixture: BehaveFixture, tmp_path_factory: TempPathFactory, mocker: MockerFixture, caplog: LogCaptureFixture) -> None:  # noqa: PLR0915
+    context = behave_fixture.context
+    test_context = tmp_path_factory.mktemp('test_context')
+
+    amq_error_dir = test_context / 'IBM' / 'MQ' / 'data' / 'errors'
+    amq_error_dir.mkdir(parents=True, exist_ok=True)
+
+    test_logger = logging.getLogger('test_grizzly_print_stats')
+
+    mocker.patch('grizzly.utils.Path.expanduser', return_value=amq_error_dir)
+    mocker.patch('grizzly.locust.stats_logger', test_logger)
+
+    # context.started not set
+    with caplog.at_level(logging.INFO):
+        mq_client_logs(context)
+
+    assert len(caplog.messages) == 0
+
+    # no error files
+    context.started = datetime.now().astimezone()
+    with caplog.at_level(logging.INFO):
+        mq_client_logs(context)
+
+    assert len(caplog.messages) == 0
+
+    # one AMQERR*.LOG file, previous run
+    amqerr_log_file_1 = amq_error_dir / 'AMQERR01.LOG'
+    amqerr_log_file_1.write_text("""10/13/22 06:13:07 - Process(6437.52) User(mqm) Program(amqrmppa)
+                    Host(mq.example.io) Installation(Installation1)
+                    VRMF(9.2.1.0) QMgr(QM1)
+                    Time(2022-10-13T06:13:07.215Z)
+                    CommentInsert1(CLIENT.CONN)
+                    CommentInsert2(1111)
+                    CommentInsert3(1.2.3.4)
+
+AMQ9999E: Channel 'CLIENT.CONN' to host '1.2.3.4' ended abnormally.
+
+EXPLANATION:
+----- amqccisa.c : 10957 ------------------------------------------------------
+""")
+
+    with caplog.at_level(logging.INFO):
+        mq_client_logs(context)
+
+    assert len(caplog.messages) == 0
+
+    entry_date_1 = (datetime.now() + timedelta(hours=1)).astimezone(tz=timezone.utc)
+
+    # one AMQERR*.LOG file, one entry
+    with amqerr_log_file_1.open('a') as fd:
+        fd.write(f"""{entry_date_1.strftime('%m/%d/%y %H:%M:%S')} - Process(6437.52) User(mqm) Program(amqrmppa)
+                    Host(mq.example.io) Installation(Installation1)
+                    VRMF(9.2.1.0) QMgr(QM1)
+                    Time({entry_date_1.strftime('%Y-%m-%dT%H:%M:%S.000Z')})
+                    CommentInsert1(CLIENT.CONN)
+                    CommentInsert2(1111)
+                    CommentInsert3(1.2.3.4)
+
+AMQ9999E: Channel 'CLIENT.CONN' to host '1.2.3.4' ended abnormally.
+
+EXPLANATION:
+----- amqccisa.c : 10957 ------------------------------------------------------
+""")
+
+    with caplog.at_level(logging.INFO):
+        mq_client_logs(context)
+
+    assert len(caplog.messages) == 6
+
+    assert caplog.messages[0] == 'AMQ error log entries:'
+    assert caplog.messages[1].strip() == 'Timestamp (UTC)      Message'
+    assert caplog.messages[3].strip() == f"{entry_date_1.strftime('%Y-%m-%d %H:%M:%S')}  AMQ9999E: Channel 'CLIENT.CONN' to host '1.2.3.4' ended abnormally."
+    assert (
+        caplog.messages[2]
+        == caplog.messages[4]
+        == (
+            '--------------------|-----------------------------------------------------------------'
+            '----------------------------------------------------------------------------'
+        )
+    )
+    assert caplog.messages[5] == ''
+
+    caplog.clear()
+
+    # two AMQERR files, one with no data, one FDC file, old
+    old_date = entry_date_1 - timedelta(hours=2)
+
+    amqerr_log_file_2 = amq_error_dir / 'AMQERR99.LOG'
+    amqerr_log_file_2.touch()
+
+    amqerr_fdc_file_1 = amq_error_dir / 'AMQ6150.0.FDC'
+    amqerr_fdc_file_1.touch()
+    utime(amqerr_fdc_file_1, (old_date.timestamp(), old_date.timestamp()))
+
+    with caplog.at_level(logging.INFO):
+        mq_client_logs(context)
+
+    assert len(caplog.messages) == 6
+
+    assert caplog.messages[0] == 'AMQ error log entries:'
+    assert caplog.messages[1].strip() == 'Timestamp (UTC)      Message'
+    assert caplog.messages[3].strip() == f"{entry_date_1.strftime('%Y-%m-%d %H:%M:%S')}  AMQ9999E: Channel 'CLIENT.CONN' to host '1.2.3.4' ended abnormally."
+    assert (
+        caplog.messages[2]
+        == caplog.messages[4]
+        == (
+            '--------------------|-----------------------------------------------------------------'
+            '----------------------------------------------------------------------------'
+        )
+    )
+    assert caplog.messages[5] == ''
+
+    caplog.clear()
+
+    # two AMQERR files, both with valid data. three FDC files, one old
+    entry_date_2 = entry_date_1 + timedelta(minutes=23)
+    amqerr_log_file_2.write_text(f"""{entry_date_2.strftime('%m/%d/%y %H:%M:%S')} - Process(6437.52) User(mqm) Program(amqrmppa)
+                    Host(mq.example.io) Installation(Installation1)
+                    VRMF(9.2.1.0) QMgr(QM1)
+                    Time({entry_date_2.strftime('%Y-%m-%dT%H:%M:%S.000Z')})
+                    CommentInsert1(CLIENT.CONN)
+                    CommentInsert2(1111)
+                    CommentInsert3(1.2.3.4)
+
+AMQ1234E: dude, what did you do?!
+
+EXPLANATION:
+----- amqccisa.c : 10957 ------------------------------------------------------
+""")
+    amqerr_fdc_file_2 = amq_error_dir / 'AMQ1234.1.FDC'
+    amqerr_fdc_file_2.touch()
+    utime(amqerr_fdc_file_2, (entry_date_2.timestamp(), entry_date_2.timestamp()))
+
+    amqerr_fdc_file_3 = amq_error_dir / 'AMQ4321.9.FDC'
+    amqerr_fdc_file_3.touch()
+    entry_date_3 = entry_date_2 + timedelta(minutes=73)
+    utime(amqerr_fdc_file_3, (entry_date_3.timestamp(), entry_date_3.timestamp()))
+
+    with caplog.at_level(logging.INFO):
+        mq_client_logs(context)
+
+    assert len(caplog.messages) == 14
+
+    assert caplog.messages.index('AMQ error log entries:') == 0
+    assert caplog.messages.index('AMQ FDC files:') == 7
+
+    amqerr_log_entries = caplog.messages[0:6]
+    assert len(amqerr_log_entries) == 6
+
+    assert amqerr_log_entries[1].strip() == 'Timestamp (UTC)      Message'
+    assert (
+        amqerr_log_entries[2]
+        == amqerr_log_entries[5]
+        == (
+            '--------------------|-----------------------------------------------------------------'
+            '----------------------------------------------------------------------------'
+        )
+    )
+    assert amqerr_log_entries[3].strip() == f"{entry_date_1.strftime('%Y-%m-%d %H:%M:%S')}  AMQ9999E: Channel 'CLIENT.CONN' to host '1.2.3.4' ended abnormally."
+    assert amqerr_log_entries[4].strip() == f'{entry_date_2.strftime("%Y-%m-%d %H:%M:%S")}  AMQ1234E: dude, what did you do?!'
+
+    amqerr_fdc_files = caplog.messages[7:-1]
+    assert len(amqerr_fdc_files) == 6
+
+    assert amqerr_fdc_files[1].strip() == 'Timestamp (UTC)      File'
+    assert (
+        amqerr_fdc_files[2]
+        == amqerr_fdc_files[5]
+        == (
+            '--------------------|-----------------------------------------------------------------'
+            '----------------------------------------------------------------------------'
+        )
+    )
+
+    assert amqerr_fdc_files[3].strip() == f'{entry_date_2.strftime("%Y-%m-%d %H:%M:%S")}  {amqerr_fdc_file_2}'
+    assert amqerr_fdc_files[4].strip() == f'{entry_date_3.strftime("%Y-%m-%d %H:%M:%S")}  {amqerr_fdc_file_3}'
+
+
+def test_async_message_request_wrapper(grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
+    parent = grizzly_fixture()
+
+    async_message_request_mock = mocker.patch('grizzly.utils.protocols.async_message_request', return_value=None)
+    client_mock = mocker.MagicMock()
+
+    # nothing to render
+    request: AsyncMessageRequest = {
+        'context': {
+            'endpoint': 'hello world',
+        },
+    }
+
+    async_message_request_wrapper(parent, client_mock, request)
+
+    request.update({'client': id(parent.user)})
+
+    async_message_request_mock.assert_called_once_with(client_mock, request)
+    async_message_request_mock.reset_mock()
+
+    del request['client']
+
+    # template to render, variable not set
+    request = {
+        'context': {
+            'endpoint': 'hello {{ world }}!',
+        },
+    }
+
+    async_message_request_wrapper(parent, client_mock, request)
+
+    async_message_request_mock.assert_called_once_with(client_mock, {'context': {'endpoint': 'hello !'}, 'client': id(parent.user)})
+    async_message_request_mock.reset_mock()
+
+    # template to render, variable set
+    parent.user._context['variables'].update({'world': 'foobar'})
+
+    async_message_request_wrapper(parent, client_mock, request)
+
+    async_message_request_mock.assert_called_once_with(client_mock, {'context': {'endpoint': 'hello foobar!'}, 'client': id(parent.user)})
+
+
+def test_http_populate_cookiejar() -> None:
+    class CookieMonster:
+        cookiejar: CookieJar
+
+        def __init__(self) -> None:
+            self.cookiejar = CookieJar()
+
+    monster = CookieMonster()
+
+    # add cookie that should be discarded
+    monster.cookiejar.set_cookie(Cookie(
+        version=0,
+        name='leftovers',
+        value='crumbles',
+        port=None,
+        port_specified=False,
+        domain='example.com',
+        domain_specified=True,
+        domain_initial_dot=False,
+        path='/',
+        path_specified=True,
+        secure=False,
+        expires=None,
+        discard=False,
+        comment=None,
+        comment_url=None,
+        rest={},
+    ))
+
+    assert len(monster.cookiejar) == 1
+
+    cookies = {'foo': 'bar', 'bar': 'foo', 'hello': 'world'}
+
+    http_populate_cookiejar(monster, cookies, url='https://example.net')
+
+    assert len(monster.cookiejar) == len(cookies)
+
+    for cookie, (name, value) in zip(monster.cookiejar, cookies.items()):
+        assert cookie == SOME(
+            Cookie,
+            version=0,
+            name=name,
+            value=value,
+            port=None,
+            port_specified=False,
+            domain='example.net',
+            domain_specified=True,
+            domain_initial_dot=False,
+            path='/',
+            path_specified=True,
+            secure=True,
+            expires=None,
+            discard=False,
+            comment=None,
+            comment_url=None,
+            _rest={},
+        )
+
+
+def test_zmq_disconnect(mocker: MockerFixture) -> None:
+    socket = mocker.MagicMock(spec=zmq.Socket)
+
+    zmq_disconnect(socket, destroy_context=False)
+
+    socket.close.assert_called_once_with(linger=0)
+    socket.context.destroy.assert_not_called()
+    socket.reset_mock()
+
+    zmq_disconnect(socket, destroy_context=True)
+
+    socket.close.assert_called_once_with(linger=0)
+    socket.context.destroy.assert_called_once_with(linger=0)
+    socket.reset_mock()

--- a/tests/unit/test_grizzly_extras/async_message/mq/test___init__.py
+++ b/tests/unit/test_grizzly_extras/async_message/mq/test___init__.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 from contextlib import suppress
 from os import environ
-from typing import TYPE_CHECKING, Any, ClassVar, List, Tuple, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import pytest
 
@@ -42,7 +42,7 @@ def test_no_pymqi_dependencies() -> None:
     output = out.decode()
     assert process.returncode == 1
     assert "mq.pymqi.__name__='grizzly_extras.dummy_pymqi'" in output
-    assert 'NotImplementedError: AsyncMessageQueueHandler could not import pymqi, have you installed IBM MQ dependencies?' in output
+    assert 'NotImplementedError: AsyncMessageQueueHandler could not import pymqi, have you installed IBM MQ dependencies and set environment variable LD_LIBRARY_PATH?' in output
 
 
 @pytest.mark.skipif(pymqi.__name__ == 'grizzly_extras.dummy_pymqi', reason='needs native IBM MQ libraries')
@@ -593,7 +593,7 @@ class TestAsyncMessageQueueHandler:
         # Mocked representation of pymqi Queue
         class DummyQueue:
             # List with (comp, reason) errors to raise, -1 in comp means skip
-            error_list: ClassVar[List[Tuple[int, int]]] = []
+            error_list: ClassVar[list[tuple[int, int]]] = []
 
             def __init__(self) -> None:
                 self.msg_ix = 0

--- a/tests/unit/test_grizzly_extras/async_message/test_daemon.py
+++ b/tests/unit/test_grizzly_extras/async_message/test_daemon.py
@@ -192,7 +192,6 @@ def test_router(mocker: MockerFixture, caplog: LogCaptureFixture) -> None:
 
     create_context_mock.assert_called_once_with(
         ANY(),
-        1,
     )
 
     assert context_mock.socket.call_count == 2

--- a/tests/unit/test_grizzly_extras/async_message/test_daemon.py
+++ b/tests/unit/test_grizzly_extras/async_message/test_daemon.py
@@ -165,7 +165,7 @@ def test_worker(mocker: MockerFixture, caplog: LogCaptureFixture, scheme: str, i
 
     integration_close_spy.assert_called_once_with()
 
-    assert caplog.messages[-1] == 'stopping'
+    assert caplog.messages[1:] == ['stopping', 'stopped']
 
 
 def test_router(mocker: MockerFixture, caplog: LogCaptureFixture) -> None:

--- a/tests/unit/test_grizzly_extras/async_message/test_daemon.py
+++ b/tests/unit/test_grizzly_extras/async_message/test_daemon.py
@@ -5,7 +5,7 @@ from importlib import reload
 from itertools import cycle
 from json import dumps as jsondumps
 from signal import SIGINT
-from typing import TYPE_CHECKING, Any, List, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 import zmq.green as zmq
@@ -44,7 +44,7 @@ def test_worker(mocker: MockerFixture, caplog: LogCaptureFixture, scheme: str, i
     context_mock.socket.return_value = worker_mock
 
     def mock_recv_multipart(message: AsyncMessageRequest) -> None:
-        def build_zmq_message(_message: AsyncMessageRequest) -> List[bytes]:
+        def build_zmq_message(_message: AsyncMessageRequest) -> list[bytes]:
             worker = cast(str, _message.get('worker', ''))
             return [
                 worker.encode(),

--- a/tests/unit/test_grizzly_extras/test_novella.py
+++ b/tests/unit/test_grizzly_extras/test_novella.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from shutil import rmtree
-from typing import Dict, List, Union
+from typing import Union
 
 import pytest
 
@@ -85,7 +85,7 @@ def test_make_human_readable() -> None:
 def test__create_nav_node(tmp_path_factory: pytest.TempPathFactory) -> None:
     test_context = tmp_path_factory.mktemp('test_context')
     try:
-        target: List[Union[str, Dict[str, str]]] = []
+        target: list[Union[str, dict[str, str]]] = []
         # <!-- not a file
         node = test_context
         _create_nav_node(target, 'foobar', node)
@@ -196,7 +196,7 @@ class TestGrizzlyMarkdown:
 
     def test__get_tokens(self) -> None:
         tokens = GrizzlyMarkdown._get_tokens('<a href="')
-        assert [token.string for token in tokens] == ['utf-8', '<', 'a', 'href', '=', '"', '', '']
+        assert [token.string for token in tokens][:5] == ['utf-8', '<', 'a', 'href', '=']
 
     def test_get_step_expression_from_code_block(self) -> None:
         code_block = """

--- a/tests/unit/test_grizzly_extras/test_transformer.py
+++ b/tests/unit/test_grizzly_extras/test_transformer.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from json import dumps as jsondumps
 from json import loads as jsonloads
 from json.decoder import JSONDecodeError
-from typing import TYPE_CHECKING, Any, Callable, List
+from typing import TYPE_CHECKING, Any, Callable
 
 import pytest
 from lxml import etree as XML  # noqa: N812
@@ -36,7 +36,7 @@ class TestTransformer:
                 return super().validate(expression)
 
             @classmethod
-            def parser(cls, expression: str) -> Callable[[Any], List[str]]:
+            def parser(cls, expression: str) -> Callable[[Any], list[str]]:
                 return super().parser(expression)
 
 
@@ -52,7 +52,7 @@ class TestTransformer:
 
 class Testtransformer:
     def test___init__(self) -> None:
-        transformers: List[transformer] = []
+        transformers: list[transformer] = []
 
         assert TransformerContentType.get_vector() == (False, True)
 
@@ -82,7 +82,7 @@ class Testtransformer:
                 return True
 
             @classmethod
-            def parser(cls, expression: str) -> Callable[[Any], List[str]]:
+            def parser(cls, expression: str) -> Callable[[Any], list[str]]:
                 return super().parser(expression)
 
         transform_spy = mocker.spy(DummyTransformer, 'transform')

--- a/tests/webserver.py
+++ b/tests/webserver.py
@@ -236,6 +236,14 @@ def app_oauth2_token(tenant: str) -> FlaskResponse:
     return jsonify({'access_token': auth_expected['token']})
 
 
+@app.route('/write', methods=['POST'])
+def app_write() -> FlaskResponse:
+    response = jsonify({'success': True})
+    response.status_code = 204
+
+    return response
+
+
 @app.errorhandler(404)
 def catch_all(_: Any) -> FlaskResponse:
     return jsonify({}, status=200)

--- a/tests/webserver.py
+++ b/tests/webserver.py
@@ -6,7 +6,7 @@ import json
 import logging
 from pathlib import Path
 from time import perf_counter
-from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Type, cast
+from typing import TYPE_CHECKING, Any, Literal, Optional, cast
 
 import gevent
 from flask import Flask, jsonify, request
@@ -23,7 +23,7 @@ if TYPE_CHECKING:  # pragma: no cover
 logger = logging.getLogger('webserver')
 
 
-auth_expected: Optional[Dict[str, Any]] = None
+auth_expected: Optional[dict[str, Any]] = None
 
 
 app = Flask('webserver')
@@ -161,7 +161,7 @@ def app_sleep(seconds: str) -> FlaskResponse:
     return response
 
 
-app_request_count: Dict[str, int] = {}
+app_request_count: dict[str, int] = {}
 
 
 @app.route('/api/until/reset')
@@ -266,11 +266,11 @@ class Webserver:
         return cast(int, self._web_server.server_port)
 
     @property
-    def auth(self) -> Optional[Dict[str, Any]]:
+    def auth(self) -> Optional[dict[str, Any]]:
         return auth_expected
 
     @auth.setter
-    def auth(self, value: Optional[Dict[str, Any]]) -> None:
+    def auth(self, value: Optional[dict[str, Any]]) -> None:
         global auth_expected  # noqa: PLW0603
         auth_expected = value
 
@@ -290,7 +290,7 @@ class Webserver:
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
+        exc_type: Optional[type[BaseException]],
         exc: Optional[BaseException],
         traceback: Optional[TracebackType],
     ) -> Literal[True]:


### PR DESCRIPTION
another shot at trying to solve the "no heartbeat received from master in `XX` seconds" problem, with some additional fixes needed.

locust is upgraded to 2.29.2.dev23, but must be changed to the official release before releasing a new package of grizzly.

the new locust version includes events for useful information if the "no heartbeat" problem occurs again.

`HttpClientTask` replaced `requests` with `geventhttpclient`, as the next step for removing `requests` completly.

improvements related to:
- closing zmq sockets
- handling of `ServiceBusError` 
- new step to create temporary files that only lives during the time of a test

bug fixes:
- provide OTP secret to `AzureAadCredential`
- possibility to use relative paths for `key_file` (MQ certificate files)