### PR TITLE
fix for "Aborting test can fail when running distributed with MQ"

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,6 +24,7 @@
                     "*.j2.json": "jinja-json",
                     "*.j2.xml": "jinja-xml"
                 },
+                "mypy-type-checker.ignorePatterns": ["tests/project/**/*.py"],
                 "mypy.targets": [
                     "grizzly/",
                     "grizzly_extras/",

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -21,7 +21,7 @@ jobs:
       id: setup-python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
         cache: 'pip'
 
     - name: install python dependencies
@@ -52,7 +52,7 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12']
         runs-on: ['ubuntu-latest']
         include:
-          - python-version: '3.11'
+          - python-version: '3.12'
             runs-on: windows-latest
 
     env:
@@ -118,7 +118,7 @@ jobs:
       id: setup-python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
         cache: 'pip'
 
     - name: setup environment
@@ -195,7 +195,7 @@ jobs:
       id: setup-python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
         cache: 'pip'
 
     - name: install python dependencies
@@ -225,7 +225,7 @@ jobs:
       id: setup-python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
         cache: 'pip'
 
     - name: setup node

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
       id: setup-python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
         cache: 'pip'
 
     - name: setup node

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ docs/_site
 docs/_build*
 grizzly/__version__.py
 .pytest_tmp/
+tests/project

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-	"python.pythonPath": "/usr/local/bin/python"
-}

--- a/grizzly/auth/__init__.py
+++ b/grizzly/auth/__init__.py
@@ -197,7 +197,7 @@ class refresh_token(Generic[P]):
 
 def render(client: GrizzlyHttpAuthClient) -> None:
     variables = cast(dict[str, Any], client._context.get('variables', {}))
-    host = client.grizzly.state.jinja2.from_string(client.host).render(**variables)
+    host = client._scenario.jinja2.from_string(client.host).render(**variables)
     parsed = urlparse(host)
 
     client.host = f'{parsed.scheme}://{parsed.netloc}'

