### PR TITLE
geventhttpclient does not accept `verify` in request arguments

### DIFF
--- a/grizzly/testdata/__init__.py
+++ b/grizzly/testdata/__init__.py
@@ -129,7 +129,7 @@ class GrizzlyVariables(dict):
             check_value = check_value[1:]
 
         if check_value.isdecimal():
-            casted_value = (str(value) if value.startswith('0') else int(float(value))) if float(value) % 1 == 0 else float(value)
+            casted_value = (str(value) if value.startswith('0') and len(value) > 1 else int(float(value))) if float(value) % 1 == 0 else float(value)
         elif value.lower() in ['true', 'false']:
             casted_value = value.lower() == 'true'
         else:

--- a/tests/e2e/steps/scenario/test_tasks.py
+++ b/tests/e2e/steps/scenario/test_tasks.py
@@ -591,7 +591,7 @@ def test_e2e_step_task_client_get_endpoint_until(e2e_fixture: End2EndFixture) ->
         assert parent_task.expected_matches == 1
         task = parent_task.request
         assert isinstance(task, HttpClientTask)
-        assert task.arguments == {'verify': False}
+        assert not task.verify
         assert task.content_type == TransformerContentType.JSON
         assert task.direction == RequestDirection.FROM
         assert task.endpoint == f'http://{e2e_fixture_host}/api/until/hello?nth=2&wrong=foobar&right=world&as_array=True', f'{task.name=}, {task.endpoint=}'

--- a/tests/unit/test_grizzly/tasks/clients/test_http.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_http.py
@@ -19,7 +19,6 @@ from grizzly.tasks.clients import HttpClientTask
 from grizzly.types import RequestDirection
 from grizzly.types.locust import CatchResponseError, StopUser
 from grizzly_extras.transformer import TransformerContentType
-from grizzly.tasks.clients.http import Session
 from tests.helpers import ANY
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/tests/unit/test_grizzly/tasks/clients/test_http.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_http.py
@@ -19,6 +19,7 @@ from grizzly.tasks.clients import HttpClientTask
 from grizzly.types import RequestDirection
 from grizzly.types.locust import CatchResponseError, StopUser
 from grizzly_extras.transformer import TransformerContentType
+from grizzly.tasks.clients.http import Session
 from tests.helpers import ANY
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -243,7 +244,7 @@ class TestHttpClientTask:
             grizzly.state.configuration['test.host'] = 'https://example.org'
 
             task_factory = test_cls(RequestDirection.FROM, 'https://$conf::test.host$/api/test', 'http-env-get', payload_variable='test')
-            assert task_factory.arguments == {'verify': True}
+            assert task_factory.verify
             assert task_factory.content_type == TransformerContentType.UNDEFINED
             task = task_factory()
             response.url = 'https://example.org/api/test'
@@ -253,7 +254,6 @@ class TestHttpClientTask:
 
             requests_get_spy.assert_called_once_with(
                 'https://example.org/api/test',
-                verify=True,
                 headers={'x-grizzly-user': f'HttpClientTestTask::{id(task_factory)}'},
             )
             requests_get_spy.reset_mock()
@@ -264,7 +264,7 @@ class TestHttpClientTask:
 
             task_factory = test_cls(RequestDirection.FROM, 'https://$conf::test.host$/api/test | verify=False, content_type=json', 'http-env-get-1', payload_variable='test')
             task = task_factory()
-            assert task_factory.arguments == {'verify': False}
+            assert not task_factory.verify
             assert task_factory.content_type == TransformerContentType.JSON
             assert len(list(task_factory.log_dir.rglob('**/*'))) == 5
 
@@ -272,7 +272,6 @@ class TestHttpClientTask:
 
             requests_get_spy.assert_called_once_with(
                 'https://example.org/api/test',
-                verify=False,
                 headers={'x-grizzly-user': f'HttpClientTestTask::{id(task_factory)}'},
             )
             requests_get_spy.reset_mock()
@@ -283,7 +282,7 @@ class TestHttpClientTask:
 
             task_factory = test_cls(RequestDirection.FROM, 'https://$conf::test.host$/api/test | verify=True, content_type=json', 'http-env-get-2', payload_variable='test')
             task = task_factory()
-            assert task_factory.arguments == {'verify': True}
+            assert task_factory.verify
             assert task_factory.content_type == TransformerContentType.JSON
 
             parent.user._scenario.context['log_all_requests'] = True
@@ -297,7 +296,6 @@ class TestHttpClientTask:
 
             requests_get_spy.assert_called_once_with(
                 'https://example.org/api/test',
-                verify=True,
                 headers={'x-grizzly-user': f'HttpClientTestTask::{id(task_factory)}', 'x-test-header': 'foobar'},
             )
             requests_get_spy.reset_mock()

--- a/tests/unit/test_grizzly/testdata/test___init__.py
+++ b/tests/unit/test_grizzly/testdata/test___init__.py
@@ -93,6 +93,12 @@ class TestGrizzlyVariables:
         assert isinstance(t['test4'], int)
         assert t['test4'] == -1337
 
+        t['test5'] = 0
+        assert t['test5'] == 0
+
+        t['test6'] = '0'
+        assert t['test6'] == 0
+
     def test_static_bool(self, grizzly_fixture: GrizzlyFixture) -> None:
         grizzly = grizzly_fixture.grizzly
         grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test-1'))


### PR DESCRIPTION
use `insecure` in `Session` / UserAgent instead.

handle edge case where a (grizzly) variable is set to `"0"`, which should be treated as an `int` and not a `str`.