### PR TITLE
unique scenario variables per user type instance

### DIFF
--- a/grizzly/scenarios/__init__.py
+++ b/grizzly/scenarios/__init__.py
@@ -88,7 +88,6 @@ class GrizzlyScenario(SequentialTaskSet):
             self.consumer = TestdataConsumer(
                 scenario=self,
                 address=producer_address,
-                identifier=self.__class__.__name__,
             )
             self.user.scenario_state = ScenarioState.RUNNING
         else:

--- a/grizzly/steps/background/shapes.py
+++ b/grizzly/steps/background/shapes.py
@@ -52,7 +52,8 @@ def step_shapes_user_count(context: Context, value: str, **_kwargs: Any) -> None
     user_count = max(int(round(float(resolve_variable(grizzly.scenario, value)), 0)), 1)
 
     if has_template(value):
-        grizzly.scenario.orphan_templates.append(value)
+        for scenario in grizzly.scenarios:
+            scenario.orphan_templates.append(value)
 
     assert user_count >= 0, f'{value} resolved to {user_count} users, which is not valid'
 
@@ -85,7 +86,8 @@ def step_shapes_spawn_rate(context: Context, value: str, **_kwargs: Any) -> None
     spawn_rate = max(float(resolve_variable(grizzly.scenario, value)), 0.01)
 
     if has_template(value):
-        grizzly.scenario.orphan_templates.append(value)
+        for scenario in grizzly.scenarios:
+            scenario.orphan_templates.append(value)
 
     assert spawn_rate > 0.0, f'{value} resolved to {spawn_rate} users, which is not valid'
 

--- a/grizzly/testdata/communication.py
+++ b/grizzly/testdata/communication.py
@@ -32,14 +32,12 @@ class TestdataConsumer:
     __test__: bool = False
 
     scenario: GrizzlyScenario
-    logger: logging.Logger
     identifier: str
     stopped: bool
 
-    def __init__(self, scenario: GrizzlyScenario, identifier: str, address: str = 'tcp://127.0.0.1:5555') -> None:
+    def __init__(self, scenario: GrizzlyScenario, address: str = 'tcp://127.0.0.1:5555') -> None:
         self.scenario = scenario
-        self.identifier = identifier
-        self.logger = logging.getLogger(f'{__name__}/{self.identifier}')
+        self.identifier = scenario.__class__.__name__
 
         self.context = zmq.Context()
         self.socket = self.context.socket(zmq.REQ)
@@ -48,6 +46,10 @@ class TestdataConsumer:
         self.stopped = False
 
         self.logger.debug('connected to producer at %s', address)
+
+    @property
+    def logger(self) -> logging.Logger:
+        return self.scenario.logger
 
     def stop(self) -> None:
         if self.stopped:

--- a/grizzly/types/__init__.py
+++ b/grizzly/types/__init__.py
@@ -232,7 +232,7 @@ TestdataType = dict[str, dict[str, Any]]
 
 HandlerContextType = Union[dict[str, Any], Optional[Any]]
 
-GrizzlyVariableType = Union[str, float, int, bool] # , dict, list]
+GrizzlyVariableType = Union[str, float, int, bool]
 
 MessageCallback = Callable[Concatenate[Environment, Message, P], None]
 

--- a/grizzly/users/__init__.py
+++ b/grizzly/users/__init__.py
@@ -98,6 +98,8 @@ class GrizzlyUser(User, metaclass=GrizzlyUserMeta):
         self._scenario = copy(self.__scenario__)
         # these are not copied, and we can share reference
         self._scenario._tasks = self.__scenario__._tasks
+        # each instance of a user type should have their own globals dict
+        self._scenario.jinja2._globals = self.__scenario__.jinja2._globals.copy()
 
         self.logger = logging.getLogger(f'{self.__class__.__name__}/{id(self)}')
         self.abort = False