--- a/grizzly/behave.py
+++ b/grizzly/behave.py
@@ -154,7 +154,7 @@ def after_feature(context: Context, feature: Feature, *_args: Any, **_kwargs: An
                 buffer.append(f'Scenario: {scenario_name}')
             else:
                 buffer.append('')
-            buffer.extend([indent(str(exception), '    ') for exception in exceptions])
+            buffer.extend([str(exception).replace('\n', '\n    ') for exception in exceptions])
             buffer.append('')
 
         failure_summary = indent('\n'.join(buffer), '    ')

--- a/grizzly/events/request_logger.py
+++ b/grizzly/events/request_logger.py
@@ -9,8 +9,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 from urllib.parse import urlparse, urlunparse
 
-from jinja2 import Template
-
 from grizzly.events import GrizzlyEventHandler
 from grizzly.utils import normalize
 from grizzly_extras.transformer import JsonBytesEncoder
@@ -182,7 +180,7 @@ class RequestLogger(GrizzlyEventHandler):
         name = normalize(name)
 
         log_name = f'{name}.{log_date.strftime("%Y%m%dT%H%M%S%f")}.log'
-        contents = Template(LOG_FILE_TEMPLATE).render(**variables)
+        contents = self.user._scenario.jinja2.from_string(LOG_FILE_TEMPLATE).render(**variables)
 
         log_file = self.log_dir / log_name
         log_file.write_text(contents)

--- a/grizzly/events/response_handler.py
+++ b/grizzly/events/response_handler.py
@@ -54,7 +54,7 @@ class ResponseHandlerAction(ABC):
 
         """
         input_content_type, input_payload = input_context
-        j2env = self.grizzly.state.jinja2
+        j2env = user._scenario.jinja2
         rendered_expression = j2env.from_string(self.expression).render(user.context_variables)
         rendered_match_with = j2env.from_string(self.match_with).render(user.context_variables)
         rendered_expected_matches = int(j2env.from_string(self.expected_matches).render(user.context_variables))

--- a/grizzly/exceptions.py
+++ b/grizzly/exceptions.py
@@ -64,7 +64,7 @@ class StepError(AssertionError):
         self.error = error
 
     def __str__(self) -> str:
-        return '\n'.join([f'{self.step.keyword} {self.step.name} # {self.step.location}', f'    ! {self.error!s}'])
+        return '\n'.join([f'    {self.step.keyword} {self.step.name} # {self.step.location}', f'    ! {self.error!s}'])
 
 
 class ScenarioError(AssertionError):
@@ -73,7 +73,7 @@ class ScenarioError(AssertionError):
         self.error = error
 
     def __str__(self) -> str:
-        return f'    ! {self.error!s}'
+        return f'! {self.error!s}'
 
 
 class FeatureError(Exception):
@@ -81,4 +81,4 @@ class FeatureError(Exception):
         self.error = error
 
     def __str__(self) -> str:
-        return f'    {self.error!s}'
+        return f'{self.error!s}'

--- a/grizzly/exceptions.py
+++ b/grizzly/exceptions.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 __all__ = [
     'StopUser',
+    'AsyncMessageAbort',
 ]
 
 
@@ -27,7 +28,7 @@ class RestartScenario(Exception):  # noqa: N818
     pass
 
 
-class StopScenario(AsyncMessageAbort):
+class StopScenario(Exception):  # noqa: N818
     pass
 
 class AssertionErrors(Exception):  # noqa: N818

--- a/grizzly/scenarios/__init__.py
+++ b/grizzly/scenarios/__init__.py
@@ -70,7 +70,7 @@ class GrizzlyScenario(SequentialTaskSet):
         else:
             render_variables = {**self.user._context['variables'], **variables}
 
-        return self.grizzly.state.jinja2.from_string(template).render(**render_variables)
+        return self.user._scenario.jinja2.from_string(template).render(**render_variables)
 
     def prefetch(self) -> None:
         """Do not prefetch anything by default."""

--- a/grizzly/tasks/clients/__init__.py
+++ b/grizzly/tasks/clients/__init__.py
@@ -29,6 +29,7 @@ from time import perf_counter as time
 from typing import TYPE_CHECKING, Any, ClassVar, Optional, cast, final
 from urllib.parse import unquote, urlparse
 
+from grizzly.exceptions import AsyncMessageAbort, StopUser
 from grizzly.tasks import GrizzlyMetaRequestTask, grizzlytask, template
 from grizzly.testdata.utils import resolve_variable
 from grizzly.types import GrizzlyResponse, RequestDirection, RequestType
@@ -261,7 +262,7 @@ class ClientTask(GrizzlyMetaRequestTask):
             if exception is None:
                 exception = meta.get('exception')
 
-            if not suppress or exception is not None:
+            if not suppress or (exception is not None and not isinstance(exception, AsyncMessageAbort)):
                 parent.user.environment.events.request.fire(
                     request_type=RequestType.CLIENT_TASK(),
                     name=name,
@@ -292,6 +293,9 @@ class ClientTask(GrizzlyMetaRequestTask):
                     )})
 
                 log_file.write_text(jsondumps(request_log, indent=2))
+
+            if isinstance(exception, AsyncMessageAbort):
+                raise StopUser
 
             if exception is not None and parent.user._scenario.failure_exception is not None:
                 parent.logger.error('%s raising %s', self.__class__.__name__, parent.user._scenario.failure_exception)

--- a/grizzly/tasks/clients/messagequeue.py
+++ b/grizzly/tasks/clients/messagequeue.py
@@ -151,7 +151,7 @@ class MessageQueueClientTask(ClientTask):
         self._zmq_context.destroy(linger=0)
 
     def create_context(self) -> None:  # noqa: PLR0915
-        endpoint = cast(str, resolve_variable(self.grizzly, self.endpoint, guess_datatype=False))
+        endpoint = cast(str, resolve_variable(self.grizzly, self.endpoint, guess_datatype=False, env=self._scenario.jinja2))
         parsed = urlparse(endpoint)
 
         if (parsed.scheme or 'none') not in ['mq', 'mqs']:

--- a/grizzly/tasks/request.py
+++ b/grizzly/tasks/request.py
@@ -180,9 +180,6 @@ class RequestTask(GrizzlyMetaRequestTask):
         if self._source is None:
             return None
 
-        if self._template is None:
-            self._template = self.grizzly.state.jinja2.from_string(self._source)
-
         return self._template
 
     def add_metadata(self, key: str, value: str) -> None:

--- a/grizzly/tasks/until.py
+++ b/grizzly/tasks/until.py
@@ -48,6 +48,7 @@ from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 from gevent import sleep as gsleep
 
 from grizzly.exceptions import StopScenario
+from grizzly.testdata.utils import resolve_variable
 from grizzly.types import RequestType
 from grizzly.types.locust import StopUser
 from grizzly.utils import safe_del
@@ -93,7 +94,7 @@ class UntilRequestTask(GrizzlyTask):
             self.condition, until_arguments = split_value(self.condition)
 
             if '{{' in until_arguments and '}}' in until_arguments:
-                until_arguments = self.grizzly.state.jinja2.from_string(until_arguments).render(**self.grizzly.state.variables)
+                until_arguments = cast(str, resolve_variable(self.grizzly, until_arguments, guess_datatype=False))
 
             arguments = parse_arguments(until_arguments)
 

--- a/grizzly/testdata/ast.py
+++ b/grizzly/testdata/ast.py
@@ -142,11 +142,13 @@ def get_template_variables(grizzly: GrizzlyContext) -> dict[str, set[str]]:
 
     # check except between declared variables and variables found in templates
     missing_in_templates = {variable for variable in declared_variables if variable not in found_variables} - template_variables.__conditional__
-    assert len(missing_in_templates) == 0, f'variables has been declared, but cannot be found in templates:\n{"\n".join(sorted(missing_in_templates))}'
+    missing_in_templates_message = '\n'.join(sorted(missing_in_templates))
+    assert len(missing_in_templates) == 0, f'variables has been declared, but cannot be found in templates:\n{missing_in_templates_message}'
 
     # check if any variable hasn't first been declared
     missing_declarations = {variable for variable in found_variables if variable not in declared_variables} - template_variables.__conditional__ - template_variables.__local__
-    assert len(missing_declarations) == 0, f'variables has been found in templates, but have not been declared:\n{"\n".join(sorted(missing_declarations))}'
+    missing_declarations_message = '\n'.join(sorted(missing_declarations))
+    assert len(missing_declarations) == 0, f'variables has been found in templates, but have not been declared:\n{missing_declarations_message}'
 
     # only include variables that has been declared, filtering out conditional ones
     filtered_template_variables: dict[str, set[str]] = {}

--- a/grizzly/testdata/ast.py
+++ b/grizzly/testdata/ast.py
@@ -142,11 +142,11 @@ def get_template_variables(grizzly: GrizzlyContext) -> dict[str, set[str]]:
 
     # check except between declared variables and variables found in templates
     missing_in_templates = {variable for variable in declared_variables if variable not in found_variables} - template_variables.__conditional__
-    assert len(missing_in_templates) == 0, f'variables has been declared, but cannot be found in templates: {",".join(missing_in_templates)}'
+    assert len(missing_in_templates) == 0, f'variables has been declared, but cannot be found in templates:\n{"\n".join(sorted(missing_in_templates))}'
 
     # check if any variable hasn't first been declared
     missing_declarations = {variable for variable in found_variables if variable not in declared_variables} - template_variables.__conditional__ - template_variables.__local__
-    assert len(missing_declarations) == 0, f'variables has been found in templates, but have not been declared: {",".join(missing_declarations)}'
+    assert len(missing_declarations) == 0, f'variables has been found in templates, but have not been declared:\n{"\n".join(sorted(missing_declarations))}'
 
     # only include variables that has been declared, filtering out conditional ones
     filtered_template_variables: dict[str, set[str]] = {}

--- a/grizzly/testdata/ast.py
+++ b/grizzly/testdata/ast.py
@@ -5,7 +5,6 @@ import itertools
 import logging
 from typing import TYPE_CHECKING, Any, Optional
 
-from jinja2 import Environment as Jinja2Environment
 from jinja2 import nodes as j2
 
 from . import GrizzlyVariables
@@ -130,7 +129,7 @@ def get_template_variables(grizzly: GrizzlyContext) -> dict[str, set[str]]:
             del templates[_scenario]
 
     # first find all variables in all templates grouped by scenario
-    template_variables = _parse_templates(templates, env=grizzly.state.jinja2)
+    template_variables = _parse_templates(templates)
 
     found_variables = AstVariableNameSet()
     for variable in itertools.chain(*template_variables.values()):
@@ -200,7 +199,7 @@ def walk_attr(node: j2.Getattr) -> list[str]:
     return attributes
 
 
-def _parse_templates(templates: dict[GrizzlyContextScenario, set[str]], *, env: Jinja2Environment) -> AstVariableSet:  # noqa: C901, PLR0915
+def _parse_templates(templates: dict[GrizzlyContextScenario, set[str]]) -> AstVariableSet:  # noqa: C901, PLR0915
     variables = AstVariableSet()
 
     def _getattr(node: j2.Node) -> Generator[list[str], None, None]:  # noqa: C901, PLR0912, PLR0915
@@ -349,7 +348,7 @@ def _parse_templates(templates: dict[GrizzlyContextScenario, set[str]], *, env: 
             # json.dumps escapes quote (") causing it to be \\", which inturn causes problems for jinja
             template_normalized = template.replace('\\"', "'")
 
-            parsed = env.parse(template_normalized)
+            parsed = scenario.jinja2.parse(template_normalized)
 
             for body in getattr(parsed, 'body', []):
                 for attributes in _getattr(body):

--- a/grizzly_extras/async_message/daemon.py
+++ b/grizzly_extras/async_message/daemon.py
@@ -120,9 +120,7 @@ class Worker:
                 }
 
             if response is None and self.integration is not None:
-                self.logger.debug('send request to handler')
                 response = self.integration.handle(request)
-                self.logger.debug('got response from handler')
 
             response_proto = [
                 request_proto[0],
@@ -132,6 +130,7 @@ class Worker:
 
             self.socket.send_multipart(response_proto)
 
+        self.logger.info('stopping')
         if self.integration is not None:
             self.integration.close()
 
@@ -187,8 +186,6 @@ def router(run_daemon: Event) -> None:  # noqa: C901, PLR0915
 
             if not socks:
                 continue
-
-            logger.debug('got sockets, run_daemon=%r', run_daemon.is_set())
 
             logger.debug("i'm alive!")
 
@@ -355,4 +352,4 @@ def main() -> int:
     except KeyboardInterrupt:
         return 1
     else:
-        return process.exitcode or 1
+        return process.exitcode or 0

--- a/grizzly_extras/async_message/daemon.py
+++ b/grizzly_extras/async_message/daemon.py
@@ -79,7 +79,6 @@ class Worker:
             self.logger.debug("i'm alive! run_daemon=%r, received=%r", self._event.is_set(), received)
 
             if not request_proto:
-                self.logger.error('empty msg')
                 continue
 
             request = cast(

--- a/grizzly_extras/async_message/daemon.py
+++ b/grizzly_extras/async_message/daemon.py
@@ -4,10 +4,11 @@ Based on ZMQ PUB/SUB, where each request type is handled to a worker which is fo
 from __future__ import annotations
 
 import logging
+from concurrent import futures
 from json import dumps as jsondumps
 from json import loads as jsonloads
 from signal import SIGINT, SIGTERM, Signals, signal
-from threading import Thread
+from threading import Event
 from time import sleep
 from typing import TYPE_CHECKING, Optional, Union, cast
 from urllib.parse import urlparse
@@ -15,6 +16,7 @@ from uuid import uuid4
 
 import setproctitle as proc
 import zmq.green as zmq
+from typing_extensions import Literal
 
 from grizzly_extras.transformer import JsonBytesEncoder
 
@@ -27,10 +29,9 @@ from . import (
 )
 
 if TYPE_CHECKING:  # pragma: no cover
-    from types import FrameType
+    from types import FrameType, TracebackType
 
 abort: bool = False
-
 
 def signal_handler(signum: Union[int, Signals], _frame: Optional[FrameType]) -> None:
     logger = logging.getLogger('signal_handler')
@@ -46,6 +47,115 @@ signal(SIGTERM, signal_handler)
 signal(SIGINT, signal_handler)
 
 
+class ThreadPoolExecutor(futures.ThreadPoolExecutor):
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> Literal[False]:
+        self.shutdown(wait=False)
+        return False
+
+
+class Worker:
+    logger: logging.Logger
+    identity: str
+    context: zmq.Context
+
+    integration: Optional[AsyncMessageHandler]
+
+    _event: Event
+
+    def __init__(self, context: zmq.Context, identity: str) -> None:
+        self.logger = logging.getLogger(f'worker::{identity}')
+        self.identity = identity
+        self.context = context
+        self.integration = None
+
+        self._event = Event()
+
+    def stop(self) -> None:
+        self._event.set()
+
+    def run(self) -> None:
+        self.socket = self.context.socket(zmq.REQ)
+        self.socket.setsockopt_string(zmq.IDENTITY, self.identity)
+        self.socket.connect('inproc://workers')
+        self.socket.send_string(LRU_READY)
+
+        while not self._event.is_set():
+            received = False
+            try:
+                request_proto = self.socket.recv_multipart(flags=zmq.NOBLOCK)
+                received = True
+            except zmq.Again:
+                sleep(0.1)
+                continue
+
+            self.logger.debug("i'm alive! abort=%r, received=%r", abort, received)
+
+            if not request_proto:
+                self.logger.error('empty msg')
+                continue
+
+            request = cast(
+                AsyncMessageRequest,
+                jsonloads(request_proto[-1].decode()),
+            )
+
+            response: Optional[AsyncMessageResponse] = None
+
+            try:
+                if request['worker'] != self.identity:
+                    message = f'got {request["worker"]}, expected {self.identity}'
+                    raise RuntimeError(message)
+
+                if self.integration is None:
+                    integration_url = request.get('context', {}).get('url', None)
+                    if integration_url is None:
+                        message = 'no url found in request context'
+                        raise RuntimeError(message)
+
+                    parsed = urlparse(integration_url)
+
+                    if parsed.scheme in ['mq', 'mqs']:
+                        from .mq import AsyncMessageQueueHandler
+                        self.integration = AsyncMessageQueueHandler(self.identity)
+                    elif parsed.scheme == 'sb':
+                        from .sb import AsyncServiceBusHandler
+                        self.integration = AsyncServiceBusHandler(self.identity)
+                    else:
+                        message = f'integration for {parsed.scheme}:// is not implemented'
+                        raise RuntimeError(message)
+            except Exception as e:
+                response = {
+                    'worker': self.identity,
+                    'response_time': 0,
+                    'success': False,
+                    'message': str(e),
+                }
+
+            if response is None and self.integration is not None:
+                self.logger.debug('send request to handler')
+                response = self.integration.handle(request)
+                self.logger.debug('got response from handler')
+
+            response_proto = [
+                request_proto[0],
+                SPLITTER_FRAME,
+                jsondumps(response, cls=JsonBytesEncoder).encode(),
+            ]
+
+            self.socket.send_multipart(response_proto)
+
+        if self.integration is not None:
+            self.integration.close()
+
+        self.socket.close()
+        self.logger.info('stopped')
+
+
 def create_router_socket(context: zmq.Context) -> zmq.Socket:
     socket = cast(zmq.Socket, context.socket(zmq.ROUTER))
     socket.setsockopt(zmq.LINGER, 0)
@@ -54,7 +164,7 @@ def create_router_socket(context: zmq.Context) -> zmq.Socket:
     return socket
 
 
-def router() -> None:  # noqa: C901, PLR0912, PLR0915
+def router() -> None:  # noqa: C901, PLR0915
     logger = logging.getLogger('router')
     proc.setproctitle('grizzly-async-messaged')  # set appl name on ibm mq
     logger.debug('starting')
@@ -70,207 +180,154 @@ def router() -> None:  # noqa: C901, PLR0912, PLR0915
     poller.register(frontend, zmq.POLLIN)
     poller.register(backend, zmq.POLLIN)
 
-    worker_threads: list[Thread] = []
+    workers: dict[str, tuple[futures.Future, Worker]] = {}
 
-    def spawn_worker() -> None:
-        identity = str(uuid4())
+    with ThreadPoolExecutor() as executor:
+        def spawn_worker() -> None:
+            identity = str(uuid4())
 
-        thread = Thread(target=worker, args=(context, identity))
-        thread.daemon = True
-        worker_threads.append(thread)
-        thread.start()
-        logger.info('spawned worker %s (%d)', identity, thread.ident)
+            worker = Worker(context, identity)
 
-    workers_available: list[str] = []
+            future = executor.submit(worker.run)
+            workers.update({identity: (future, worker)})
+            logger.info('spawned worker %s', identity)
 
-    client_worker_map: dict[str, str] = {}
+        workers_available: list[str] = []
 
-    spawn_worker()
+        client_worker_map: dict[str, str] = {}
 
-    worker_id: str
+        spawn_worker()
 
-    while not abort:
-        socks = dict(poller.poll(timeout=1000))
+        worker_id: str
 
-        if not socks:
-            continue
+        while not abort:
+            socks = dict(poller.poll(timeout=1000))
 
-        logger.debug("i'm alive!")
-
-        if socks.get(backend) == zmq.POLLIN:
-            logger.debug('polling backend')
-            try:
-                backend_response = backend.recv_multipart(flags=zmq.NOBLOCK)
-            except zmq.Again:
-                sleep(0.1)
+            if not socks:
                 continue
 
-            if not backend_response:
-                continue
+            logger.debug("i'm alive!")
 
-            reply = backend_response[2:]
-            worker_id = backend_response[0].decode()
+            if socks.get(backend) == zmq.POLLIN:
+                logger.debug('polling backend')
+                try:
+                    backend_response = backend.recv_multipart(flags=zmq.NOBLOCK)
+                except zmq.Again:
+                    sleep(0.1)
+                    continue
 
-            if reply[0] != LRU_READY.encode():
-                frontend.send_multipart(reply)
-                logger.debug('forwarding backend response from %s', worker_id)
-            else:
-                logger.info('worker %s ready', worker_id)
-                workers_available.append(worker_id)
+                if not backend_response:
+                    continue
 
-        if socks.get(frontend) == zmq.POLLIN:
-            logger.debug('polling frontend')
-            try:
-                msg = frontend.recv_multipart(flags=zmq.NOBLOCK)
-            except zmq.Again:
-                sleep(0.1)
-                continue
+                logger.debug('backend_response: %r', backend_response)
+                reply = backend_response[2:]
+                worker_id = backend_response[0].decode()
 
-            request_id = msg[0]
-            payload = cast(AsyncMessageRequest, jsonloads(msg[-1].decode()))
-
-            request_worker_id = payload.get('worker', None)
-            request_client_id = payload.get('client', None)
-            client_key: Optional[str] = None
-
-            logger.debug('request_worker_id=%r (%r), request_client_id=%r (%r)', request_worker_id, type(request_worker_id), request_client_id, type(request_client_id))
-
-            if request_client_id is not None:
-                integration_url = payload.get('context', {}).get('url', None)
-                parsed = urlparse(integration_url)
-                scheme = parsed.scheme
-                if isinstance(scheme, bytes):
-                    scheme = scheme.decode()
-
-                client_key = f'{request_client_id}::{scheme}'
-
-            if request_worker_id is None and client_key is not None:
-                request_worker_id = client_worker_map.get(client_key)
-
-            if request_worker_id is None:
-                worker_id = workers_available.pop()
-
-                if client_key is not None:
-                    client_worker_map.update({client_key: worker_id})
-
-                payload['worker'] = worker_id
-                logger.info('assigned worker %s to %s', worker_id, client_key)
-
-                if len(workers_available) == 0:
-                    logger.debug('spawning an additional worker, for next client')
-                    spawn_worker()
-            else:
-                logger.debug('%s is assigned %s', request_client_id, request_worker_id)
-                worker_id = request_worker_id
-
-                if payload.get('worker', None) is None:
-                    payload['worker'] = worker_id
-
-            request = jsondumps(payload).encode()
-            backend_request = [worker_id.encode(), SPLITTER_FRAME, request_id, SPLITTER_FRAME, request]
-            backend.send_multipart(backend_request)
-
-    logger.info('stopping')
-    for worker_thread in worker_threads:
-        logger.debug('waiting for %d', worker_thread.ident)
-        worker_thread.join()
-
-    try:
-        context.destroy(linger=0)
-    except:
-        logger.exception('failed to destroy zmq context')
-
-    logger.info('stopped')
-
-
-def worker(context: zmq.Context, identity: str) -> None:  # noqa: PLR0912, PLR0915
-    logger = logging.getLogger(f'worker::{identity}')
-    worker = context.socket(zmq.REQ)
-
-    worker.setsockopt_string(zmq.IDENTITY, identity)
-    worker.connect('inproc://workers')
-    worker.send_string(LRU_READY)
-
-    integration: Optional[AsyncMessageHandler] = None
-
-    while not abort:
-        try:
-            request_proto = worker.recv_multipart(flags=zmq.NOBLOCK)
-        except zmq.Again:
-            sleep(0.1)
-            continue
-
-        logger.debug("i'm alive! abort=%r", abort)
-
-        if not request_proto:
-            logger.error('empty msg')
-            continue
-
-        request = cast(
-            AsyncMessageRequest,
-            jsonloads(request_proto[-1].decode()),
-        )
-
-        response: Optional[AsyncMessageResponse] = None
-
-        try:
-            if request['worker'] != identity:
-                message = f'got {request["worker"]}, expected {identity}'
-                raise RuntimeError(message)
-
-            if integration is None:
-                integration_url = request.get('context', {}).get('url', None)
-                if integration_url is None:
-                    message = 'no url found in request context'
-                    raise RuntimeError(message)
-
-                parsed = urlparse(integration_url)
-
-                if parsed.scheme in ['mq', 'mqs']:
-                    from .mq import AsyncMessageQueueHandler
-                    integration = AsyncMessageQueueHandler(identity)
-                elif parsed.scheme == 'sb':
-                    from .sb import AsyncServiceBusHandler
-                    integration = AsyncServiceBusHandler(identity)
+                if reply[0] != LRU_READY.encode():
+                    logger.debug('sending %r', reply)
+                    frontend.send_multipart(reply)
+                    logger.debug('forwarding backend response from %s', worker_id)
                 else:
-                    message = f'integration for {parsed.scheme}:// is not implemented'
-                    raise RuntimeError(message)
-        except Exception as e:
-            response = {
-                'worker': identity,
-                'response_time': 0,
-                'success': False,
-                'message': str(e),
-            }
+                    logger.info('worker %s ready', worker_id)
+                    workers_available.append(worker_id)
 
-        if response is None and integration is not None:
-            logger.debug('send request to handler')
-            response = integration.handle(request)
-            logger.debug('got response from handler')
+            if socks.get(frontend) == zmq.POLLIN:
+                logger.debug('polling frontend')
+                try:
+                    msg = frontend.recv_multipart(flags=zmq.NOBLOCK)
+                except zmq.Again:
+                    sleep(0.1)
+                    continue
 
-        response_proto = [
-            request_proto[0],
-            SPLITTER_FRAME,
-            jsondumps(response, cls=JsonBytesEncoder).encode(),
-        ]
+                request_id = msg[0]
+                payload = cast(AsyncMessageRequest, jsonloads(msg[-1].decode()))
 
-        worker.send_multipart(response_proto)
+                request_worker_id = payload.get('worker', None)
+                request_client_id = payload.get('client', None)
+                client_key: Optional[str] = None
 
-    logger.debug("i'm going to die! abort=%r", abort)
-    logger.info('stopping')
-    if integration is not None:
-        logger.debug('closing %s', integration.__class__.__name__)
+                logger.debug('request_worker_id=%r (%r), request_client_id=%r (%r)', request_worker_id, type(request_worker_id), request_client_id, type(request_client_id))
+
+                if request_client_id is not None:
+                    integration_url = payload.get('context', {}).get('url', None)
+                    parsed = urlparse(integration_url)
+                    scheme = parsed.scheme
+                    if isinstance(scheme, bytes):
+                        scheme = scheme.decode()
+
+                    client_key = f'{request_client_id}::{scheme}'
+
+                if request_worker_id is None and client_key is not None:
+                    request_worker_id = client_worker_map.get(client_key)
+
+                if request_worker_id is None:
+                    worker_id = workers_available.pop()
+
+                    if client_key is not None:
+                        client_worker_map.update({client_key: worker_id})
+
+                    payload['worker'] = worker_id
+                    logger.info('assigned worker %s to %s', worker_id, client_key)
+
+                    if len(workers_available) == 0:
+                        logger.debug('spawning an additional worker, for next client')
+                        spawn_worker()
+                else:
+                    logger.debug('%s is assigned %s', request_client_id, request_worker_id)
+                    worker_id = request_worker_id
+
+                    if payload.get('worker', None) is None:
+                        payload['worker'] = worker_id
+
+                request = jsondumps(payload).encode()
+                backend_request = [worker_id.encode(), SPLITTER_FRAME, request_id, SPLITTER_FRAME, request]
+                backend.send_multipart(backend_request)
+
+        logger.info('stopping')
+        # for identity, (future, worker) in workers.items():
+        for identity, (future, worker) in workers.items():
+            if not future.running():
+                continue
+
+            worker.stop()
+
+            # tell client that we aborted
+            if worker.integration is not None:
+                response = {
+                    'success': False,
+                    'worker': identity,
+                    'message': 'abort',
+                }
+
+                response_proto = [
+                    worker.identity.encode(),
+                    SPLITTER_FRAME,
+                    jsondumps(response, cls=JsonBytesEncoder).encode(),
+                ]
+
+                frontend.send_multipart(response_proto)
+
+                worker.logger.debug('sent abort to client')
+
+
+                worker.integration.close()
+                worker.socket.close()
+                worker.logger.info('socket closed')
+
+                # stop worker
+                cancelled = future.cancel()
+                logger.info('worker %s cancelled: %r', identity, cancelled)
+            else:
+                # should complete when `worker.stop()` has had effect
+                futures.wait([future])
+
         try:
-            integration.close()
-        except:  # pragma: no cover
-            logger.exception('failed to close integration')
+            logger.debug('destroy zmq context')
+            context.destroy(linger=0)
+        except:
+            logger.exception('failed to destroy zmq context')
 
-    try:
-        worker.close()
-    except:  # pragma: no cover
-        logger.exception('failed to close worker')
     logger.info('stopped')
-
 
 def main() -> int:
     try:

--- a/grizzly_extras/async_message/utils.py
+++ b/grizzly_extras/async_message/utils.py
@@ -40,6 +40,7 @@ def async_message_request(client: zmq.Socket, request: AsyncMessageRequest) -> A
                 break
             except ZMQAgain:
                 sleep(0.1)
+
             delta = perf_counter() - start
             if delta > 1.0:
                 logger.debug('async_message_request::recv_json took %f seconds', delta)
@@ -51,6 +52,9 @@ def async_message_request(client: zmq.Socket, request: AsyncMessageRequest) -> A
         message = response.get('message', None)
 
         if not response['success']:
+            if response['message'] == 'abort':
+                raise AsyncMessageAbort
+
             raise AsyncMessageError(message)
 
     except Exception as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,7 @@ max-branches = 15
 max-args = 10
 
 [tool.mypy]
+exclude = ["tests/project/**/*.py"]
 # https://github.com/python/mypy/issues/5870
 #follow_missing_imports = true
 show_column_numbers = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,7 +164,7 @@ max-branches = 15
 max-args = 10
 
 [tool.mypy]
-exclude = ["tests/project/**/*.py"]
+exclude = ["tests/project/"]
 # https://github.com/python/mypy/issues/5870
 #follow_missing_imports = true
 show_column_numbers = true

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -10,7 +10,6 @@ from hashlib import sha1
 from json import dumps as jsondumps
 from os import chdir, environ
 from pathlib import Path
-from shutil import rmtree
 from tempfile import NamedTemporaryFile
 from textwrap import dedent, indent
 from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, cast
@@ -38,7 +37,7 @@ from grizzly.types.behave import Feature, Scenario, Step
 from grizzly.types.locust import Environment, LocustRunner
 from grizzly.utils import create_scenario_class_type, create_user_class_type
 
-from .helpers import TestScenario, TestUser, onerror, run_command
+from .helpers import TestScenario, TestUser, rm_rf, run_command
 
 if TYPE_CHECKING:  # pragma: no cover
     from types import TracebackType
@@ -105,7 +104,7 @@ class LocustFixture:
         with suppress(KeyError):
             del environ['GRIZZLY_CONTEXT_ROOT']
 
-        rmtree(self._test_context_root)
+        rm_rf(self._test_context_root)
 
         return True
 
@@ -264,7 +263,7 @@ class RequestTaskFixture:
         exc: Optional[BaseException],
         traceback: Optional[TracebackType],
     ) -> Literal[True]:
-        rmtree(Path(self.context_root).parent)
+        rm_rf(Path(self.context_root).parent)
 
         return True
 
@@ -786,7 +785,7 @@ def step_start_webserver(context: Context, port: int) -> None:
 
             if not self.keep_files:
                 with suppress(AttributeError):
-                    rmtree(self.root.parent, onerror=onerror)
+                    rm_rf(self.root.parent)
             else:
                 print(self._root)
 

--- a/tests/unit/test_grizzly/events/test_request_logger.py
+++ b/tests/unit/test_grizzly/events/test_request_logger.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from contextlib import suppress
 from os import environ
 from pathlib import Path
-from shutil import rmtree
 from typing import TYPE_CHECKING, Callable
 
 import pytest
@@ -12,6 +11,7 @@ import pytest
 from grizzly.events import RequestLogger
 from grizzly.tasks import RequestTask
 from grizzly.types import RequestMethod
+from tests.helpers import rm_rf
 
 if TYPE_CHECKING:  # pragma: no cover
     from tests.fixtures import GrizzlyFixture
@@ -49,7 +49,7 @@ class TestRequestLogger:
             with suppress(KeyError):
                 del environ['GRIZZLY_LOG_DIR']
 
-            rmtree(log_root)
+            rm_rf(log_root)
 
     def test__remove_secrets_attribute(self) -> None:
         assert RequestLogger._remove_secrets_attribute({

--- a/tests/unit/test_grizzly/listeners/test_influxdb.py
+++ b/tests/unit/test_grizzly/listeners/test_influxdb.py
@@ -45,32 +45,32 @@ def patch_influxdblistener(mocker: MockerFixture) -> Callable[[], None]:
 
 class TestInfluxDb:
     def test___init__(self) -> None:
-        client = InfluxDb('https://influx.example.com', 1337, 'testdb')
+        client = InfluxDb('https://influx.example.com', 1232, 'testdb')
         assert client.host == 'https://influx.example.com'
-        assert client.port == 1337
+        assert client.port == 1232
         assert client.database == 'testdb'
         assert client.username is None
         assert client.password is None
 
-        client = InfluxDb('https://influx.example.com', 8888, 'testdb', 'test-user', 'secret!')
+        client = InfluxDb('https://influx.example.com', 1233, 'testdb', 'test-user', 'secret!')
         assert client.host == 'https://influx.example.com'
-        assert client.port == 8888
+        assert client.port == 1233
         assert client.database == 'testdb'
         assert client.username == 'test-user'
         assert client.password == 'secret!'  # noqa: S105
 
     def test_connect(self) -> None:
-        client = InfluxDb('https://influx.example.com', 1337, 'testdb')
+        client = InfluxDb('https://influx.example.com', 1234, 'testdb')
 
         assert client.connect() is client
 
     def test___enter__(self) -> None:
-        client = InfluxDb('https://influx.example.com', 1337, 'testdb')
+        client = InfluxDb('https://influx.example.com', 1235, 'testdb')
 
         assert client.__enter__() is client
 
     def test___exit__(self, mocker: MockerFixture) -> None:
-        influx = InfluxDb('https://influx.example.com', 1337, 'testdb').connect()
+        influx = InfluxDb('https://influx.example.com', 1236, 'testdb').connect()
 
         def noop___exit__(*_args: Any, **_kwargs: Any) -> None:
             pass
@@ -96,7 +96,7 @@ class TestInfluxDb:
         class ResultContainer:
             raw: dict[str, Any]
 
-        influx = InfluxDb('https://influx.example.com', 1337, 'testdb').connect()
+        influx = InfluxDb('https://influx.example.com', 1237, 'testdb').connect()
 
         def test_query(table: str, columns: list[str]) -> None:
             def query(_instance: InfluxDBClient, _query: str) -> ResultContainer:
@@ -134,7 +134,7 @@ class TestInfluxDb:
             return_value=None,
         )
 
-        influx = InfluxDb('https://influx.example.com', 1337, 'testdb').connect()
+        influx = InfluxDb('https://influx.example.com', 1238, 'testdb').connect()
 
         def logger_debug(_logger: logging.Logger, msg: str, count: int, database: str, host: str, port: int) -> None:
             assert count == 0
@@ -208,10 +208,10 @@ class TestInfluxDblistener:
 
         listener = InfluxDbListener(
             locust_fixture.environment,
-            'https://influx.test.com:1337/testdb?Testplan=unittest-plan&TargetEnvironment=local&ProfileName=unittest-profile&Description=unittesting',
+            'https://influx.test.com:1239/testdb?Testplan=unittest-plan&TargetEnvironment=local&ProfileName=unittest-profile&Description=unittesting',
         )
         assert len(locust_fixture.environment.events.request._handlers) == 2
-        assert listener.influx_port == 1337
+        assert listener.influx_port == 1239
         assert listener._testplan == 'unittest-plan'
         assert listener._target_environment == 'local'
         assert listener._hostname == socket.gethostname()
@@ -240,7 +240,7 @@ class TestInfluxDblistener:
 
         listener = InfluxDbListener(
             locust_fixture.environment,
-            'https://influx.test.com:1337/testdb?Testplan=unittest-plan&TargetEnvironment=local&ProfileName=unittest-profile&Description=unittesting',
+            'https://influx.test.com:1240/testdb?Testplan=unittest-plan&TargetEnvironment=local&ProfileName=unittest-profile&Description=unittesting',
         )
 
         write_spy = mocker.patch.object(listener.connection, 'write', return_value=None)
@@ -280,7 +280,7 @@ class TestInfluxDblistener:
 
         listener = InfluxDbListener(
             locust_fixture.environment,
-            'https://influx.test.com:1337/testdb?Testplan=unittest-plan&TargetEnvironment=local&ProfileName=unittest-profile&Description=unittesting',
+            'https://influx.test.com:1241/testdb?Testplan=unittest-plan&TargetEnvironment=local&ProfileName=unittest-profile&Description=unittesting',
         )
 
         mocker.patch(
@@ -344,7 +344,7 @@ class TestInfluxDblistener:
 
         listener = InfluxDbListener(
             grizzly_fixture.behave.locust.environment,
-            'https://influx.test.com:1337/testdb?Testplan=unittest-plan&TargetEnvironment=local&ProfileName=unittest-profile&Description=unittesting',
+            'https://influx.test.com:1242/testdb?Testplan=unittest-plan&TargetEnvironment=local&ProfileName=unittest-profile&Description=unittesting',
         )
 
         listener._override_event(event, {
@@ -382,7 +382,7 @@ class TestInfluxDblistener:
 
         listener = InfluxDbListener(
             grizzly_fixture.behave.locust.environment,
-            'https://influx.test.com:1337/testdb?Testplan=unittest-plan&TargetEnvironment=local&ProfileName=unittest-profile&Description=unittesting',
+            'https://influx.test.com:1243/testdb?Testplan=unittest-plan&TargetEnvironment=local&ProfileName=unittest-profile&Description=unittesting',
         )
 
         assert len(listener._events) == 0
@@ -485,7 +485,7 @@ class TestInfluxDblistener:
 
         listener = InfluxDbListener(
             locust_fixture.environment,
-            'https://influx.example.com:1337/testdb?Testplan=unittest-plan&TargetEnvironment=local&ProfileName=unittest-profile&Description=unittesting',
+            'https://influx.example.com:1244/testdb?Testplan=unittest-plan&TargetEnvironment=local&ProfileName=unittest-profile&Description=unittesting',
         )
 
         mocker.patch(
@@ -509,7 +509,7 @@ class TestInfluxDblistener:
     ) -> None:
         listener = InfluxDbListener(
             locust_fixture.environment,
-            'https://influx.example.com:1337/testdb?Testplan=unittest-plan&TargetEnvironment=local&ProfileName=unittest-profile&Description=unittesting',
+            'https://influx.example.com:1245/testdb?Testplan=unittest-plan&TargetEnvironment=local&ProfileName=unittest-profile&Description=unittesting',
         )
         mocker.patch.object(listener, '_create_metrics', side_effect=[Exception])
 
@@ -524,7 +524,7 @@ class TestInfluxDblistener:
 
         listener = InfluxDbListener(
             locust_fixture.environment,
-            'https://influx.example.com:1337/testdb?Testplan=unittest-plan&TargetEnvironment=local&ProfileName=unittest-profile&Description=unittesting',
+            'https://influx.example.com:1246/testdb?Testplan=unittest-plan&TargetEnvironment=local&ProfileName=unittest-profile&Description=unittesting',
         )
         expected_keys = ['response_time', 'response_length']
 

--- a/tests/unit/test_grizzly/steps/background/test_setup.py
+++ b/tests/unit/test_grizzly/steps/background/test_setup.py
@@ -173,6 +173,7 @@ def test_step_setup_run_time(behave_fixture: BehaveFixture) -> None:
 def test_step_setup_set_global_context_variable(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('test-1'))
 
     step_setup_set_global_context_variable(behave, 'token.url', 'test')
     assert grizzly.setup.global_context == {

--- a/tests/unit/test_grizzly/steps/scenario/tasks/test_request.py
+++ b/tests/unit/test_grizzly/steps/scenario/tasks/test_request.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, cast
 
 import pytest
+from jinja2 import Template
 from parse import compile
 
 from grizzly.context import GrizzlyContext
@@ -13,6 +14,7 @@ from grizzly.steps import (
     step_task_request_text_with_name,
     step_task_request_text_with_name_endpoint,
 )
+from grizzly.tasks import RequestTask
 from grizzly.types import RequestDirection, RequestMethod
 from tests.helpers import ANY
 
@@ -113,6 +115,11 @@ def test_step_task_request_text_with_name_endpoint_to(behave_fixture: BehaveFixt
     behave.text = '{}'
 
     step_task_request_text_with_name_endpoint(behave, method, 'test-name', RequestDirection.TO, '/api/test')
+
+    task = grizzly.scenario.tasks()[-1]
+    assert isinstance(task, RequestTask)
+    assert isinstance(task.template, Template)
+    assert task.source == '{}'
 
     step_task_request_text_with_name_endpoint(behave, method, 'test-name', RequestDirection.FROM, '/api/test')
     assert behave.exceptions == {behave.scenario.name: [ANY(AssertionError, message=f'"from endpoint" is not allowed for {method.name}, use "to endpoint"')]}

--- a/tests/unit/test_grizzly/steps/test__helpers.py
+++ b/tests/unit/test_grizzly/steps/test__helpers.py
@@ -47,12 +47,13 @@ def test_add_request_task_response_status_codes() -> None:
     assert request.response.status_codes == [200, 302, 400]
 
 
-@pytest.mark.parametrize('as_async', [False, True])
-def test_add_request_task(grizzly_fixture: GrizzlyFixture, tmp_path_factory: TempPathFactory, *, as_async: bool) -> None:  # noqa: PLR0915
+@pytest.mark.parametrize('request_type', ['sync', 'async'])
+def test_add_request_task(grizzly_fixture: GrizzlyFixture, tmp_path_factory: TempPathFactory, *, request_type: str) -> None:  # noqa: PLR0915
     behave = grizzly_fixture.behave.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
     grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test scenario'))
     grizzly.scenario.context['host'] = 'http://test'
+    as_async = request_type == 'async'
 
     if as_async:
         grizzly.scenario.tasks.tmp.async_group = AsyncRequestGroupTask(name='async-test-1')

--- a/tests/unit/test_grizzly/steps/test__helpers.py
+++ b/tests/unit/test_grizzly/steps/test__helpers.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import json
 import os
-import shutil
 from itertools import product
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, cast
@@ -28,6 +27,7 @@ from grizzly.testdata.utils import templatingfilter
 from grizzly.types import RequestMethod, ResponseAction, ResponseTarget
 from grizzly.types.behave import Row, Table
 from grizzly_extras.transformer import TransformerContentType
+from tests.helpers import rm_rf
 
 if TYPE_CHECKING:  # pragma: no cover
     from _pytest.tmpdir import TempPathFactory
@@ -189,7 +189,7 @@ def test_add_request_task(grizzly_fixture: GrizzlyFixture, tmp_path_factory: Tem
             assert request.source == f'Hello {name} and good {time_of_day}!'
     finally:
         del os.environ['GRIZZLY_CONTEXT_ROOT']
-        shutil.rmtree(test_context_root)
+        rm_rf(test_context_root)
 
     with pytest.raises(ValueError, match='incorrect format in arguments: "world:False"'):
         add_request_task(behave, method=RequestMethod.GET, endpoint='hello | world:False', source=None, name='hello-world')

--- a/tests/unit/test_grizzly/steps/test_setup.py
+++ b/tests/unit/test_grizzly/steps/test_setup.py
@@ -69,6 +69,8 @@ def test_step_setup_variable_value_ask(behave_fixture: BehaveFixture) -> None:
 def test_step_setup_variable_value(behave_fixture: BehaveFixture, mocker: MockerFixture) -> None:  # noqa: PLR0915
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.create(behave_fixture.create_scenario('dummy-1'))
+    grizzly.scenarios.create(behave_fixture.create_scenario('dummy-2'))
     grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
     behave.scenario = grizzly.scenario.behave
 
@@ -204,6 +206,29 @@ def test_step_setup_variable_value(behave_fixture: BehaveFixture, mocker: Mocker
         ANY(AssertionError, message='variable dynamic_variable_value has already been initialized'),
         ANY(AssertionError, message='variable new_variable has already been initialized'),
     ]}
+
+    for scenario in grizzly.scenarios:
+        assert scenario.jinja2.globals == SOME(dict, {
+            'test_string': 'test',
+            'test_int': 1,
+            'AtomicIntegerIncrementer.test': '1 | step=10',
+            'step': 13,
+            'AtomicIntegerIncrementer.test2': '1 | step=13',
+            'csv_repeat': False,
+            'AtomicCsvReader.input': 'test/input.csv | repeat="False"',
+            'AtomicCsvReader.csv_input': 'test/input.test.csv | repeat="False"',
+            'leveranser': 100,
+            'AtomicRandomString.regnr': '%sA%s1%d%d | count=26, upper=True',
+            'AtomicDate.test': '2021-04-13',
+            'value': 'hello world!',
+            'dynamic_variable_value': 'hello world!',
+            'AtomicIntegerIncrementer.persistent': '10 | step=10, persist=True',
+            'AtomicCsvWriter.output': 'output.csv | headers="foo,bar"',
+            'foo_value': 'foobar',
+            'bar_value': 'foobaz',
+            'custom.variable.AtomicFooBar.value': 'hello',
+            'new_variable': 'foobar',
+        })
 
 
 def test_step_setup_execute_python_script(grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:

--- a/tests/unit/test_grizzly/tasks/clients/test_servicebus.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_servicebus.py
@@ -21,10 +21,10 @@ class TestServiceBusClientTask:
     def test___init__(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:  # noqa: PLR0915
         context_mock = mocker.patch('grizzly.tasks.clients.servicebus.zmq.Context', autospec=True)
 
-        cls_task = type('ServiceBusClientTaskTest', (ServiceBusClientTask,), {'__scenario__': grizzly_fixture.grizzly.scenario})
+        task_type = type('ServiceBusClientTaskTest', (ServiceBusClientTask,), {'__scenario__': grizzly_fixture.grizzly.scenario})
 
         # <!-- connection string
-        task = cls_task(RequestDirection.FROM, 'sb://my-sbns.servicebus.windows.net/;SharedAccessKeyName=AccessKey;SharedAccessKey=37aabb777f454324=', 'test')
+        task = task_type(RequestDirection.FROM, 'sb://my-sbns.servicebus.windows.net/;SharedAccessKeyName=AccessKey;SharedAccessKey=37aabb777f454324=', 'test')
 
         assert task.endpoint == 'sb://my-sbns.servicebus.windows.net/;SharedAccessKeyName=AccessKey;SharedAccessKey=37aabb777f454324='
         assert task.context == {
@@ -45,7 +45,7 @@ class TestServiceBusClientTask:
         # // -->
 
         # <!-- credential
-        task = cls_task(RequestDirection.FROM, 'sb://bob@example.com:secret@my-sbns/#Tenant=example.com', 'test')
+        task = task_type(RequestDirection.FROM, 'sb://bob@example.com:secret@my-sbns/#Tenant=example.com', 'test')
 
         assert task.endpoint == 'sb://my-sbns.servicebus.windows.net'
         assert task.context == {
@@ -65,7 +65,7 @@ class TestServiceBusClientTask:
         context_mock.reset_mock()
         # // -->
 
-        task = cls_task(
+        task = task_type(
             RequestDirection.TO,
             'sb://my-sbns.servicebus.windows.net/queue:my-queue;SharedAccessKeyName=AccessKey;SharedAccessKey=37aabb777f454324=',
             'test',
@@ -95,7 +95,7 @@ class TestServiceBusClientTask:
         grizzly.state.configuration.update({'sbns.host': 'sb.windows.net', 'sbns.key.name': 'KeyName', 'sbns.key.secret': 'SeCrEtKeY=='})
         grizzly.state.variables.update({'foobar': 'none'})
 
-        task = cls_task(
+        task = task_type(
             RequestDirection.FROM,
             (
                 'sb://$conf::sbns.host$/topic:my-topic/subscription:"my-subscription-{{ id }}"/expression:$.hello.world'
@@ -129,7 +129,7 @@ class TestServiceBusClientTask:
 
         grizzly.state.variables.update({'barfoo': 'none'})
 
-        task = cls_task(
+        task = task_type(
             RequestDirection.FROM,
             (
                 'sb://$conf::sbns.host$/topic:my-topic/subscription:"my-subscription-{{ id }}"/expression:$.hello.world'
@@ -162,7 +162,7 @@ class TestServiceBusClientTask:
         context_mock.assert_called_once_with()
         context_mock.reset_mock()
 
-        task = cls_task(
+        task = task_type(
             RequestDirection.FROM, (
                 'sb://my-sbns/topic:my-topic/subscription:my-subscription/expression:$.name|=\'["hello", "world"]\''
                 ';SharedAccessKeyName=AccessKey;SharedAccessKey=37aabb777f454324=#MessageWait=120&ContentType=json'
@@ -187,7 +187,7 @@ class TestServiceBusClientTask:
         context_mock.reset_mock()
 
         with pytest.raises(AssertionError, match='MessageWait parameter in endpoint fragment is not a valid integer'):
-            cls_task(
+            task_type(
                 RequestDirection.FROM,
                 'sb://my-sbns.servicebus.windows.net/topic:my-topic/subscription:my-subscription;SharedAccessKeyName=AccessKey;SharedAccessKey=37aabb777f454324=#MessageWait=foo',
                 'test',
@@ -195,7 +195,7 @@ class TestServiceBusClientTask:
         context_mock.assert_not_called()
 
         with pytest.raises(AssertionError, match='Consume parameter in endpoint fragment is not a valid boolean'):
-            cls_task(
+            task_type(
                 RequestDirection.FROM,
                 'sb://my-sbns.servicebus.windows.net/topic:my-topic/subscription:my-subscription;SharedAccessKeyName=AccessKey;SharedAccessKey=37aabb777f454324=#Consume=foo',
                 'test',
@@ -203,7 +203,7 @@ class TestServiceBusClientTask:
         context_mock.assert_not_called()
 
         with pytest.raises(ValueError, match='"foo" is an unknown response content type'):
-            cls_task(
+            task_type(
                 RequestDirection.FROM,
                 'sb://my-sbns.servicebus.windows.net/topic:my-topic/subscription:my-subscription;SharedAccessKeyName=AccessKey;SharedAccessKey=37aabb777f454324=#ContentType=foo',
                 'test',
@@ -211,7 +211,7 @@ class TestServiceBusClientTask:
         context_mock.assert_not_called()
 
         with pytest.raises(AssertionError, match='Tenant fragment in endpoint is not allowed when using connection string'):
-            cls_task(
+            task_type(
                 RequestDirection.FROM,
                 'sb://my-sbns.servicebus.windows.net/topic:my-topic/subscription:my-subscription;SharedAccessKeyName=AccessKey;SharedAccessKey=37aabb777f454324=#Tenant=example.com',
                 'test',
@@ -219,7 +219,7 @@ class TestServiceBusClientTask:
         context_mock.assert_not_called()
 
         with pytest.raises(AssertionError, match='no query string found in endpoint'):
-            cls_task(
+            task_type(
                 RequestDirection.FROM,
                 'sb://my-sbns.servicebus.windows.net/topic:my-topic/subscription:my-subscription#ContentType=xml',
                 'test',
@@ -227,7 +227,7 @@ class TestServiceBusClientTask:
         context_mock.assert_not_called()
 
         with pytest.raises(AssertionError, match='SharedAccessKey not found in query string of endpoint'):
-            cls_task(
+            task_type(
                 RequestDirection.FROM,
                 'sb://my-sbns.servicebus.windows.net/topic:my-topic/subscription:my-subscription;SharedAccessKeyName=AccessKey',
                 'test',
@@ -235,7 +235,7 @@ class TestServiceBusClientTask:
         context_mock.assert_not_called()
 
         with pytest.raises(AssertionError, match='SharedAccessKeyName not found in query string of endpoint'):
-            cls_task(
+            task_type(
                 RequestDirection.FROM,
                 'sb://my-sbns.servicebus.windows.net/topic:my-topic/subscription:my-subscription;SharedAccessKey=AccessKey',
                 'test',
@@ -243,15 +243,15 @@ class TestServiceBusClientTask:
         context_mock.assert_not_called()
 
         with pytest.raises(AssertionError, match='Tenant not found in fragment of endpoint'):
-            cls_task(RequestDirection.FROM, 'sb://bob@example.com:secret@my-sbns/', 'test')
+            task_type(RequestDirection.FROM, 'sb://bob@example.com:secret@my-sbns/', 'test')
         context_mock.assert_not_called()
 
         with pytest.raises(AssertionError, match='query string found in endpoint, which is not allowed when using credential authentication'):
-            cls_task(RequestDirection.FROM, 'sb://bob@example.com:secret@my-sbns/;SharedAccessKeyName=key;SharedAccessKey=asdf#Tenant=example.com', 'test')
+            task_type(RequestDirection.FROM, 'sb://bob@example.com:secret@my-sbns/;SharedAccessKeyName=key;SharedAccessKey=asdf#Tenant=example.com', 'test')
         context_mock.assert_not_called()
 
         with pytest.raises(AssertionError, match='subscription name is too long, max length is 50 characters'):
-            cls_task(
+            task_type(
                 RequestDirection.FROM, (
                     'sb://my-sbns/topic:my-topic/subscription:my-subscriptionaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
                     ';SharedAccessKeyName=AccessKey;SharedAccessKey=37aabb777f454324=#MessageWait=120&ContentType=json'
@@ -260,7 +260,7 @@ class TestServiceBusClientTask:
             )
 
         with pytest.raises(AssertionError, match='subscription name is too long, max length is 42 characters'):
-            cls_task(
+            task_type(
                 RequestDirection.FROM, (
                     'sb://my-sbns/topic:my-topic/subscription:my-subscriptionaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
                     ';SharedAccessKeyName=AccessKey;SharedAccessKey=37aabb777f454324=#MessageWait=120&ContentType=json'
@@ -270,8 +270,8 @@ class TestServiceBusClientTask:
             )
 
     def test_text(self, grizzly_fixture: GrizzlyFixture) -> None:
-        ServiceBusClientTask.__scenario__ = grizzly_fixture.grizzly.scenario
-        task = ServiceBusClientTask(RequestDirection.FROM, 'sb://my-sbns.servicebus.windows.net/;SharedAccessKeyName=AccessKey;SharedAccessKey=37aabb777f454324=', 'test')
+        task_type = type('ServiceBusClientTaskTest', (ServiceBusClientTask,), {'__scenario__': grizzly_fixture.grizzly.scenario})
+        task = task_type(RequestDirection.FROM, 'sb://my-sbns.servicebus.windows.net/;SharedAccessKeyName=AccessKey;SharedAccessKey=37aabb777f454324=', 'test')
 
         assert task.text is None
 
@@ -294,8 +294,8 @@ class TestServiceBusClientTask:
 
         grizzly_fixture.grizzly.state.configuration.update({'sbns.key.secret': 'fooBARfoo'})
 
-        ServiceBusClientTask.__scenario__ = grizzly_fixture.grizzly.scenario
-        task = ServiceBusClientTask(
+        task_type = type('ServiceBusClientTaskTest', (ServiceBusClientTask,), {'__scenario__': grizzly_fixture.grizzly.scenario})
+        task = task_type(
             RequestDirection.FROM,
             'sb://my-sbns.servicebus.windows.net/queue:my-queue;SharedAccessKeyName=AccessKey;SharedAccessKey=$conf::sbns.key.secret$',
             'test',
@@ -328,8 +328,8 @@ class TestServiceBusClientTask:
         async_message_request_mock = mocker.patch('grizzly.utils.protocols.async_message_request')
         zmq_disconnect_mock = mocker.patch('grizzly.tasks.clients.servicebus.zmq_disconnect')
 
-        ServiceBusClientTask.__scenario__ = grizzly_fixture.grizzly.scenario
-        task = ServiceBusClientTask(
+        task_type = type('ServiceBusClientTaskTest', (ServiceBusClientTask,), {'__scenario__': grizzly_fixture.grizzly.scenario})
+        task = task_type(
             RequestDirection.FROM,
             'sb://my-sbns.servicebus.windows.net/queue:my-queue;SharedAccessKeyName=AccessKey;SharedAccessKey=37aabb777f454324=',
             'test',
@@ -367,8 +367,8 @@ class TestServiceBusClientTask:
 
         async_message_request_mock = mocker.patch('grizzly.utils.protocols.async_message_request', return_value={'message': 'foobar!'})
 
-        ServiceBusClientTask.__scenario__ = grizzly_fixture.grizzly.scenario
-        task = ServiceBusClientTask(
+        task_type = type('ServiceBusClientTaskTest', (ServiceBusClientTask,), {'__scenario__': grizzly_fixture.grizzly.scenario})
+        task = task_type(
             RequestDirection.FROM,
             'sb://my-sbns.servicebus.windows.net/topic:my-topic/subscription:"my-subscription-{{ id }}";SharedAccessKeyName=AccessKey;SharedAccessKey=37aabb777f454324=',
             'test',
@@ -398,7 +398,7 @@ class TestServiceBusClientTask:
         caplog.clear()
         async_message_request_mock.reset_mock()
 
-        task = ServiceBusClientTask(
+        task = task_type(
             RequestDirection.FROM,
             (
                 "sb://my-sbns.servicebus.windows.net/topic:my-topic/subscription:'my-subscription-{{ id }}'/expression:'$.`this`[bar='foo' && bar='foo']';"
@@ -440,7 +440,7 @@ class TestServiceBusClientTask:
         async_message_request_mock.reset_mock()
         caplog.clear()
 
-        task = ServiceBusClientTask(
+        task = task_type(
             RequestDirection.FROM,
             (
                 "sb://my-sbns.servicebus.windows.net/topic:my-topic/subscription:'my-subscription-{{ id }}'/"

--- a/tests/unit/test_grizzly/tasks/test_request.py
+++ b/tests/unit/test_grizzly/tasks/test_request.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
-from jinja2 import Template
 
 from grizzly.events.response_handler import ResponseHandlerAction
 from grizzly.tasks import (
@@ -99,7 +98,7 @@ class TestRequestTask:
 
         # automagically create template if not set
         task_factory.source = 'hello {{ world }}'
-        assert isinstance(task_factory.template, Template)
+        assert task_factory.template is None
 
     def test_arguments(self) -> None:
         task_factory = RequestTask(RequestMethod.GET, 'test-name', endpoint='/api/test | content_type="application/json", foo=bar')

--- a/tests/unit/test_grizzly/test_behave.py
+++ b/tests/unit/test_grizzly/test_behave.py
@@ -7,7 +7,6 @@ from contextlib import suppress
 from datetime import datetime
 from json import dumps as jsondumps
 from os import environ
-from shutil import rmtree
 from time import perf_counter
 from typing import TYPE_CHECKING, Any, Optional, cast
 
@@ -24,7 +23,7 @@ from grizzly.steps.setup import step_setup_variable_value_ask as step_both
 from grizzly.tasks import AsyncRequestGroupTask, ConditionalTask, LogMessageTask, LoopTask, TimerTask
 from grizzly.types import RequestType
 from grizzly.types.behave import Context, Feature, Status, Step
-from tests.helpers import onerror
+from tests.helpers import rm_rf
 
 if TYPE_CHECKING:  # pragma: no cover
     from _pytest.capture import CaptureFixture
@@ -126,7 +125,7 @@ def test_before_feature(behave_fixture: BehaveFixture, tmp_path_factory: TempPat
             with suppress(KeyError):
                 del environ[key]
 
-        rmtree(context_root, onerror=onerror)
+        rm_rf(context_root)
 
 
 def test_after_feature(grizzly_fixture: GrizzlyFixture, mocker: MockerFixture, capsys: CaptureFixture) -> None:  # noqa: PLR0915

--- a/tests/unit/test_grizzly/test_context.py
+++ b/tests/unit/test_grizzly/test_context.py
@@ -1,7 +1,6 @@
 """Unit tests for grizzly.context."""
 from __future__ import annotations
 
-import shutil
 from contextlib import suppress
 from os import environ
 from typing import TYPE_CHECKING, Any, Optional, cast
@@ -27,7 +26,7 @@ from grizzly.locust import FixedUsersDispatcher
 from grizzly.tasks import AsyncRequestGroupTask, ConditionalTask, ExplicitWaitTask, LogMessageTask, LoopTask, RequestTask
 from grizzly.types import MessageDirection, RequestMethod
 from grizzly.types.behave import Scenario
-from tests.helpers import TestTask, get_property_decorated_attributes
+from tests.helpers import TestTask, get_property_decorated_attributes, rm_rf
 
 if TYPE_CHECKING:  # pragma: no cover
     from _pytest.tmpdir import TempPathFactory
@@ -126,7 +125,7 @@ configuration:
             'additional.conf': 'foobar',
         }
     finally:
-        shutil.rmtree(configuration_file.parent)
+        rm_rf(configuration_file.parent)
         with suppress(KeyError):
             del environ['GRIZZLY_CONFIGURATION_FILE']
 
@@ -269,7 +268,7 @@ class TestGrizzlyContextState:
             }
 
         finally:
-            shutil.rmtree(configuration_file.parent)
+            rm_rf(configuration_file.parent)
             with suppress(KeyError):
                 del environ['GRIZZLY_CONFIGURATION_FILE']
 

--- a/tests/unit/test_grizzly/test_context.py
+++ b/tests/unit/test_grizzly/test_context.py
@@ -4,10 +4,8 @@ from __future__ import annotations
 from contextlib import suppress
 from os import environ
 from typing import TYPE_CHECKING, Any, Optional, cast
-from unittest.mock import ANY
 
 import pytest
-from jinja2.environment import Template
 
 from grizzly.context import (
     GrizzlyContext,
@@ -26,7 +24,7 @@ from grizzly.locust import FixedUsersDispatcher
 from grizzly.tasks import AsyncRequestGroupTask, ConditionalTask, ExplicitWaitTask, LogMessageTask, LoopTask, RequestTask
 from grizzly.types import MessageDirection, RequestMethod
 from grizzly.types.behave import Scenario
-from tests.helpers import TestTask, get_property_decorated_attributes, rm_rf
+from tests.helpers import SOME, TestTask, get_property_decorated_attributes, rm_rf
 
 if TYPE_CHECKING:  # pragma: no cover
     from _pytest.tmpdir import TempPathFactory
@@ -204,20 +202,22 @@ class TestGrizzlyContextSetupLocustMessages:
 
 
 class TestGrizzlyContextState:
-    def test(self) -> None:
-        state = GrizzlyContextState()
+    def test(self, grizzly_fixture: GrizzlyFixture) -> None:
+        grizzly = grizzly_fixture.grizzly
+        grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test-1'))
+        grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test-2'))
+        state = GrizzlyContextState(grizzly.scenarios)
 
         expected_properties = {
             'spawning_complete': (False, True),
             'background_section_done': (False, True),
-            'variables': ({}, {'test': 'hello'}),
             'configuration': ({}, {'sut.host': 'http://example.com'}),
             'alias': ({}, {'AtomicIntegerIncrementer.test': 'auth.randomseed'}),
             'verbose': (False, True),
             'persistent': ({}, {'AtomicIntegerIncrementer.persist': '1 | step=10, persist=True'}),
-            '_jinja2': (ANY, ANY),
         }
         actual_attributes = list(state.__dict__.keys())
+        actual_attributes.remove('variables')  # @TODO: remove...
         actual_attributes.sort()
         expected_attributes = list(expected_properties.keys())
         expected_attributes.sort()
@@ -231,7 +231,16 @@ class TestGrizzlyContextState:
             setattr(state, test_attribute_name, test_value)
             assert getattr(state, test_attribute_name) == test_value
 
-    def test_configuration(self, tmp_path_factory: TempPathFactory) -> None:
+        assert state.variables == {}
+        state.variables.update({'test': 'hello'})
+
+        for scenario in grizzly.scenarios:
+            assert scenario.jinja2.globals == SOME(dict, test='hello')
+
+    def test_configuration(self, grizzly_fixture: GrizzlyFixture, tmp_path_factory: TempPathFactory) -> None:
+        grizzly = grizzly_fixture.grizzly
+        grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test-1'))
+
         configuration_file = tmp_path_factory.mktemp('configuration_file') / 'configuration.yaml'
         try:
             configuration_file.write_text("""
@@ -248,7 +257,7 @@ class TestGrizzlyContextState:
                                 redirect_uri: "https://www.example.com/authenticated"
             """)
 
-            state = GrizzlyContextState()
+            state = GrizzlyContextState(grizzly.scenarios)
 
             assert state.configuration == {}
 
@@ -256,7 +265,7 @@ class TestGrizzlyContextState:
 
             environ['GRIZZLY_CONFIGURATION_FILE'] = str(configuration_file)
 
-            state = GrizzlyContextState()
+            state = GrizzlyContextState(grizzly.scenarios)
 
             assert state.configuration == {
                 'sut.host': 'https://backend.example.com',
@@ -319,7 +328,9 @@ class TestGrizzlyContext:
 
 
 class TestGrizzlyContextScenarios:
-    def test(self) -> None:
+    def test(self, grizzly_fixture: GrizzlyFixture) -> None:
+        # setup env variable GRIZZLY_CONTEXT_ROOT
+        _ = grizzly_fixture()
         scenarios = GrizzlyContextScenarios()
 
         assert issubclass(scenarios.__class__, list)
@@ -390,7 +401,7 @@ class TestGrizzlyContextScenario:
 
         second_request = RequestTask(RequestMethod.POST, name='Second Request', endpoint='/api/test/2')
         second_request.source = '{"hello": "world!"}'
-        assert isinstance(second_request.template, Template)
+        assert second_request.template is None
 
         scenario.tasks.add(second_request)
         assert scenario.tasks() == [request, second_request]

--- a/tests/unit/test_grizzly/test_locust.py
+++ b/tests/unit/test_grizzly/test_locust.py
@@ -413,7 +413,7 @@ def test_setup_environment_listeners(behave_fixture: BehaveFixture, mocker: Mock
         grizzly.scenario.tasks.add(task)
 
         # this is a bit misplaced after a refactoring...
-        with pytest.raises(AssertionError, match='variables has been found in templates, but have not been declared: test_id'):
+        with pytest.raises(AssertionError, match='variables has been found in templates, but have not been declared:\ntest_id'):
             testdata, _, _ = initialize_testdata(grizzly)
 
         grizzly.state.variables['test_id'] = 'test-1'

--- a/tests/unit/test_grizzly/test_locust.py
+++ b/tests/unit/test_grizzly/test_locust.py
@@ -388,7 +388,7 @@ def test_setup_environment_listeners(behave_fixture: BehaveFixture, mocker: Mock
         assert len(environment.events.quitting._handlers) == 0
 
         environment.events.spawning_complete._handlers = []  # grizzly handler should only append
-        grizzly.setup.statistics_url = 'influxdb://influx.example.com/testdb'
+        grizzly.setup.statistics_url = 'influxdb://influx.example.com:1230/testdb'
 
         setup_environment_listeners(behave, testdata={})
 
@@ -429,7 +429,7 @@ def test_setup_environment_listeners(behave_fixture: BehaveFixture, mocker: Mock
         assert len(environment.events.quitting._handlers) == 1
 
         AtomicIntegerIncrementer.destroy()
-        grizzly.setup.statistics_url = 'influxdb://influx.example.com/testdb'
+        grizzly.setup.statistics_url = 'influxdb://influx.example.com:1231/testdb'
         environment.events.spawning_complete._handlers = []
 
         setup_environment_listeners(behave, testdata=testdata)

--- a/tests/unit/test_grizzly/testdata/test___init__.py
+++ b/tests/unit/test_grizzly/testdata/test___init__.py
@@ -10,23 +10,28 @@ import pytest
 from grizzly.context import GrizzlyContext
 from grizzly.testdata import GrizzlyVariables
 from grizzly.testdata.variables import AtomicCsvReader, AtomicIntegerIncrementer
-from tests.helpers import rm_rf
+from tests.helpers import SOME, rm_rf
 
 if TYPE_CHECKING:  # pragma: no cover
     from _pytest.tmpdir import TempPathFactory
 
-    from tests.fixtures import AtomicVariableCleanupFixture
+    from tests.fixtures import AtomicVariableCleanupFixture, GrizzlyFixture
 
 
 class TestGrizzlyVariables:
-    def test_static_str(self) -> None:
-        t = GrizzlyVariables()
+    def test_static_str(self, grizzly_fixture: GrizzlyFixture) -> None:
+        grizzly = grizzly_fixture.grizzly
+        grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test-1'))
+        grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test-2'))
+        grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test-3'))
+
+        t = GrizzlyVariables(scenarios=grizzly.scenarios)
 
         t['test1'] = 'hallo'
         assert isinstance(t['test1'], str)
 
-        t['test7'] = '"true"'
-        assert isinstance(t['test7'], str)
+        t['test2'] = '"true"'
+        assert isinstance(t['test2'], str)
 
         t['test4'] = "'1337'"
         assert isinstance(t['test4'], str)
@@ -47,45 +52,69 @@ class TestGrizzlyVariables:
         assert isinstance(t['test8'], str)
         assert t['test8'] == '02002-00000'
 
-    def test_static_float(self) -> None:
-        t = GrizzlyVariables()
+        for scenario in grizzly.scenarios:
+            assert scenario.jinja2.globals == SOME(dict, test1='hallo', test2='true', test4='1337', test5='1337', test6='True', test7='00004302', test8='02002-00000')
 
-        t['test2'] = 1.337
+    def test_static_float(self, grizzly_fixture: GrizzlyFixture) -> None:
+        grizzly = grizzly_fixture.grizzly
+        grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test-1'))
+        grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test-2'))
+        grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test-3'))
+
+        t = GrizzlyVariables(scenarios=grizzly.scenarios)
+
+        t['test1'] = 1.337
+        assert isinstance(t['test1'], float)
+
+        t['test2'] = -1.337
         assert isinstance(t['test2'], float)
 
-        t['test2.1'] = -1.337
-        assert isinstance(t['test2.1'], float)
+        t['test3'] = '1.337'
+        assert isinstance(t['test3'], float)
+        assert t['test3'] == 1.337
 
-        t['test2.2'] = '1.337'
-        assert isinstance(t['test2.2'], float)
-        assert t['test2.2'] == 1.337
+        t['test4'] = '-1.337'
+        assert isinstance(t['test4'], float)
+        assert t['test4'] == -1.337
 
-        t['test2.3'] = '-1.337'
-        assert isinstance(t['test2.3'], float)
-        assert t['test2.3'] == -1.337
+        t['test5'] = '0.01'
+        assert isinstance(t['test5'], float)
+        assert t['test5'] == 0.01
 
-        t['test2.4'] = '0.01'
-        assert isinstance(t['test2.4'], float)
-        assert t['test2.4'] == 0.01
+        for scenario in grizzly.scenarios:
+            assert scenario.jinja2.globals == SOME(dict, test1=1.337, test2=-1.337, test3=1.337, test4=-1.337, test5=0.01)
 
-    def test_static_int(self) -> None:
-        t = GrizzlyVariables()
-        t['test3'] = 1337
+    def test_static_int(self, grizzly_fixture: GrizzlyFixture) -> None:
+        grizzly = grizzly_fixture.grizzly
+        grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test-1'))
+        grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test-2'))
+        grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test-3'))
+
+        t = GrizzlyVariables(scenarios=grizzly.scenarios)
+        t['test1'] = 1337
+        assert isinstance(t['test1'], int)
+
+        t['test2'] = -1337
+        assert isinstance(t['test2'], int)
+
+        t['test3'] = '1337'
         assert isinstance(t['test3'], int)
+        assert t['test3'] == 1337
 
-        t['test3.1'] = 1337
-        assert isinstance(t['test3.1'], int)
+        t['test4'] = '-1337'
+        assert isinstance(t['test4'], int)
+        assert t['test4'] == -1337
 
-        t['test3.2'] = '1337'
-        assert isinstance(t['test3.2'], int)
-        assert t['test3.2'] == 1337
+        for scenario in grizzly.scenarios:
+            assert scenario.jinja2.globals == SOME(dict, test1=1337, test2=-1337, test3=1337, test4=-1337)
 
-        t['test3.3'] = '-1337'
-        assert isinstance(t['test3.3'], int)
-        assert t['test3.3'] == -1337
+    def test_static_bool(self, grizzly_fixture: GrizzlyFixture) -> None:
+        grizzly = grizzly_fixture.grizzly
+        grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test-1'))
+        grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test-2'))
+        grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test-3'))
 
-    def test_static_bool(self) -> None:
-        t: GrizzlyVariables = GrizzlyVariables()
+        t: GrizzlyVariables = GrizzlyVariables(scenarios=grizzly.scenarios)
 
         t['test6'] = True
         assert isinstance(t['test6'], bool)
@@ -104,9 +133,17 @@ class TestGrizzlyVariables:
         assert isinstance(t['test11'], bool)
         assert t.__getitem__('test11') is False
 
-    def test_atomic_integer_incrementer(self, cleanup: AtomicVariableCleanupFixture) -> None:
+        for scenario in grizzly.scenarios:
+            assert scenario.jinja2.globals == SOME(dict, test6=True, test8=True, test9=False, test10=True, test11=False)
+
+    def test_atomic_integer_incrementer(self, grizzly_fixture: GrizzlyFixture, cleanup: AtomicVariableCleanupFixture) -> None:
+        grizzly = grizzly_fixture.grizzly
+        grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test-1'))
+        grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test-2'))
+        grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test-3'))
+
         try:
-            t = GrizzlyVariables()
+            t = GrizzlyVariables(scenarios=grizzly.scenarios)
             t['AtomicIntegerIncrementer.test1'] = 1337
             assert isinstance(t['AtomicIntegerIncrementer.test1'], str)
 
@@ -139,27 +176,41 @@ class TestGrizzlyVariables:
 
             t['AtomicIntegerIncrementer.test10'] = '1.337 | step=-1'
             assert t['AtomicIntegerIncrementer.test10'] == '1 | step=-1'
+
+            for scenario in grizzly.scenarios:
+                assert 'AtomicIntegerIncrementer.test6' not in scenario.jinja2.globals
+                assert scenario.jinja2.globals == SOME(dict, {
+                    'AtomicIntegerIncrementer.test1': '1337',
+                    'AtomicIntegerIncrementer.test2': '-1337',
+                    'AtomicIntegerIncrementer.test3': '1337',
+                    'AtomicIntegerIncrementer.test4': '-1337',
+                    'AtomicIntegerIncrementer.test5': '1',
+                    'AtomicIntegerIncrementer.test7': '1337 | step=10',
+                    'AtomicIntegerIncrementer.test8': '1337 | step=1',
+                    'AtomicIntegerIncrementer.test9': '-1337 | step=-10',
+                    'AtomicIntegerIncrementer.test10': '1 | step=-1',
+                })
         finally:
             cleanup()
 
-    def test_atomic_directory_contents(self, cleanup: AtomicVariableCleanupFixture, tmp_path_factory: TempPathFactory) -> None:
-        test_context = tmp_path_factory.mktemp('test_context') / 'requests'
-        test_context.mkdir()
-        test_context_root = test_context.parent.as_posix()
-        environ['GRIZZLY_CONTEXT_ROOT'] = test_context_root
+    def test_atomic_directory_contents(self, grizzly_fixture: GrizzlyFixture, cleanup: AtomicVariableCleanupFixture) -> None:
+        grizzly = grizzly_fixture.grizzly
+        grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test-1'))
+        grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test-2'))
+        grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test-3'))
 
         try:
-            t = GrizzlyVariables()
+            t = GrizzlyVariables(scenarios=grizzly.scenarios)
 
             with pytest.raises(ValueError, match='is not a directory in'):
                 t['AtomicDirectoryContents.test1'] = 'doesnotexist/'
 
-            (test_context / 'notadirectory').write_text('test')
+            (grizzly_fixture.test_context / 'requests' / 'notadirectory').write_text('test')
 
             with pytest.raises(ValueError, match='is not a directory in'):
                 t['AtomicDirectoryContents.test2'] = 'notadirectory'
 
-            (test_context / 'adirectory').mkdir()
+            (grizzly_fixture.test_context / 'requests' / 'adirectory').mkdir()
 
             t['AtomicDirectoryContents.test3'] = 'adirectory'
 
@@ -167,30 +218,37 @@ class TestGrizzlyVariables:
                 t['AtomicDirectoryContents.test4'] = 'adirectory | repeat=asdf'
 
             with pytest.raises(ValueError, match='argument prefix is not allowed'):
-                t['AtomicDirectoryContents.test4'] = 'adirectory | repeat=True, prefix="test-"'
+                t['AtomicDirectoryContents.test5'] = 'adirectory | repeat=True, prefix="test-"'
 
-            t['AtomicDirectoryContents.test4'] = 'adirectory | repeat=True'
+            t['AtomicDirectoryContents.test6'] = 'adirectory | repeat=True'
 
-            t['AtomicDirectoryContents.test5'] = 'adirectory|repeat=True'
-            assert t['AtomicDirectoryContents.test5'] == 'adirectory | repeat=True'
+            t['AtomicDirectoryContents.test7'] = 'adirectory|repeat=True'
+            assert t['AtomicDirectoryContents.test7'] == 'adirectory | repeat=True'
 
-            t['AtomicDirectoryContents.test6'] = 'adirectory| random=True'
-            assert t['AtomicDirectoryContents.test6'] == 'adirectory | random=True'
+            t['AtomicDirectoryContents.test8'] = 'adirectory| random=True'
+            assert t['AtomicDirectoryContents.test8'] == 'adirectory | random=True'
 
-            t['AtomicDirectoryContents.test7'] = 'adirectory|repeat=True, random=True'
-            assert t['AtomicDirectoryContents.test7'] == 'adirectory | repeat=True, random=True'
+            t['AtomicDirectoryContents.test9'] = 'adirectory|repeat=True, random=True'
+            assert t['AtomicDirectoryContents.test9'] == 'adirectory | repeat=True, random=True'
+
+            for scenario in grizzly.scenarios:
+                assert all(f'AtomicDirectoryContents.{name}' not in scenario.jinja2.globals for name in ['test1', 'test2', 'test4', 'test5'])
+                assert scenario.jinja2.globals == SOME(dict, {
+                    'AtomicDirectoryContents.test3': 'adirectory',
+                    'AtomicDirectoryContents.test6': 'adirectory | repeat=True',
+                    'AtomicDirectoryContents.test7': 'adirectory | repeat=True',
+                    'AtomicDirectoryContents.test8': 'adirectory | random=True',
+                    'AtomicDirectoryContents.test9': 'adirectory | repeat=True, random=True',
+                })
         finally:
-            with suppress(KeyError):
-                del environ['GRIZZLY_CONTEXT_ROOT']
-
-            rm_rf(test_context_root)
             cleanup()
 
-    def test_atomic_csv_reader(self, cleanup: AtomicVariableCleanupFixture, tmp_path_factory: TempPathFactory) -> None:
-        test_context = tmp_path_factory.mktemp('test_context') / 'requests'
-        test_context.mkdir()
-        test_context_root = test_context.parent.as_posix()
-        environ['GRIZZLY_CONTEXT_ROOT'] = test_context_root
+    def test_atomic_csv_reader(self, grizzly_fixture: GrizzlyFixture, cleanup: AtomicVariableCleanupFixture) -> None:
+        grizzly = grizzly_fixture.grizzly
+        grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test-1'))
+        grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test-2'))
+        grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test-3'))
+        test_context = grizzly_fixture.test_context / 'requests'
 
         (test_context / 'test.csv').write_text("""header1,header2
 header1,header2
@@ -198,62 +256,81 @@ value1,value2
 """)
 
         try:
-            t = GrizzlyVariables()
+            t = GrizzlyVariables(scenarios=grizzly.scenarios)
 
             with pytest.raises(ValueError, match='is not a file in'):
-                t['AtomicCsvReader.test'] = 'doesnotexist.csv'
+                t['AtomicCsvReader.test1'] = 'doesnotexist.csv'
 
-            t['AtomicCsvReader.test'] = 'test.csv'
+            t['AtomicCsvReader.test2'] = 'test.csv'
 
             with pytest.raises(ValueError, match='asdf is not a valid boolean'):
-                t['AtomicCsvReader.test2'] = 'test.csv | repeat=asdf'
+                t['AtomicCsvReader.test3'] = 'test.csv | repeat=asdf'
 
             with pytest.raises(ValueError, match='argument suffix is not allowed'):
-                t['AtomicCsvReader.test2'] = 'test.csv | repeat=True, suffix=True'
+                t['AtomicCsvReader.test4'] = 'test.csv | repeat=True, suffix=True'
 
-            t['AtomicCsvReader.test2'] = 'test.csv|repeat=True'
-            assert t['AtomicCsvReader.test2'] == 'test.csv | repeat=True'
+            t['AtomicCsvReader.test5'] = 'test.csv|repeat=True'
+            assert t['AtomicCsvReader.test5'] == 'test.csv | repeat=True'
+
+            for scenario in grizzly.scenarios:
+                assert all(f'AtomicCsvReader.{name}' not in scenario.jinja2.globals for name in ['test1', 'test3', 'test4'])
+                assert scenario.jinja2.globals == SOME(dict, {
+                    'AtomicCsvReader.test2': 'test.csv',
+                    'AtomicCsvReader.test5': 'test.csv | repeat=True',
+                })
         finally:
-            with suppress(KeyError):
-                del environ['GRIZZLY_CONTEXT_ROOT']
-
-            rm_rf(test_context_root)
             cleanup()
 
-    def test_atomic_date(self, cleanup: AtomicVariableCleanupFixture) -> None:
+    def test_atomic_date(self, grizzly_fixture: GrizzlyFixture, cleanup: AtomicVariableCleanupFixture) -> None:
+        grizzly = grizzly_fixture.grizzly
+        grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test-1'))
+        grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test-2'))
+        grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test-3'))
+
         try:
-            t = GrizzlyVariables()
+            t = GrizzlyVariables(scenarios=grizzly.scenarios)
             with pytest.raises(TypeError, match='is not a string'):
                 t['AtomicDate.test1'] = 1337
 
             with pytest.raises(ValueError, match='Unknown string format: hello'):
-                t['AtomicDate.test6'] = 'hello'
+                t['AtomicDate.test2'] = 'hello'
 
-            t['AtomicDate.test2'] = '2021-03-29'
-            assert isinstance(t['AtomicDate.test2'], str)
-            assert t['AtomicDate.test2'] == '2021-03-29'
+            t['AtomicDate.test3'] = '2021-03-29'
+            assert t['AtomicDate.test3'] == '2021-03-29'
 
-            t['AtomicDate.test3'] = '2021-03-29 16:43:49'
-            assert isinstance(t['AtomicDate.test3'], str)
-            assert t['AtomicDate.test3'] == '2021-03-29 16:43:49'
+            t['AtomicDate.test4'] = '2021-03-29 16:43:49'
+            assert t['AtomicDate.test4'] == '2021-03-29 16:43:49'
 
-            t['AtomicDate.test4'] = 'now|format="%Y-%m-%d"'
-            assert isinstance(t['AtomicDate.test4'], str)
-            assert t['AtomicDate.test4'] == 'now | format="%Y-%m-%d"'
+            t['AtomicDate.test5'] = 'now|format="%Y-%m-%d"'
+            assert t['AtomicDate.test5'] == 'now | format="%Y-%m-%d"'
 
             with pytest.raises(ValueError, match='Unknown string format: asdf'):
-                t['AtomicDate.test5'] = 'asdf|format="%Y-%m-%d"'
+                t['AtomicDate.test6'] = 'asdf|format="%Y-%m-%d"'
 
             with pytest.raises(ValueError, match='incorrect format in arguments: ""'):
-                t['AtomicDate.test6'] = 'now|'
+                t['AtomicDate.test7'] = 'now|'
 
-            t['AtomicDate.test7'] = 'now | format="%Y-%m-%dT%H:%M:%S.000Z"'
+            t['AtomicDate.test8'] = 'now | format="%Y-%m-%dT%H:%M:%S.000Z"'
+
+            for scenario in grizzly.scenarios:
+                assert all(f'AtomicDate.{name}' not in scenario.jinja2.globals for name in ['test1', 'test2', 'test6', 'test7'])
+                assert scenario.jinja2.globals == SOME(dict, {
+                    'AtomicDate.test3': '2021-03-29',
+                    'AtomicDate.test4': '2021-03-29 16:43:49',
+                    'AtomicDate.test5': 'now | format="%Y-%m-%d"',
+                    'AtomicDate.test8': 'now | format="%Y-%m-%dT%H:%M:%S.000Z"',
+                })
         finally:
             cleanup()
 
-    def test_atomic_random_integer(self, cleanup: AtomicVariableCleanupFixture) -> None:
+    def test_atomic_random_integer(self, grizzly_fixture: GrizzlyFixture, cleanup: AtomicVariableCleanupFixture) -> None:
+        grizzly = grizzly_fixture.grizzly
+        grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test-1'))
+        grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test-2'))
+        grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test-3'))
+
         try:
-            t = GrizzlyVariables()
+            t = GrizzlyVariables(scenarios=grizzly.scenarios)
 
             with pytest.raises(ValueError, match='10 is not a valid value format, must be: "a..b"'):
                 t['AtomicRandomInteger.test1'] = '10'
@@ -262,14 +339,19 @@ value1,value2
                 t['AtomicRandomInteger.test2'] = '1.17..5.0'
 
             with pytest.raises(ValueError, match='1.0 is not a valid integer'):
-                t['AtomicRandomInteger.test5'] = '1.0..3.5'
+                t['AtomicRandomInteger.test3'] = '1.0..3.5'
 
             with pytest.raises(ValueError, match='first value needs to be less than second value'):
-                t['AtomicRandomInteger.test3'] = '100..10'
+                t['AtomicRandomInteger.test4'] = '100..10'
 
-            t['AtomicRandomInteger.test4'] = '1..10'
-            assert isinstance(t['AtomicRandomInteger.test4'], str)
-            assert t['AtomicRandomInteger.test4'] == '1..10'
+            t['AtomicRandomInteger.test5'] = '1..10'
+            assert t['AtomicRandomInteger.test5'] == '1..10'
+
+            for scenario in grizzly.scenarios:
+                assert all(f'AtomicRandomInteger.{name}' not in scenario.jinja2.globals for name in ['test1', 'test2', 'test3', 'test4'])
+                assert scenario.jinja2.globals == SOME(dict, {
+                    'AtomicRandomInteger.test5': '1..10',
+                })
         finally:
             cleanup()
 

--- a/tests/unit/test_grizzly/testdata/test___init__.py
+++ b/tests/unit/test_grizzly/testdata/test___init__.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from contextlib import suppress
 from os import environ
-from shutil import rmtree
 from typing import TYPE_CHECKING, Optional
 
 import pytest
@@ -11,6 +10,7 @@ import pytest
 from grizzly.context import GrizzlyContext
 from grizzly.testdata import GrizzlyVariables
 from grizzly.testdata.variables import AtomicCsvReader, AtomicIntegerIncrementer
+from tests.helpers import rm_rf
 
 if TYPE_CHECKING:  # pragma: no cover
     from _pytest.tmpdir import TempPathFactory
@@ -183,7 +183,7 @@ class TestGrizzlyVariables:
             with suppress(KeyError):
                 del environ['GRIZZLY_CONTEXT_ROOT']
 
-            rmtree(test_context_root)
+            rm_rf(test_context_root)
             cleanup()
 
     def test_atomic_csv_reader(self, cleanup: AtomicVariableCleanupFixture, tmp_path_factory: TempPathFactory) -> None:
@@ -217,7 +217,7 @@ value1,value2
             with suppress(KeyError):
                 del environ['GRIZZLY_CONTEXT_ROOT']
 
-            rmtree(test_context_root)
+            rm_rf(test_context_root)
             cleanup()
 
     def test_atomic_date(self, cleanup: AtomicVariableCleanupFixture) -> None:
@@ -383,5 +383,5 @@ value3,value4
                 with suppress(KeyError):
                     del environ['GRIZZLY_CONTEXT_ROOT']
 
-                rmtree(test_context_root)
+                rm_rf(test_context_root)
                 cleanup()

--- a/tests/unit/test_grizzly/testdata/test_ast.py
+++ b/tests/unit/test_grizzly/testdata/test_ast.py
@@ -45,7 +45,7 @@ def test__parse_template(request_task: RequestTaskFixture, caplog: LogCaptureFix
     templates = {scenario: set(request.get_templates())}
 
     with caplog.at_level(logging.WARNING):
-        actual_variables = _parse_templates(templates, env=request_task.behave_fixture.grizzly.state.jinja2)
+        actual_variables = _parse_templates(templates)
 
         expected_variables = {
             'IteratorScenario_001': {
@@ -123,7 +123,7 @@ def test__parse_template_nested_pipe(request_task: RequestTaskFixture, caplog: L
     templates = {scenario: set(request.get_templates())}
 
     with caplog.at_level(logging.WARNING):
-        actual_variables = _parse_templates(templates, env=request_task.behave_fixture.grizzly.state.jinja2)
+        actual_variables = _parse_templates(templates)
 
         assert actual_variables == {
             'IteratorScenario_001': {
@@ -144,7 +144,7 @@ def test__parse_template_nested_pipe(request_task: RequestTaskFixture, caplog: L
 
         templates = {scenario: set(request.get_templates())}
 
-        actual_variables = _parse_templates(templates, env=request_task.behave_fixture.grizzly.state.jinja2)
+        actual_variables = _parse_templates(templates)
 
         assert actual_variables == {
             'IteratorScenario_001': {
@@ -163,7 +163,7 @@ def test__parse_template_nested_pipe(request_task: RequestTaskFixture, caplog: L
 
         templates = {scenario: set(request.get_templates())}
 
-        actual_variables = _parse_templates(templates, env=request_task.behave_fixture.grizzly.state.jinja2)
+        actual_variables = _parse_templates(templates)
 
         assert actual_variables == {
             'IteratorScenario_001': {
@@ -211,7 +211,7 @@ def test__parse_template_nested_pipe(request_task: RequestTaskFixture, caplog: L
         scenario.tasks.add(request)
         templates = {scenario: set(request.get_templates())}
 
-        actual_variables = _parse_templates(templates, env=request_task.behave_fixture.grizzly.state.jinja2)
+        actual_variables = _parse_templates(templates)
 
         expected_variables = {
             'IteratorScenario_001': {
@@ -238,7 +238,7 @@ def test__parse_template_nested_pipe(request_task: RequestTaskFixture, caplog: L
         scenario.tasks.add(request)
         templates = {scenario: set(request.get_templates())}
 
-        actual_variables = _parse_templates(templates, env=request_task.behave_fixture.grizzly.state.jinja2)
+        actual_variables = _parse_templates(templates)
 
         assert actual_variables == {
             'IteratorScenario_001': {
@@ -289,7 +289,7 @@ def test__parse_template_nested_pipe(request_task: RequestTaskFixture, caplog: L
         scenario.tasks.add(request)
         templates = {scenario: set(request.get_templates())}
 
-        actual_variables = _parse_templates(templates, env=request_task.behave_fixture.grizzly.state.jinja2)
+        actual_variables = _parse_templates(templates)
 
         expected_variables = {
             'IteratorScenario_001': {

--- a/tests/unit/test_grizzly/testdata/test_ast.py
+++ b/tests/unit/test_grizzly/testdata/test_ast.py
@@ -382,13 +382,14 @@ def test_get_template_variables(behave_fixture: BehaveFixture, caplog: LogCaptur
         }
 
         del grizzly.state.variables['foo']
+        del grizzly.state.variables['env']
 
-        with pytest.raises(AssertionError, match='variables has been found in templates, but have not been declared: foo'):
+        with pytest.raises(AssertionError, match='variables has been found in templates, but have not been declared:\nenv\nfoo'):
             get_template_variables(grizzly)
 
-        grizzly.state.variables.update({'foo': 'bar', 'bar': 'foo'})
+        grizzly.state.variables.update({'foo': 'bar', 'bar': 'foo', 'baz': 'zab'})
 
-        with pytest.raises(AssertionError, match='variables has been declared, but cannot be found in templates: bar'):
+        with pytest.raises(AssertionError, match='variables has been declared, but cannot be found in templates:\nbar\nbaz'):
             get_template_variables(grizzly)
 
     assert caplog.messages == []

--- a/tests/unit/test_grizzly/testdata/variables/test_csv_reader.py
+++ b/tests/unit/test_grizzly/testdata/variables/test_csv_reader.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 
 from contextlib import suppress
 from os import environ
-from shutil import rmtree
 from typing import TYPE_CHECKING
 
 import pytest
 
 from grizzly.testdata.variables import AtomicCsvReader
 from grizzly.testdata.variables.csv_reader import atomiccsvreader__base_type__
+from tests.helpers import rm_rf
 
 if TYPE_CHECKING:  # pragma: no cover
     from _pytest.tmpdir import TempPathFactory
@@ -45,7 +45,7 @@ def test_atomiccsvreader__base_type__(tmp_path_factory: TempPathFactory) -> None
 
         assert atomiccsvreader__base_type__('file1.csv|random=True') == 'file1.csv | random=True'
     finally:
-        rmtree(test_context_root)
+        rm_rf(test_context_root)
 
         with suppress(KeyError):
             del environ['GRIZZLY_CONTEXT_ROOT']
@@ -210,7 +210,7 @@ class TestAtomicCsvReader:
                 {'header13': 'value133', 'header23': 'value233', 'header33': 'value333'},
             ]
         finally:
-            rmtree(test_context_root)
+            rm_rf(test_context_root)
 
             with suppress(KeyError):
                 del environ['GRIZZLY_CONTEXT_ROOT']
@@ -253,7 +253,7 @@ class TestAtomicCsvReader:
 
             AtomicCsvReader.destroy()
         finally:
-            rmtree(test_context_root)
+            rm_rf(test_context_root)
 
             with suppress(KeyError):
                 del environ['GRIZZLY_CONTEXT_ROOT']

--- a/tests/unit/test_grizzly/testdata/variables/test_directory_contents.py
+++ b/tests/unit/test_grizzly/testdata/variables/test_directory_contents.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 
 from contextlib import suppress
 from os import environ, sep
-from shutil import rmtree
 from typing import TYPE_CHECKING
 
 import pytest
 
 from grizzly.testdata.variables import AtomicDirectoryContents
 from grizzly.testdata.variables.directory_contents import atomicdirectorycontents__base_type__
+from tests.helpers import rm_rf
 
 if TYPE_CHECKING:  # pragma: no cover
     from _pytest.tmpdir import TempPathFactory
@@ -44,7 +44,7 @@ def test_atomicdirectorycontents__base_type__(tmp_path_factory: TempPathFactory)
 
         assert atomicdirectorycontents__base_type__('a-directory|random=True') == 'a-directory | random=True'
     finally:
-        rmtree(test_context_root)
+        rm_rf(test_context_root)
 
         with suppress(KeyError):
             del environ['GRIZZLY_CONTEXT_ROOT']
@@ -192,7 +192,7 @@ class TestAtomicDirectoryContents:
                 f'1-test{sep}3-test.json',
             ]
         finally:
-            rmtree(test_context_root)
+            rm_rf(test_context_root)
 
             with suppress(KeyError):
                 del environ['GRIZZLY_CONTEXT_ROOT']
@@ -230,7 +230,7 @@ class TestAtomicDirectoryContents:
 
             AtomicDirectoryContents.destroy()
         finally:
-            rmtree(test_context_root)
+            rm_rf(test_context_root)
 
             with suppress(KeyError):
                 del environ['GRIZZLY_CONTEXT_ROOT']

--- a/tests/unit/test_grizzly/users/test___init__.py
+++ b/tests/unit/test_grizzly/users/test___init__.py
@@ -5,7 +5,6 @@ import logging
 from contextlib import suppress
 from json import loads as jsonloads
 from os import environ
-from shutil import rmtree
 from typing import TYPE_CHECKING, cast
 
 import pytest
@@ -17,7 +16,7 @@ from grizzly.testdata.utils import templatingfilter
 from grizzly.types import GrizzlyResponse, RequestMethod, ScenarioState
 from grizzly.types.locust import StopUser
 from grizzly.users import GrizzlyUser
-from tests.helpers import ANY
+from tests.helpers import ANY, rm_rf
 
 if TYPE_CHECKING:  # pragma: no cover
     from _pytest.logging import LogCaptureFixture
@@ -117,7 +116,7 @@ class TestGrizzlyUser:
             with suppress(KeyError):
                 del FILTERS['uppercase']
 
-            rmtree(test_context)
+            rm_rf(test_context)
 
             with suppress(KeyError):
                 del environ['GRIZZLY_CONTEXT_ROOT']
@@ -173,7 +172,7 @@ class TestGrizzlyUser:
             assert data['MeasureResult']['name'] == user.context_variables['name']
             assert data['MeasureResult']['value'] == user.context_variables['value']
         finally:
-            rmtree(test_context.parent.parent)
+            rm_rf(test_context.parent.parent)
             with suppress(KeyError):
                 del environ['GRIZZLY_CONTEXT_ROOT']
 

--- a/tests/unit/test_grizzly_extras/async_message/test_daemon.py
+++ b/tests/unit/test_grizzly_extras/async_message/test_daemon.py
@@ -153,7 +153,7 @@ def test_worker(mocker: MockerFixture, caplog: LogCaptureFixture, scheme: str, i
 
     integration_close_spy.assert_called_once_with()
 
-    assert caplog.messages[1:] == ['stopping', 'stopped']
+    assert caplog.messages[-1] == 'stopped'
 
 
 def test_router(mocker: MockerFixture, caplog: LogCaptureFixture) -> None:

--- a/tests/unit/test_grizzly_extras/test_novella.py
+++ b/tests/unit/test_grizzly_extras/test_novella.py
@@ -1,7 +1,6 @@
 """Unit tests of grizzly_extras.novella."""
 from __future__ import annotations
 
-from shutil import rmtree
 from typing import Union
 
 import pytest
@@ -16,6 +15,7 @@ from grizzly_extras.novella import (
     _generate_dynamic_page,
     make_human_readable,
 )
+from tests.helpers import rm_rf
 
 
 class TestMarkdownAstType:
@@ -111,7 +111,7 @@ def test__create_nav_node(tmp_path_factory: pytest.TempPathFactory) -> None:
         assert target == ['hello/index.md', {'Foobar SFTP API': 'foobar/foobar_sftp_api.md'}]
         # -->
     finally:
-        rmtree(test_context)
+        rm_rf(test_context)
 
 
 def test__generate_dynamic_page(tmp_path_factory: pytest.TempPathFactory) -> None:
@@ -169,7 +169,7 @@ title: Foobar / Foobar SFTP API
 """
         # -->
     finally:
-        rmtree(test_context)
+        rm_rf(test_context)
 
 
 class TestGrizzlyMarkdown:


### PR DESCRIPTION
Fixes issue #323.

Required a rewrite of `grizzly_extras.async_message.daemon` so that the daemon function is executing in a seperate process, which can be killed since there is no way to interrupt/abort blocking (IBM MQ) operations.

The ones that has been problematic has been `GET` with a long `message_wait` time.

`daemon` will try to close all running workers, so that they gracefully shutdown. For the ones that are not stopped this way (e.g. in a blocking call), it will send an "abort" message to the client and then forcefully kill the sub-process that the daemon was running in.