--- a/tests/e2e/test_variables.py
+++ b/tests/e2e/test_variables.py
@@ -11,13 +11,13 @@ if TYPE_CHECKING:  # pragma: no cover
 def test_e2e_variables(e2e_fixture: End2EndFixture) -> None:
     feature_file = e2e_fixture.create_feature(dedent("""Feature: variables
     Background: common configuration
-        Given "2" users
-        And spawn rate is "2" users per second
+        Given spawn rate is "2" users per second
         And value for variable "background_variable" is "foobar"
         And value for variable "AtomicIntegerIncrementer.test" is "10"
     Scenario: Scenario 1
-        Given a user of type "Dummy" load testing "null"
-        And repeat for "1" iteration
+        Given "2" users of type "Dummy" load testing "null"
+        And repeat for "2" iteration
+        And wait "0.0..0.5" seconds between tasks
         And value for variable "scenario_1" is "{{ background_variable }}"
         And value for variable "AtomicRandomString.scenario" is "AA%s | upper=True, count=10"
 
@@ -26,8 +26,9 @@ def test_e2e_variables(e2e_fixture: End2EndFixture) -> None:
         Then log message "Scenario 1::AtomicIntegerIncrementer.test={{ AtomicIntegerIncrementer.test }}"
         Then log message "Scenario 1::AtomicRandomString.scenario={{ AtomicRandomString.scenario }}"
     Scenario: Scenario 2
-        Given a user of type "Dummy" load testing "null"
-        And repeat for "1" iteration
+        Given "2" users of type "Dummy" load testing "null"
+        And repeat for "2" iteration
+        And wait "0.0..0.5" seconds between tasks
         And value for variable "scenario_2" is "{{ background_variable }}"
         And value for variable "AtomicRandomString.scenario" is "BB%s | upper=True, count=5"
 
@@ -45,10 +46,12 @@ def test_e2e_variables(e2e_fixture: End2EndFixture) -> None:
 
     print(result)
 
-    assert result.count('scenario_1=foobar') == 1
-    assert result.count('scenario_2=foobar') == 1
-    assert result.count('background_variable=foobar') == 2
+    assert result.count('scenario_1=foobar') == 2
+    assert result.count('scenario_2=foobar') == 2
+    assert result.count('background_variable=foobar') == 4
     assert result.count('Scenario 1::AtomicIntegerIncrementer.test=10') == 1
+    assert result.count('Scenario 1::AtomicIntegerIncrementer.test=11') == 1
     assert result.count('Scenario 2::AtomicIntegerIncrementer.test=10') == 1
-    assert result.count('Scenario 1::AtomicRandomString.scenario=AA') == 1
-    assert result.count('Scenario 2::AtomicRandomString.scenario=BB') == 1
+    assert result.count('Scenario 2::AtomicIntegerIncrementer.test=11') == 1
+    assert result.count('Scenario 1::AtomicRandomString.scenario=AA') == 2
+    assert result.count('Scenario 2::AtomicRandomString.scenario=BB') == 2

--- a/tests/unit/test_grizzly/scenarios/test_iterator.py
+++ b/tests/unit/test_grizzly/scenarios/test_iterator.py
@@ -184,7 +184,7 @@ class TestIterationScenario:
         assert isinstance(parent, IteratorScenario)
         assert not parent._prefetch
 
-        parent.consumer = TestdataConsumer(parent, identifier='test')
+        parent.consumer = TestdataConsumer(parent)
 
         def mock_request(data: Optional[dict[str, Any]]) -> None:
             def testdata_request(self: TestdataConsumer, scenario: str) -> Optional[dict[str, Any]]:  # noqa: ARG001

--- a/tests/unit/test_grizzly/testdata/test_communication.py
+++ b/tests/unit/test_grizzly/testdata/test_communication.py
@@ -679,7 +679,7 @@ class TestTestdataConsumer:
         parent = grizzly_fixture()
         grizzly = grizzly_fixture.grizzly
 
-        consumer = TestdataConsumer(parent, identifier='test')
+        consumer = TestdataConsumer(parent)
 
         try:
             mock_recv_json({})
@@ -759,7 +759,7 @@ class TestTestdataConsumer:
 
         parent = grizzly_fixture()
 
-        consumer = TestdataConsumer(parent, identifier='test')
+        consumer = TestdataConsumer(parent)
 
         with caplog.at_level(logging.DEBUG):
             consumer.stop()
@@ -789,7 +789,7 @@ class TestTestdataConsumer:
 
         parent = grizzly_fixture()
 
-        consumer = TestdataConsumer(parent, identifier='test')
+        consumer = TestdataConsumer(parent)
 
         with pytest.raises(ZMQAgain):
             consumer.testdata('test')
@@ -807,7 +807,7 @@ class TestTestdataConsumer:
         noop_zmq('grizzly.testdata.communication')
         parent = grizzly_fixture()
 
-        consumer = TestdataConsumer(parent, identifier='test')
+        consumer = TestdataConsumer(parent)
 
         def echo(value: dict[str, Any]) -> dict[str, Any]:
             return value

--- a/tests/unit/test_grizzly/users/test___init__.py
+++ b/tests/unit/test_grizzly/users/test___init__.py
@@ -180,7 +180,13 @@ class TestGrizzlyUser:
     def test_context(self, behave_fixture: BehaveFixture) -> None:
         behave_fixture.grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
         DummyGrizzlyUser.__scenario__ = behave_fixture.grizzly.scenario
+        original_id = id(DummyGrizzlyUser.__scenario__._jinja2)
         user = DummyGrizzlyUser(behave_fixture.locust.environment)
+
+        assert user._scenario is not DummyGrizzlyUser.__scenario__
+        assert id(user._scenario._jinja2) != original_id
+        assert id(user._scenario._jinja2.globals) != id(DummyGrizzlyUser.__scenario__._jinja2.globals)
+        assert user._scenario._jinja2.globals.keys() == DummyGrizzlyUser.__scenario__._jinja2.globals.keys()
 
         context = user.context()
 


### PR DESCRIPTION
each instance of a user type must have a unique `Environment._globals` dictionary so they don't interfere with each other when running in the same process.

also, background steps that can contain values with templates must add them as orphan templates for all scenarios.