### PR TITLE
rewrite of variable separation per scenario

### DIFF
--- a/grizzly/events/response_handler.py
+++ b/grizzly/events/response_handler.py
@@ -54,10 +54,9 @@ class ResponseHandlerAction(ABC):
 
         """
         input_content_type, input_payload = input_context
-        j2env = user._scenario.jinja2
-        rendered_expression = j2env.from_string(self.expression).render()
-        rendered_match_with = j2env.from_string(self.match_with).render()
-        rendered_expected_matches = int(j2env.from_string(self.expected_matches).render())
+        rendered_expression = user.render(self.expression)
+        rendered_match_with = user.render(self.match_with)
+        rendered_expected_matches = int(user.render(self.expected_matches))
 
         transform = transformer.available.get(input_content_type, None)
         if transform is None:

--- a/grizzly/locust.py
+++ b/grizzly/locust.py
@@ -1134,7 +1134,13 @@ def run(context: Context) -> int:  # noqa: C901, PLR0915, PLR0912
                     gevent.sleep(1.0)
                     count += 1
                     if count % 10 == 0:
-                        logger.debug('runner.user_count=%d, runner.user_classes_count=%r', runner.user_count, runner.user_classes_count)
+                        user_classes_count: dict[str, Any]
+                        if isinstance(runner, MasterRunner):
+                            user_classes_count = {worker.id: worker.user_classes_count for worker in runner.clients.values()}
+                        else:
+                            user_classes_count = runner.user_classes_count
+
+                        logger.debug('user_count=%d, user_classes_count=%r', runner.user_count, user_classes_count)
                         count = 0
 
                 logger.info('runner.user_count=%d, quit %s, abort_test=%r', runner.user_count, runner.__class__.__name__, abort_test)

--- a/grizzly/scenarios/__init__.py
+++ b/grizzly/scenarios/__init__.py
@@ -15,7 +15,6 @@ from grizzly.tasks import GrizzlyTask, grizzlytask
 from grizzly.testdata.communication import TestdataConsumer
 from grizzly.types import ScenarioState
 from grizzly.types.locust import StopUser
-from grizzly.utils import has_template
 
 if TYPE_CHECKING:  # pragma: no cover
     from locust.user.task import TaskSet
@@ -63,17 +62,6 @@ class GrizzlyScenario(SequentialTaskSet):
             _values.update({key: _value})
 
         return _values
-
-    def render(self, template: str, variables: Optional[dict[str, Any]] = None, *, escape_values: bool = False) -> str:
-        if not has_template(template):
-            return template
-
-        if variables is None:
-            variables = {}
-
-        render_variables = self._escape_values(variables) if escape_values else variables
-
-        return self.user._scenario.jinja2.from_string(template).render(**render_variables)
 
     def prefetch(self) -> None:
         """Do not prefetch anything by default."""

--- a/grizzly/scenarios/__init__.py
+++ b/grizzly/scenarios/__init__.py
@@ -88,7 +88,6 @@ class GrizzlyScenario(SequentialTaskSet):
             self.consumer = TestdataConsumer(
                 scenario=self,
                 address=producer_address,
-                identifier=self.__class__.__name__,
             )
             self.user.scenario_state = ScenarioState.RUNNING
         else:

--- a/grizzly/scenarios/iterator.py
+++ b/grizzly/scenarios/iterator.py
@@ -288,7 +288,7 @@ class IteratorScenario(GrizzlyScenario):
         try:
             start = perf_counter()
             try:
-                value = float(self.render(self.pace_time))
+                value = float(self.user.render(self.pace_time))
             except ValueError as ve:
                 message = f'{self.pace_time} does not render to a number'
                 raise ValueError(message) from ve

--- a/grizzly/steps/_helpers.py
+++ b/grizzly/steps/_helpers.py
@@ -36,10 +36,7 @@ def create_request_task(
     substitutes: Optional[dict[str, str]] = None,
     content_type: Optional[TransformerContentType] = None,
 ) -> RequestTask:
-    grizzly = cast(GrizzlyContext, context.grizzly)
     path = Path(context.config.base_dir) / 'requests'
-
-    template: Optional[j2.Template] = None
 
     if source is not None:
         original_source = source
@@ -71,14 +68,12 @@ def create_request_task(
         for key, value in (substitutes or {}).items():
             source = source.replace(f'{{{{ {key} }}}}', value)
 
-        template = grizzly.scenario.jinja2.from_string(source)
-
     if name is None:
         name = '<unknown>'
 
     request = RequestTask(method, name=name, endpoint=endpoint)
-    request._source = source
-    request._template = template
+    request.source = source
+
     if content_type is not None:
         request.response.content_type = content_type
 

--- a/grizzly/steps/background/shapes.py
+++ b/grizzly/steps/background/shapes.py
@@ -52,7 +52,8 @@ def step_shapes_user_count(context: Context, value: str, **_kwargs: Any) -> None
     user_count = max(int(round(float(resolve_variable(grizzly.scenario, value)), 0)), 1)
 
     if has_template(value):
-        grizzly.scenario.orphan_templates.append(value)
+        for scenario in grizzly.scenarios:
+            scenario.orphan_templates.append(value)
 
     assert user_count >= 0, f'{value} resolved to {user_count} users, which is not valid'
 
@@ -85,7 +86,8 @@ def step_shapes_spawn_rate(context: Context, value: str, **_kwargs: Any) -> None
     spawn_rate = max(float(resolve_variable(grizzly.scenario, value)), 0.01)
 
     if has_template(value):
-        grizzly.scenario.orphan_templates.append(value)
+        for scenario in grizzly.scenarios:
+            scenario.orphan_templates.append(value)
 
     assert spawn_rate > 0.0, f'{value} resolved to {spawn_rate} users, which is not valid'
 

--- a/grizzly/tasks/clients/__init__.py
+++ b/grizzly/tasks/clients/__init__.py
@@ -254,7 +254,7 @@ class ClientTask(GrizzlyMetaRequestTask):
                 action = action or meta.get('action', self.payload_variable)
                 name = f'{parent.user._scenario.identifier} {self._short_name}{meta.get("direction", self._direction_arrow[self.direction])}{action}'
             else:
-                rendered_name = parent.render(self.name)
+                rendered_name = parent.user.render(self.name)
                 name = f'{parent.user._scenario.identifier} {rendered_name}'
 
             response_time = int((time() - start_time) * 1000)

--- a/grizzly/tasks/clients/blobstorage.py
+++ b/grizzly/tasks/clients/blobstorage.py
@@ -168,9 +168,9 @@ class BlobStorageClientTask(ClientTask):
         raise NotImplementedError(message)
 
     def put(self, parent: GrizzlyScenario) -> GrizzlyResponse:
-        source = parent.render(cast(str, self.source))
+        source = parent.user.render(cast(str, self.source))
 
-        destination = parent.render(self.destination) if self.destination is not None else Path(source).name
+        destination = parent.user.render(self.destination) if self.destination is not None else Path(source).name
 
         content_type, _ = mimetype_guess(destination)
 
@@ -185,7 +185,7 @@ class BlobStorageClientTask(ClientTask):
             if not source_file.exists():
                 raise FileNotFoundError(source)
 
-            source = parent.render(source_file.read_text())
+            source = parent.user.render(source_file.read_text())
 
             meta.update({'request': {
                 'url': f'{destination}@{self.container}',

--- a/grizzly/tasks/clients/http.py
+++ b/grizzly/tasks/clients/http.py
@@ -139,7 +139,7 @@ class HttpClientTask(ClientTask, GrizzlyHttpAuthClient):
     @refresh_token(AAD)
     def get(self, parent: GrizzlyScenario) -> GrizzlyResponse:
         with self.action(parent) as meta:
-            url = parent.render(self.endpoint)
+            url = parent.user.render(self.endpoint)
 
             meta.update({'request': {
                 'url': url,

--- a/grizzly/tasks/clients/messagequeue.py
+++ b/grizzly/tasks/clients/messagequeue.py
@@ -348,11 +348,11 @@ class MessageQueueClientTask(ClientTask):
         return metadata, payload
 
     def put(self, parent: GrizzlyScenario) -> GrizzlyResponse:
-        source = parent.render(cast(str, self.source))
+        source = parent.user.render(cast(str, self.source))
         source_file = Path(self._context_root) / 'requests' / source
 
         if source_file.exists():
-            source = parent.render(source_file.read_text())
+            source = parent.user.render(source_file.read_text())
 
         request: AsyncMessageRequest = {
             'action': 'PUT',

--- a/grizzly/tasks/clients/servicebus.py
+++ b/grizzly/tasks/clients/servicebus.py
@@ -441,11 +441,11 @@ class ServiceBusClientTask(ClientTask):
     def put(self, parent: GrizzlyScenario) -> GrizzlyResponse:
         state = self.get_state(parent)
 
-        source = parent.render(cast(str, self.source))
+        source = parent.user.render(cast(str, self.source))
         source_file = Path(self._context_root) / 'requests' / source
 
         if source_file.exists():
-            source = parent.render(source_file.read_text())
+            source = parent.user.render(source_file.read_text())
 
         request: AsyncMessageRequest = {
             'action': 'SEND',

--- a/grizzly/tasks/conditional.py
+++ b/grizzly/tasks/conditional.py
@@ -97,7 +97,7 @@ class ConditionalTask(GrizzlyTaskWrapper):
 
         @grizzlytask
         def task(parent: GrizzlyScenario) -> Any:
-            condition_rendered = parent.render(self.condition)
+            condition_rendered = parent.user.render(self.condition)
             exception: Optional[Exception] = None
             task_count = 0
 

--- a/grizzly/tasks/date.py
+++ b/grizzly/tasks/date.py
@@ -84,14 +84,14 @@ class DateTask(GrizzlyTask):
     def __call__(self) -> grizzlytask:
         @grizzlytask
         def task(parent: GrizzlyScenario) -> Any:
-            value_rendered = parent.render(self.value)
+            value_rendered = parent.user.render(self.value)
 
             arguments_rendered: dict[str, str] = {}
 
             for argument_name, argument_value in self.arguments.items():
                 if argument_value is None:
                     continue
-                arguments_rendered[argument_name] = parent.render(argument_value)
+                arguments_rendered[argument_name] = parent.user.render(argument_value)
 
             try:
                 date_value = dateparser(value_rendered)
@@ -101,14 +101,14 @@ class DateTask(GrizzlyTask):
 
             offset = self.arguments.get('offset', None)
             if offset is not None:
-                offset_rendered = parent.render(offset)
+                offset_rendered = parent.user.render(offset)
                 offset_params = cast(Any, parse_timespan(offset_rendered))
                 date_value += relativedelta(**offset_params)
 
             timezone_argument = self.arguments.get('timezone', None)
             timezone: Optional[ZoneInfo] = None  # None in asttimezone == local time zone
             if timezone_argument is not None:
-                timezone_argument = parent.render(timezone_argument)
+                timezone_argument = parent.user.render(timezone_argument)
                 try:
                     timezone = ZoneInfo(timezone_argument)
                 except ZoneInfoNotFoundError as e:

--- a/grizzly/tasks/keystore.py
+++ b/grizzly/tasks/keystore.py
@@ -81,7 +81,7 @@ class KeystoreTask(GrizzlyTask):
                         value = cast(Any, self.default_value)
 
                     if value is not None and self.action_context is not None:
-                        parent.user.set_variable(self.action_context, jsonloads(parent.render(jsondumps(value))))
+                        parent.user.set_variable(self.action_context, jsonloads(parent.user.render(jsondumps(value))))
                     else:
                         message = f'key {self.key} does not exist in keystore'
                         raise RuntimeError(message)
@@ -89,7 +89,7 @@ class KeystoreTask(GrizzlyTask):
                     value = parent.consumer.keystore_inc(self.key, step=1)
 
                     if value is not None and self.action_context is not None:
-                        parent.user.set_variable(self.action_context, jsonloads(parent.render(jsondumps(value))))
+                        parent.user.set_variable(self.action_context, jsonloads(parent.user.render(jsondumps(value))))
                     else:
                         message = f'key {self.key} does not exist in keystore'
                         raise RuntimeError(message)

--- a/grizzly/tasks/log_message.py
+++ b/grizzly/tasks/log_message.py
@@ -36,7 +36,7 @@ class LogMessageTask(GrizzlyTask):
     def __call__(self) -> grizzlytask:
         @grizzlytask
         def task(parent: GrizzlyScenario) -> Any:
-            message = parent.render(self.message)
+            message = parent.user.render(self.message)
             parent.logger.info(message)
 
         return task

--- a/grizzly/tasks/loop.py
+++ b/grizzly/tasks/loop.py
@@ -70,14 +70,14 @@ class LoopTask(GrizzlyTaskWrapper):
 
         @grizzlytask
         def task(parent: GrizzlyScenario) -> Any:
-            orig_value = parent.user._scenario.variables.get(self.variable, None)
+            orig_value = parent.user.variables.get(self.variable, None)
             start = perf_counter()
             exception: Optional[Exception] = None
             task_count = len(self.tasks)
             response_length: int = 0
 
             try:
-                values = jsonloads(parent.render(self.values))
+                values = jsonloads(parent.user.render(self.values))
 
                 if not isinstance(values, list):
                     message = f'"{self.values}" is not a list'

--- a/grizzly/tasks/request.py
+++ b/grizzly/tasks/request.py
@@ -67,8 +67,6 @@ from . import GrizzlyMetaRequestTask, grizzlytask
 from . import template as task_template
 
 if TYPE_CHECKING:  # pragma: no cover
-    from jinja2.environment import Template
-
     from grizzly.events.response_handler import ResponseHandlerAction
     from grizzly.scenarios import GrizzlyScenario
     from grizzly.types import GrizzlyResponse, RequestMethod
@@ -115,8 +113,7 @@ class RequestTask(GrizzlyMetaRequestTask):
     method: RequestMethod
     name: str
     endpoint: str
-    _template: Optional[Template]
-    _source: Optional[str]
+    source: Optional[str]
     arguments: Optional[dict[str, str]]
     metadata: dict[str, str]
     async_request: bool
@@ -133,8 +130,7 @@ class RequestTask(GrizzlyMetaRequestTask):
         self.metadata = {}
         self.async_request = False
 
-        self._template = None
-        self._source = source
+        self.source = source
 
         self.response = RequestTaskResponse()
         self.__rendered__ = False
@@ -163,24 +159,6 @@ class RequestTask(GrizzlyMetaRequestTask):
 
         self.response.content_type = content_type
         self.content_type = content_type
-
-    @property
-    def source(self) -> Optional[str]:
-        return self._source
-
-    @source.setter
-    def source(self, value: Optional[str]) -> None:
-        """Reset template if source is changed."""
-        self._template = None
-        self._source = value
-
-    @property
-    def template(self) -> Optional[Template]:
-        """Get template, or if it doesn't exist create it."""
-        if self._source is None:
-            return None
-
-        return self._template
 
     def add_metadata(self, key: str, value: str) -> None:
         """Add new metadata key value, where default value of metadata is None, it must be initialized as a dict."""

--- a/grizzly/tasks/set_variable.py
+++ b/grizzly/tasks/set_variable.py
@@ -77,10 +77,10 @@ class SetVariableTask(GrizzlyTask):
     def __call__(self) -> grizzlytask:
         @grizzlytask
         def task(parent: GrizzlyScenario) -> Any:
-            value = parent.render(self.value)
+            value = parent.user.render(self.value)
 
             if is_file(value):
-                value = parent.render(read_file(value))
+                value = parent.user.render(read_file(value))
 
             if self.variable_type == VariableType.VARIABLES:
                 # Atomic variables that has support for __setitem__

--- a/grizzly/tasks/set_variable.py
+++ b/grizzly/tasks/set_variable.py
@@ -82,11 +82,12 @@ class SetVariableTask(GrizzlyTask):
             if is_file(value):
                 value = parent.user.render(read_file(value))
 
+            parent.logger.debug('%s: variable=%s, value=%r, type=%s', self.__class__.__name__, self.variable, value, self.variable_type.name)
+
             if self.variable_type == VariableType.VARIABLES:
                 # Atomic variables that has support for __setitem__
                 if self._variable_instance is None and self._variable_instance_type is not None:
                     self._variable_instance = cast(MutableMapping[str, Any], self._variable_instance_type.get(parent.user._scenario))
-
 
                 if self._variable_instance is not None:
                     self._variable_instance[self._variable_key] = value

--- a/grizzly/tasks/timer.py
+++ b/grizzly/tasks/timer.py
@@ -50,7 +50,7 @@ class TimerTask(GrizzlyTask):
         @grizzlytask
         def task(parent: GrizzlyScenario) -> Any:
             name = f'{parent.user._scenario.identifier} {self.name}'
-            variable = parent.user._scenario.variables.get(self.variable, None)
+            variable = parent.user.variables.get(self.variable, None)
 
             # start timer
             if variable is None:
@@ -74,6 +74,6 @@ class TimerTask(GrizzlyTask):
                     exception=None,
                 )
 
-                del parent.user._scenario.variables[self.variable]
+                del parent.user.variables[self.variable]
 
         return task

--- a/grizzly/tasks/transformer.py
+++ b/grizzly/tasks/transformer.py
@@ -82,7 +82,7 @@ class TransformerTask(GrizzlyTask):
             response_length = 0
 
             try:
-                content_raw = parent.render(self.content)
+                content_raw = parent.user.render(self.content)
                 response_length = len(content_raw)
 
                 try:

--- a/grizzly/tasks/until.py
+++ b/grizzly/tasks/until.py
@@ -119,8 +119,8 @@ class UntilRequestTask(GrizzlyTask):
         @grizzlytask
         def task(parent: GrizzlyScenario) -> Any:  # noqa: C901, PLR0912, PLR0915
             task_name = f'{parent.user._scenario.identifier} {self.request.name}, w={self.wait}s, r={self.retries}, em={self.expected_matches}'
-            condition_rendered = parent.render(self.condition)
-            endpoint_rendered = parent.render(self.request.endpoint)
+            condition_rendered = parent.user.render(self.condition)
+            endpoint_rendered = parent.user.render(self.request.endpoint)
 
             if not transform.validate(condition_rendered):
                 message = f'{condition_rendered} is not a valid expression for {self.request.content_type.name}'

--- a/grizzly/tasks/wait_between.py
+++ b/grizzly/tasks/wait_between.py
@@ -53,7 +53,7 @@ class WaitBetweenTask(GrizzlyTask):
     def __call__(self) -> grizzlytask:
         @grizzlytask
         def task(parent: GrizzlyScenario) -> Any:
-            min_time_rendered = parent.render(self.min_time)
+            min_time_rendered = parent.user.render(self.min_time)
             try:
                 min_time = float(min_time_rendered.strip())
             except Exception as e:
@@ -64,7 +64,7 @@ class WaitBetweenTask(GrizzlyTask):
             max_time: Optional[float] = None
 
             if self.max_time is not None:
-                max_time_rendered = parent.render(self.max_time)
+                max_time_rendered = parent.user.render(self.max_time)
                 try:
                     max_time = float(max_time_rendered.strip())
                 except Exception as e:

--- a/grizzly/tasks/wait_explicit.py
+++ b/grizzly/tasks/wait_explicit.py
@@ -36,7 +36,7 @@ class ExplicitWaitTask(GrizzlyTask):
         @grizzlytask
         def task(parent: GrizzlyScenario) -> Any:
             try:
-                time_rendered = parent.render(self.time_expression)
+                time_rendered = parent.user.render(self.time_expression)
                 if len(time_rendered.strip()) < 1:
                     message = f'"{self.time_expression}" rendered into "{time_rendered}" which is not valid'
                     raise RuntimeError(message)

--- a/grizzly/tasks/write_file.py
+++ b/grizzly/tasks/write_file.py
@@ -52,7 +52,7 @@ class WriteFileTask(GrizzlyTask):
     def __call__(self) -> grizzlytask:
         @grizzlytask
         def task(parent: GrizzlyScenario) -> Any:
-            file_name = parent.render(self.file_name)
+            file_name = parent.user.render(self.file_name)
             file = Path(self._context_root) / 'requests' / file_name
 
 
@@ -65,7 +65,7 @@ class WriteFileTask(GrizzlyTask):
             response_length = 0
 
             try:
-                content = parent.render(self.content)
+                content = parent.user.render(self.content)
 
                 self.file.parent.mkdir(parents=True, exist_ok=True)
 

--- a/grizzly/testdata/ast.py
+++ b/grizzly/testdata/ast.py
@@ -142,11 +142,7 @@ def get_template_variables(grizzly: GrizzlyContext) -> dict[GrizzlyContextScenar
         found_variables.update(variables)
 
         declared_variables = AstVariableNameSet()
-        for variable in scenario.variables:
-            if variable in scenario.jinja2._globals:
-                continue
-
-            declared_variables.add(variable)
+        declared_variables.update(scenario.variables)
 
         # check except between declared variables and variables found in templates
         missing_in_templates = {variable for variable in declared_variables if variable not in found_variables} - template_variables.__conditional__

--- a/grizzly/testdata/communication.py
+++ b/grizzly/testdata/communication.py
@@ -32,14 +32,12 @@ class TestdataConsumer:
     __test__: bool = False
 
     scenario: GrizzlyScenario
-    logger: logging.Logger
     identifier: str
     stopped: bool
 
-    def __init__(self, scenario: GrizzlyScenario, identifier: str, address: str = 'tcp://127.0.0.1:5555') -> None:
+    def __init__(self, scenario: GrizzlyScenario, address: str = 'tcp://127.0.0.1:5555') -> None:
         self.scenario = scenario
-        self.identifier = identifier
-        self.logger = logging.getLogger(f'{__name__}/{self.identifier}')
+        self.identifier = scenario.__class__.__name__
 
         self.context = zmq.Context()
         self.socket = self.context.socket(zmq.REQ)
@@ -48,6 +46,10 @@ class TestdataConsumer:
         self.stopped = False
 
         self.logger.debug('connected to producer at %s', address)
+
+    @property
+    def logger(self) -> logging.Logger:
+        return self.scenario.logger
 
     def stop(self) -> None:
         if self.stopped:

--- a/grizzly/testdata/utils.py
+++ b/grizzly/testdata/utils.py
@@ -144,7 +144,7 @@ def resolve_template(scenario: GrizzlyContextScenario, value: str) -> str:
 
         assert template_variable in scenario.variables, f'value contained variable "{template_variable}" which has not been declared'
 
-    return template.render()
+    return template.render(**scenario.variables)
 
 
 def resolve_parameters(scenario: GrizzlyContextScenario, value: str) -> str:

--- a/grizzly/types/__init__.py
+++ b/grizzly/types/__init__.py
@@ -232,7 +232,7 @@ TestdataType = dict[str, dict[str, Any]]
 
 HandlerContextType = Union[dict[str, Any], Optional[Any]]
 
-GrizzlyVariableType = Union[str, float, int, bool] # , dict, list]
+GrizzlyVariableType = Union[str, float, int, bool]
 
 MessageCallback = Callable[Concatenate[Environment, Message, P], None]
 

--- a/grizzly/users/__init__.py
+++ b/grizzly/users/__init__.py
@@ -98,6 +98,8 @@ class GrizzlyUser(User, metaclass=GrizzlyUserMeta):
         self._scenario = copy(self.__scenario__)
         # these are not copied, and we can share reference
         self._scenario._tasks = self.__scenario__._tasks
+        # each instance of a user type should have their own globals dict
+        self._scenario.jinja2._globals = self.__scenario__.jinja2._globals.copy()
 
         self.logger = logging.getLogger(f'{self.__class__.__name__}/{id(self)}')
         self.abort = False

--- a/grizzly/utils/protocols.py
+++ b/grizzly/utils/protocols.py
@@ -66,7 +66,7 @@ def async_message_request_wrapper(parent: GrizzlyScenario, client: zmq.Socket, r
 
     try:
         request_string = json.dumps(request)
-        request_rendered = parent.render(request_string, escape_values=True)
+        request_rendered = parent.user.render(request_string)
         request = json.loads(request_rendered)
     except:
         parent.user.logger.error('failed to render request:\ntemplate=%r\nrendered=%r', request, request_rendered)  # noqa: TRY400

--- a/tests/e2e/steps/scenario/test_tasks.py
+++ b/tests/e2e/steps/scenario/test_tasks.py
@@ -13,11 +13,9 @@ if TYPE_CHECKING:  # pragma: no cover
     from tests.fixtures import End2EndFixture
 
 
-def test_e2e_step_task_request_text_with_name_to_endpoint(e2e_fixture: End2EndFixture) -> None:  # noqa: PLR0915
+def test_e2e_step_task_request_text_with_name_to_endpoint(e2e_fixture: End2EndFixture) -> None:
     def validate_requests(context: Context) -> None:
         from json import loads as jsonloads
-
-        from jinja2 import Template
 
         from grizzly.tasks import RequestTask
         from grizzly.types import RequestMethod
@@ -36,7 +34,6 @@ def test_e2e_step_task_request_text_with_name_to_endpoint(e2e_fixture: End2EndFi
         assert request.method == RequestMethod.POST, f'{request.method} != RequestMethod.POST'
         assert request.name == 'test-post', f'{request.name} != test-post'
         assert request.endpoint == '/api/echo', f'{request.endpoint} != /api/echo'
-        assert isinstance(request.template, Template), 'request.template is not a Template'
         assert request.source is not None, 'request.source is None'
         assert jsonloads(request.source) == {'test': 'post'}, f"{request.source} != {'test': 'post'}"
         assert request.response.content_type == TransformerContentType.UNDEFINED, f'{request.response.content_type} != TransformerContentType.UNDEFINED'
@@ -46,7 +43,6 @@ def test_e2e_step_task_request_text_with_name_to_endpoint(e2e_fixture: End2EndFi
         assert request.method == RequestMethod.PUT
         assert request.name == 'test-put'
         assert request.endpoint == '/api/echo'
-        assert isinstance(request.template, Template)
         assert request.source is not None
         assert jsonloads(request.source) == {'test': 'put'}
         assert request.response.content_type == TransformerContentType.JSON
@@ -56,7 +52,6 @@ def test_e2e_step_task_request_text_with_name_to_endpoint(e2e_fixture: End2EndFi
         assert request.method == RequestMethod.GET
         assert request.name == 'test-get'
         assert request.endpoint == '/api/echo'
-        assert request.template is None
         assert request.source is None
         assert request.response.content_type == TransformerContentType.UNDEFINED
 
@@ -65,7 +60,6 @@ def test_e2e_step_task_request_text_with_name_to_endpoint(e2e_fixture: End2EndFi
         assert request.method == RequestMethod.SEND
         assert request.name == 'test-send'
         assert request.endpoint == 'queue:receive-queue'
-        assert isinstance(request.template, Template)
         assert request.source is not None
         assert jsonloads(request.source) == {'test': 'send'}
         assert request.response.content_type == TransformerContentType.UNDEFINED
@@ -112,11 +106,9 @@ def test_e2e_step_task_request_text_with_name_to_endpoint(e2e_fixture: End2EndFi
     assert expected in result
 
 
-def test_e2e_step_task_request_file_with_name_endpoint(e2e_fixture: End2EndFixture) -> None:  # noqa: PLR0915
+def test_e2e_step_task_request_file_with_name_endpoint(e2e_fixture: End2EndFixture) -> None:
     def validate_requests(context: Context) -> None:
         from json import loads as jsonloads
-
-        from jinja2 import Template
 
         from grizzly.tasks import RequestTask
         from grizzly.types import RequestMethod
@@ -135,7 +127,6 @@ def test_e2e_step_task_request_file_with_name_endpoint(e2e_fixture: End2EndFixtu
         assert request.method == RequestMethod.SEND, f'{request.method} != RequestMethod.SEND'
         assert request.name == 'test-send', f'{request.name} != test-send'
         assert request.endpoint == 'queue:receive-queue', f'{request.endpoint} != queue:receive-queue'
-        assert isinstance(request.template, Template), 'request.template is not a Template'
         assert request.source is not None, 'request.source is None'
         assert jsonloads(request.source) == {'test': 'request-send'}, f"{request.source} != {'test': 'request-send'}"
         assert request.response.content_type == TransformerContentType.XML, f'{request.response.content_type} != TransformerContentType.XML'
@@ -146,7 +137,6 @@ def test_e2e_step_task_request_file_with_name_endpoint(e2e_fixture: End2EndFixtu
         assert request.method == RequestMethod.POST
         assert request.name == 'test-post'
         assert request.endpoint == '/api/echo'
-        assert isinstance(request.template, Template)
         assert request.source is not None
         assert jsonloads(request.source) == {'test': 'request-{{ post }}'}
         assert request.response.content_type == TransformerContentType.JSON
@@ -157,7 +147,6 @@ def test_e2e_step_task_request_file_with_name_endpoint(e2e_fixture: End2EndFixtu
         assert request.method == RequestMethod.PUT
         assert request.name == 'test-put-{{ foo }}'
         assert request.endpoint == '/api/echo?foo={{ bar }}'
-        assert isinstance(request.template, Template)
         assert request.source is not None
         assert jsonloads(request.source) == {'test': 'request-put-{{ foobar }}'}
         assert request.response.content_type == TransformerContentType.UNDEFINED
@@ -200,8 +189,6 @@ def test_e2e_step_task_request_file_with_name(e2e_fixture: End2EndFixture) -> No
     def validate_requests(context: Context) -> None:
         from json import loads as jsonloads
 
-        from jinja2 import Template
-
         from grizzly.tasks import RequestTask
         from grizzly.types import RequestMethod
         from grizzly_extras.transformer import TransformerContentType
@@ -219,7 +206,6 @@ def test_e2e_step_task_request_file_with_name(e2e_fixture: End2EndFixture) -> No
             assert request.method == RequestMethod.POST
             assert request.name == f'test-post-{index}'
             assert request.endpoint == '/api/echo'
-            assert isinstance(request.template, Template)
             assert request.source is not None
             assert jsonloads(request.source) == {'test': f'request-{{{{ post_{index} }}}}-{index}'}
             assert request.response.content_type == TransformerContentType.JSON
@@ -251,8 +237,6 @@ def test_e2e_step_task_request_text_with_name(e2e_fixture: End2EndFixture) -> No
     def validate_requests(context: Context) -> None:
         from json import loads as jsonloads
 
-        from jinja2 import Template
-
         from grizzly.tasks import RequestTask
         from grizzly.types import RequestMethod
         from grizzly_extras.transformer import TransformerContentType
@@ -270,7 +254,6 @@ def test_e2e_step_task_request_text_with_name(e2e_fixture: End2EndFixture) -> No
             assert request.method == RequestMethod.POST
             assert request.name == f'test-post-{index}'
             assert request.endpoint == '/api/echo'
-            assert isinstance(request.template, Template)
             assert request.source is not None
             assert jsonloads(request.source) == {'value': f'test-post-{index}'}
             assert request.response.content_type == TransformerContentType.JSON
@@ -281,7 +264,6 @@ def test_e2e_step_task_request_text_with_name(e2e_fixture: End2EndFixture) -> No
             assert request.method == RequestMethod.GET
             assert request.name == f'test-get-{index}'
             assert request.endpoint == '/api/echo'
-            assert request.template is None
             assert request.source is None
             assert request.response.content_type == TransformerContentType.XML
             assert len(request.get_templates()) == 0
@@ -858,8 +840,6 @@ def test_e2e_step_async_group(e2e_fixture: End2EndFixture) -> None:
     def validate_async_group(context: Context) -> None:
         from json import loads as jsonloads
 
-        from jinja2 import Template
-
         from grizzly.tasks import AsyncRequestGroupTask, RequestTask
         from grizzly.types import RequestMethod
 
@@ -887,7 +867,6 @@ def test_e2e_step_async_group(e2e_fixture: End2EndFixture) -> None:
         assert request.method == RequestMethod.POST
         assert request.name == 'async-group-{{ index }}:test-post-1'
         assert request.endpoint == '/api/echo'
-        assert isinstance(request.template, Template)
         assert request.source is not None
         assert jsonloads(request.source) == {'value': 'i have good news!'}
         assert request.get_templates() == ['async-group-{{ index }}:test-post-1']
@@ -897,7 +876,6 @@ def test_e2e_step_async_group(e2e_fixture: End2EndFixture) -> None:
         assert request.method == RequestMethod.GET
         assert request.name == 'async-group-{{ index }}:test-get-1'
         assert request.endpoint == '/api/echo?foo=bar'
-        assert request.template is None
         assert request.source is None
         assert request.get_templates() == ['async-group-{{ index }}:test-get-1']
 
@@ -907,7 +885,6 @@ def test_e2e_step_async_group(e2e_fixture: End2EndFixture) -> None:
         assert task.name == 'test-get-2'
         assert task.endpoint == '/api/echo?bar=foo'
         assert task.source is None
-        assert task.template is None
 
     e2e_fixture.add_validator(validate_async_group)
 

--- a/tests/e2e/test_variables.py
+++ b/tests/e2e/test_variables.py
@@ -11,13 +11,13 @@ if TYPE_CHECKING:  # pragma: no cover
 def test_e2e_variables(e2e_fixture: End2EndFixture) -> None:
     feature_file = e2e_fixture.create_feature(dedent("""Feature: variables
     Background: common configuration
-        Given "2" users
-        And spawn rate is "2" users per second
+        Given spawn rate is "2" users per second
         And value for variable "background_variable" is "foobar"
         And value for variable "AtomicIntegerIncrementer.test" is "10"
     Scenario: Scenario 1
-        Given a user of type "Dummy" load testing "null"
-        And repeat for "1" iteration
+        Given "2" users of type "Dummy" load testing "null"
+        And repeat for "2" iteration
+        And wait "0.0..0.5" seconds between tasks
         And value for variable "scenario_1" is "{{ background_variable }}"
         And value for variable "AtomicRandomString.scenario" is "AA%s | upper=True, count=10"
 
@@ -26,8 +26,9 @@ def test_e2e_variables(e2e_fixture: End2EndFixture) -> None:
         Then log message "Scenario 1::AtomicIntegerIncrementer.test={{ AtomicIntegerIncrementer.test }}"
         Then log message "Scenario 1::AtomicRandomString.scenario={{ AtomicRandomString.scenario }}"
     Scenario: Scenario 2
-        Given a user of type "Dummy" load testing "null"
-        And repeat for "1" iteration
+        Given "2" users of type "Dummy" load testing "null"
+        And repeat for "2" iteration
+        And wait "0.0..0.5" seconds between tasks
         And value for variable "scenario_2" is "{{ background_variable }}"
         And value for variable "AtomicRandomString.scenario" is "BB%s | upper=True, count=5"
 
@@ -45,10 +46,12 @@ def test_e2e_variables(e2e_fixture: End2EndFixture) -> None:
 
     print(result)
 
-    assert result.count('scenario_1=foobar') == 1
-    assert result.count('scenario_2=foobar') == 1
-    assert result.count('background_variable=foobar') == 2
+    assert result.count('scenario_1=foobar') == 2
+    assert result.count('scenario_2=foobar') == 2
+    assert result.count('background_variable=foobar') == 4
     assert result.count('Scenario 1::AtomicIntegerIncrementer.test=10') == 1
+    assert result.count('Scenario 1::AtomicIntegerIncrementer.test=11') == 1
     assert result.count('Scenario 2::AtomicIntegerIncrementer.test=10') == 1
-    assert result.count('Scenario 1::AtomicRandomString.scenario=AA') == 1
-    assert result.count('Scenario 2::AtomicRandomString.scenario=BB') == 1
+    assert result.count('Scenario 2::AtomicIntegerIncrementer.test=11') == 1
+    assert result.count('Scenario 1::AtomicRandomString.scenario=AA') == 2
+    assert result.count('Scenario 2::AtomicRandomString.scenario=BB') == 2

--- a/tests/unit/test_grizzly/auth/test_aad.py
+++ b/tests/unit/test_grizzly/auth/test_aad.py
@@ -116,7 +116,7 @@ class TestAzureAadCredential:
         with caplog.at_level(logging.DEBUG):
             task(parent)
 
-        payload = parent.user._scenario.variables.get('test_payload', None)
+        payload = parent.user.variables.get('test_payload', None)
         assert payload is not None
 
     @pytest.mark.skip(reason='needs real secrets')
@@ -162,7 +162,7 @@ class TestAzureAadCredential:
         with caplog.at_level(logging.DEBUG):
             task(parent)
 
-        payload = parent.user._scenario.variables.get('test_payload', None)
+        payload = parent.user.variables.get('test_payload', None)
         assert payload is not None
 
     @pytest.mark.parametrize(('version', 'login_start'), product(['v2.0'], ['initialize_uri', 'redirect_uri']))

--- a/tests/unit/test_grizzly/events/test_response_handler.py
+++ b/tests/unit/test_grizzly/events/test_response_handler.py
@@ -345,7 +345,7 @@ class TestSaveHandlerAction:
     def test___call__(self, grizzly_fixture: GrizzlyFixture) -> None:
         parent = grizzly_fixture()
 
-        assert 'test' not in parent.user._scenario.variables
+        assert 'test' not in parent.user.variables
 
         handler = SaveHandlerAction('test', expression='.*', match_with='.*')
         with pytest.raises(TypeError, match='could not find a transformer for UNDEFINED'):
@@ -357,28 +357,28 @@ class TestSaveHandlerAction:
         handler = SaveHandlerAction('test', expression='$.test.value', match_with='.*')
 
         handler((TransformerContentType.JSON, {'test': {'value': 'test'}}), parent.user)
-        assert parent.user._scenario.variables.get('test', None) == 'test'
-        del parent.user._scenario.variables['test']
+        assert parent.user.variables.get('test', None) == 'test'
+        del parent.user.variables['test']
 
         handler((TransformerContentType.JSON, {'test': {'value': 'nottest'}}), parent.user)
-        assert parent.user._scenario.variables.get('test', None) == 'nottest'
-        del parent.user._scenario.variables['test']
+        assert parent.user.variables.get('test', None) == 'nottest'
+        del parent.user.variables['test']
 
         parent.user.set_variable('value', 'test')
         handler = SaveHandlerAction('test', expression='$.test.value', match_with='.*({{ value }})$')
 
         handler((TransformerContentType.JSON, {'test': {'value': 'test'}}), parent.user)
-        assert parent.user._scenario.variables.get('test', None) == 'test'
-        del parent.user._scenario.variables['test']
+        assert parent.user.variables.get('test', None) == 'test'
+        del parent.user.variables['test']
 
         handler((TransformerContentType.JSON, {'test': {'value': 'nottest'}}), parent.user)
-        assert parent.user._scenario.variables.get('test', None) == 'test'
-        del parent.user._scenario.variables['test']
+        assert parent.user.variables.get('test', None) == 'test'
+        del parent.user.variables['test']
 
         # failed
         with pytest.raises(ResponseHandlerError, match='did not match value'):
             handler((TransformerContentType.JSON, {'test': {'name': 'test'}}), parent.user)
-        assert parent.user._scenario.variables.get('test', 'test') is None
+        assert parent.user.variables.get('test', 'test') is None
 
 
         for failure_exception in [None, StopUser, RestartScenario]:
@@ -391,7 +391,7 @@ class TestSaveHandlerAction:
         handler = SaveHandlerAction('test', expression='$.test[*].value', match_with='.*t.*')
         with pytest.raises(ResponseHandlerError, match='did not match value'):
             handler((TransformerContentType.JSON, {'test': [{'value': 'test'}, {'value': 'test'}]}), parent.user)
-        assert parent.user._scenario.variables.get('test', None) is None
+        assert parent.user.variables.get('test', None) is None
 
         # save object dict
         handler = SaveHandlerAction(
@@ -429,7 +429,7 @@ class TestSaveHandlerAction:
             parent.user,
         )
 
-        test_object = parent.user._scenario.variables.get('test_object', None)
+        test_object = parent.user.variables.get('test_object', None)
         assert jsonloads(test_object) == {
             'prop21': False,
             'prop22': 100,
@@ -477,7 +477,7 @@ class TestSaveHandlerAction:
             parent.user,
         )
 
-        test_list = parent.user._scenario.variables.get('test_list', None)
+        test_list = parent.user.variables.get('test_list', None)
         assert jsonloads(test_list) == [
             'prop41',
             True,
@@ -510,7 +510,7 @@ class TestSaveHandlerAction:
             parent.user,
         )
 
-        test_list = parent.user._scenario.variables.get('test_list', None)
+        test_list = parent.user.variables.get('test_list', None)
         assert jsonloads(test_list) == [
             'prop41',
         ]
@@ -534,7 +534,7 @@ class TestSaveHandlerAction:
             parent.user,
         )
 
-        test_list = parent.user._scenario.variables.get('test_list', None)
+        test_list = parent.user.variables.get('test_list', None)
         assert jsonloads(test_list) == [
             'prop41',
             'prop42',

--- a/tests/unit/test_grizzly/scenarios/test_iterator.py
+++ b/tests/unit/test_grizzly/scenarios/test_iterator.py
@@ -17,7 +17,7 @@ from grizzly.exceptions import RestartScenario, StopScenario
 from grizzly.scenarios import IteratorScenario
 from grizzly.tasks import ExplicitWaitTask, LogMessageTask, grizzlytask
 from grizzly.testdata.communication import TestdataConsumer
-from grizzly.testdata.utils import templatingfilter, transform
+from grizzly.testdata.utils import transform
 from grizzly.types import ScenarioState
 from tests.helpers import RequestCalled, TestTask, regex
 
@@ -35,25 +35,6 @@ class TestIterationScenario:
         assert isinstance(parent, IteratorScenario)
         assert issubclass(parent.__class__, SequentialTaskSet)
         assert parent.pace_time is None
-
-    def test_render(self, grizzly_fixture: GrizzlyFixture) -> None:
-        parent = grizzly_fixture(scenario_type=IteratorScenario)
-
-        assert isinstance(parent, IteratorScenario)
-
-        @templatingfilter
-        def sarcasm(value: str) -> str:
-            sarcastic_value: list[str] = []
-            for index, c in enumerate(value):
-                if index % 2 == 0:
-                    sarcastic_value.append(c.upper())
-                else:
-                    sarcastic_value.append(c.lower())
-
-            return ''.join(sarcastic_value)
-
-        parent.user.set_variable('are', 'foo')
-        assert parent.render('how {{ are }} we {{ doing | sarcasm }} today', variables={'doing': 'bar'}) == 'how foo we BaR today'
 
     def test_populate(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
         parent = grizzly_fixture(scenario_type=IteratorScenario)
@@ -206,14 +187,14 @@ class TestIterationScenario:
         with pytest.raises(StopScenario):
             parent.iterator()
 
-        assert parent.user._scenario.variables == parent.user._scenario.jinja2._globals
+        assert parent.user.variables == {}
 
         mock_request({})
 
         with pytest.raises(StopScenario):
             parent.iterator()
 
-        assert parent.user._scenario.variables == parent.user._scenario.jinja2._globals
+        assert parent.user.variables == {}
 
         mock_request({
             'variables': {
@@ -227,9 +208,9 @@ class TestIterationScenario:
 
         parent.iterator(prefetch=True)
 
-        assert parent.user._scenario.variables['AtomicIntegerIncrementer'].messageID == 1337
-        assert parent.user._scenario.variables['AtomicCsvReader'].test.header1 == 'value1'
-        assert parent.user._scenario.variables['AtomicCsvReader'].test.header2 == 'value2'
+        assert parent.user.variables['AtomicIntegerIncrementer'].messageID == 1337
+        assert parent.user.variables['AtomicCsvReader'].test.header1 == 'value1'
+        assert parent.user.variables['AtomicCsvReader'].test.header2 == 'value2'
         assert getattr(parent, '_prefetch', False)
 
         mock_request({
@@ -244,16 +225,16 @@ class TestIterationScenario:
 
         parent.iterator()
 
-        assert parent.user._scenario.variables['AtomicIntegerIncrementer'].messageID == 1337
-        assert parent.user._scenario.variables['AtomicCsvReader'].test.header1 == 'value1'
-        assert parent.user._scenario.variables['AtomicCsvReader'].test.header2 == 'value2'
+        assert parent.user.variables['AtomicIntegerIncrementer'].messageID == 1337
+        assert parent.user.variables['AtomicCsvReader'].test.header1 == 'value1'
+        assert parent.user.variables['AtomicCsvReader'].test.header2 == 'value2'
         assert not getattr(parent, '_prefetch', True)
 
         parent.iterator()
 
-        assert parent.user._scenario.variables['AtomicIntegerIncrementer'].messageID == 1338
-        assert parent.user._scenario.variables['AtomicCsvReader'].test.header1 == 'value3'
-        assert parent.user._scenario.variables['AtomicCsvReader'].test.header2 == 'value4'
+        assert parent.user.variables['AtomicIntegerIncrementer'].messageID == 1338
+        assert parent.user.variables['AtomicCsvReader'].test.header1 == 'value3'
+        assert parent.user.variables['AtomicCsvReader'].test.header2 == 'value4'
         assert not getattr(parent, '_prefetch', True)
 
     def test_pace(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:  # noqa: PLR0915
@@ -704,7 +685,7 @@ class TestIterationScenario:
             def __call__(self) -> grizzlytask:
                 @grizzlytask
                 def task(parent: GrizzlyScenario) -> Any:
-                    if parent.user._scenario.variables.get('foo', None) is None:
+                    if parent.user.variables.get('foo', None) is None:
                         raise RestartScenario
 
                     parent.user.stop()
@@ -795,7 +776,7 @@ class TestIterationScenario:
                 "scenario_state=STOPPED, user_state=stopping, exception=StopUser()",
             ]
 
-            actual_messages = [message for message in caplog.messages if 'context variable=' not in message]
+            actual_messages = [message for message in caplog.messages if 'instance variable=' not in message]
 
             assert len(actual_messages) == len(expected_messages)
 

--- a/tests/unit/test_grizzly/scenarios/test_iterator.py
+++ b/tests/unit/test_grizzly/scenarios/test_iterator.py
@@ -184,7 +184,7 @@ class TestIterationScenario:
         assert isinstance(parent, IteratorScenario)
         assert not parent._prefetch
 
-        parent.consumer = TestdataConsumer(parent, identifier='test')
+        parent.consumer = TestdataConsumer(parent)
 
         def mock_request(data: Optional[dict[str, Any]]) -> None:
             def testdata_request(self: TestdataConsumer, scenario: str) -> Optional[dict[str, Any]]:  # noqa: ARG001

--- a/tests/unit/test_grizzly/steps/scenario/tasks/test_request.py
+++ b/tests/unit/test_grizzly/steps/scenario/tasks/test_request.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, cast
 
 import pytest
-from jinja2 import Template
 from parse import compile
 
 from grizzly.context import GrizzlyContext
@@ -118,7 +117,6 @@ def test_step_task_request_text_with_name_endpoint_to(behave_fixture: BehaveFixt
 
     task = grizzly.scenario.tasks()[-1]
     assert isinstance(task, RequestTask)
-    assert isinstance(task.template, Template)
     assert task.source == '{}'
 
     step_task_request_text_with_name_endpoint(behave, method, 'test-name', RequestDirection.FROM, '/api/test')

--- a/tests/unit/test_grizzly/steps/test__helpers.py
+++ b/tests/unit/test_grizzly/steps/test__helpers.py
@@ -266,13 +266,13 @@ def test_add_save_handler(grizzly_fixture: GrizzlyFixture, *, as_async: bool, de
     tasks.clear()
 
     assert len(tasks) == 0
-    assert parent.user._scenario.variables == parent.user._scenario.jinja2._globals
+    assert parent.user.variables == {}
 
     # not preceeded by a request source
     with pytest.raises(AssertionError, match='variable "test-variable" has not been declared'):
         add_save_handler(grizzly, ResponseTarget.METADATA, '$.test.value', 'test', 'test-variable', default_value=default_value)
 
-    assert parent.user._scenario.variables == parent.user._scenario.jinja2._globals
+    assert parent.user.variables == {}
 
     # add request source
     add_request_task(behave, method=RequestMethod.GET, source='{}', name='test', endpoint='/api/v2/test')
@@ -312,35 +312,35 @@ def test_add_save_handler(grizzly_fixture: GrizzlyFixture, *, as_async: bool, de
     payload_handler = next(iter(task.response.handlers.payload))
 
     metadata_handler((TransformerContentType.JSON, {'test': {'value': 'metadata'}}), parent.user)
-    assert parent.user._scenario.variables.get('test-variable-metadata', None) == 'metadata'
+    assert parent.user.variables.get('test-variable-metadata', None) == 'metadata'
 
-    del parent.user._scenario.variables['test-variable-metadata']
+    del parent.user.variables['test-variable-metadata']
 
     if default_value is None:
         with pytest.raises(ResponseHandlerError, match=r'"\$\.test.value" did not match value'):
             metadata_handler((TransformerContentType.JSON, {'test': {'attribute': 'metadata'}}), parent.user)
     else:
         metadata_handler((TransformerContentType.JSON, {'test': {'attribute': 'metadata'}}), parent.user)
-        assert parent.user._scenario.variables.get('test-variable-metadata', None) == default_value
+        assert parent.user.variables.get('test-variable-metadata', None) == default_value
 
     payload_handler((TransformerContentType.JSON, {'test': {'value': 'payload'}}), parent.user)
-    assert parent.user._scenario.variables.get('test-variable-payload', None) == 'payload'
+    assert parent.user.variables.get('test-variable-payload', None) == 'payload'
 
     if default_value is None:
         with pytest.raises(ResponseHandlerError, match='did not match value'):
             metadata_handler((TransformerContentType.JSON, {'test': {'name': 'metadata'}}), parent.user)
-        assert parent.user._scenario.variables.get('test-variable-metadata', 'metadata') is None
+        assert parent.user.variables.get('test-variable-metadata', 'metadata') is None
 
         with pytest.raises(ResponseHandlerError, match='did not match value'):
             payload_handler((TransformerContentType.JSON, {'test': {'name': 'payload'}}), parent.user)
-        assert parent.user._scenario.variables.get('test-variable-payload', 'payload') is None
+        assert parent.user.variables.get('test-variable-payload', 'payload') is None
 
     else:
         metadata_handler((TransformerContentType.JSON, {'test': {'name': 'metadata'}}), parent.user)
-        assert parent.user._scenario.variables.get('test-variable-metadata', 'metadata') == default_value
+        assert parent.user.variables.get('test-variable-metadata', 'metadata') == default_value
 
         payload_handler((TransformerContentType.JSON, {'test': {'name': 'payload'}}), parent.user)
-        assert parent.user._scenario.variables.get('test-variable-payload', 'payload') == default_value
+        assert parent.user.variables.get('test-variable-payload', 'payload') == default_value
 
     # previous non RequestTask task
     tasks.append(ExplicitWaitTask(time_expression='1.0'))

--- a/tests/unit/test_grizzly/steps/test_setup.py
+++ b/tests/unit/test_grizzly/steps/test_setup.py
@@ -380,7 +380,7 @@ def test_step_setup_set_context_variable_runtime(grizzly_fixture: GrizzlyFixture
     assert isinstance(task_factory, SetVariableTask)
     assert task_factory.variable_type == VariableType.CONTEXT
 
-    AAD.initialize(parent.user)
+    AAD.initialize(parent.user, parent.user)
 
     assert isinstance(parent.user.credential, AzureAadCredential)
     credential_bob = parent.user.credential

--- a/tests/unit/test_grizzly/tasks/clients/test_http.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_http.py
@@ -161,7 +161,7 @@ class TestHttpClientTask:
 
             task(parent)
 
-            assert parent.user._scenario.variables.get('test', '') is None  # not set
+            assert parent.user.variables.get('test', '') is None  # not set
             requests_get_spy.assert_called_once_with(
                 'http://example.org',
                 headers={'x-grizzly-user': f'HttpClientTestTask::{id(task_factory)}'},
@@ -195,7 +195,7 @@ class TestHttpClientTask:
             with pytest.raises(RestartScenario):
                 task(parent)
 
-            assert parent.user._scenario.variables.get('test', '') is None  # not set
+            assert parent.user.variables.get('test', '') is None  # not set
             requests_get_spy.assert_called_once_with(
                 'http://example.org',
                 headers={'x-grizzly-user': f'HttpClientTestTask::{id(task_factory)}'},
@@ -222,7 +222,7 @@ class TestHttpClientTask:
 
             task(parent)
 
-            assert parent.user._scenario.variables.get('test', '') is None  # not set
+            assert parent.user.variables.get('test', '') is None  # not set
             requests_get_spy.assert_called_once_with(
                 'http://example.org',
                 headers={'x-grizzly-user': f'HttpClientTestTask::{id(task_factory)}'},

--- a/tests/unit/test_grizzly/tasks/clients/test_messagequeue.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_messagequeue.py
@@ -418,6 +418,7 @@ class TestMessageQueueClientTask:
         assert isinstance(parent, IteratorScenario)
 
         parent.grizzly.scenario.variables.update({'mq-client-var': 'none', 'mq-client-metadata': 'none'})
+        parent.user.variables.update({'mq-client-var': 'none', 'mq-client-metadata': 'none'})
 
         fire_spy = mocker.spy(parent.user.environment.events.request, 'fire')
 
@@ -443,8 +444,8 @@ class TestMessageQueueClientTask:
 
             task(parent)
 
-            assert parent.user._scenario.variables.get('mq-client-var', None) == 'none'
-            assert parent.user._scenario.variables.get('mq-client-metadata', None) == 'none'
+            assert parent.user.variables.get('mq-client-var', None) == 'none'
+            assert parent.user.variables.get('mq-client-metadata', None) == 'none'
             assert task_factory._worker.get(id(parent.user), None) == 'dddd-eeee-ffff-9999'
             assert send_json_mock.call_count == 2
             args, kwargs = send_json_mock.call_args_list[-1]
@@ -493,8 +494,8 @@ class TestMessageQueueClientTask:
 
             task(parent)
 
-            assert parent.user._scenario.variables.get('mq-client-var', None) == 'none'
-            assert parent.user._scenario.variables.get('mq-client-metadata', None) == 'none'
+            assert parent.user.variables.get('mq-client-var', None) == 'none'
+            assert parent.user.variables.get('mq-client-metadata', None) == 'none'
             send_json_mock.assert_called_once_with({
                 'action': 'GET',
                 'worker': 'dddd-eeee-ffff-9999',
@@ -534,8 +535,8 @@ class TestMessageQueueClientTask:
 
             task(parent)
 
-            assert parent.user._scenario.variables.get('mq-client-var', None) == 'none'
-            assert parent.user._scenario.variables.get('mq-client-metadata', None) == 'none'
+            assert parent.user.variables.get('mq-client-var', None) == 'none'
+            assert parent.user.variables.get('mq-client-metadata', None) == 'none'
             assert send_json_mock.call_count == 1
             send_json_mock.reset_mock()
             assert recv_json_mock.call_count == 5
@@ -557,8 +558,8 @@ class TestMessageQueueClientTask:
 
             task(parent)
 
-            assert parent.user._scenario.variables.get('mq-client-var', None) == '{"hello": "world", "foo": "bar"}'
-            assert parent.user._scenario.variables.get('mq-client-metadata', None) == '{"x-foo-bar": "test"}'
+            assert parent.user.variables.get('mq-client-var', None) == '{"hello": "world", "foo": "bar"}'
+            assert parent.user.variables.get('mq-client-metadata', None) == '{"x-foo-bar": "test"}'
             assert send_json_mock.call_count == 1
             send_json_mock.reset_mock()
             assert recv_json_mock.call_count == 6

--- a/tests/unit/test_grizzly/tasks/clients/test_servicebus.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_servicebus.py
@@ -381,7 +381,7 @@ class TestServiceBusClientTask:
         state.client = client_mock
         task._text = '1={{ condition }}'
 
-        parent.user._scenario.variables.update({'id': 'baz-bar-foo', 'condition': '2'})
+        parent.user.variables.update({'id': 'baz-bar-foo', 'condition': '2'})
         expected_context = state.context.copy()
         expected_context['endpoint'] = expected_context['endpoint'].replace('{{ id }}', 'baz-bar-foo')
 
@@ -702,7 +702,7 @@ class TestServiceBusClientTask:
             'payload': None,
         })
 
-        assert parent.user._scenario.variables == parent.user._scenario.jinja2._globals
+        assert parent.user.variables == {}
 
         request_mock.reset_mock()
 
@@ -718,7 +718,7 @@ class TestServiceBusClientTask:
             'payload': None,
         })
 
-        assert parent.user._scenario.variables.get('foobaz', None) == 'foobar'
+        assert parent.user.variables.get('foobaz', None) == 'foobar'
 
         # with payload and metadata variable
         task.payload_variable = 'foobaz'
@@ -734,7 +734,7 @@ class TestServiceBusClientTask:
             'payload': None,
         })
 
-        assert parent.user._scenario.variables == SOME(dict, {'foobaz': 'foobar', 'bazfoo': jsondumps({'x-foo-bar': 'hello'})})
+        assert parent.user.variables == SOME(dict, {'foobaz': 'foobar', 'bazfoo': jsondumps({'x-foo-bar': 'hello'})})
 
     def test_put(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
         scenario = grizzly_fixture()
@@ -782,7 +782,7 @@ class TestServiceBusClientTask:
         })
 
         request_mock.reset_mock()
-        del scenario.user._scenario.variables['foobar']
+        del scenario.user.variables['foobar']
 
         # source file
         (grizzly_fixture.test_context / 'requests' / 'source.json').write_text('hello world')
@@ -800,7 +800,7 @@ class TestServiceBusClientTask:
         request_mock.reset_mock()
 
         # source file, with template
-        scenario.user._scenario.variables.update({'foobar': 'hello world', 'filename': 'source.j2.json'})
+        scenario.user.variables.update({'foobar': 'hello world', 'filename': 'source.j2.json'})
         (grizzly_fixture.test_context / 'requests' / 'source.j2.json').write_text('{{ foobar }}')
         task.source = '{{ filename }}'
 

--- a/tests/unit/test_grizzly/tasks/test___init__.py
+++ b/tests/unit/test_grizzly/tasks/test___init__.py
@@ -166,6 +166,7 @@ class TestGrizzlyTask:
         grizzly.scenarios.deselect()
         parent.user._scenario = scenario_context
 
+        parent.user._scenario.variables.update({'endpoint_suffix': 'none'})
         parent.user.set_variable('endpoint_suffix', 'none')
 
         # conditional -> loop -> request

--- a/tests/unit/test_grizzly/tasks/test_date.py
+++ b/tests/unit/test_grizzly/tasks/test_date.py
@@ -53,33 +53,33 @@ class TestDateTask:
         task = task_factory()
         task(parent)
 
-        assert parent.user._scenario.variables['date_variable'] == '2022-01-16 10:47:01'
+        assert parent.user.variables['date_variable'] == '2022-01-16 10:47:01'
 
         task_factory = DateTask('date_variable', '2022-01-17 10:37:01 | offset=-22Y-1D, timezone=UTC')
         task = task_factory()
         task(parent)
 
-        assert parent.user._scenario.variables['date_variable'] == '2000-01-16 09:37:01'
+        assert parent.user.variables['date_variable'] == '2000-01-16 09:37:01'
 
         task_factory = DateTask('date_variable', '2022-01-17 10:37:01 | offset=-22Y-16D-37m59s, timezone=UTC, format="%d/%m %y %H.%M.%S"')
         task = task_factory()
         task(parent)
 
-        assert parent.user._scenario.variables['date_variable'] == '01/01 00 09.01.00'
+        assert parent.user.variables['date_variable'] == '01/01 00 09.01.00'
 
         expected = datetime.now().strftime('%d/%m -%y')
         task_factory = DateTask('date_variable', '{{ datetime.now() }} | format="%d/%m -%y"')
         task = task_factory()
         task(parent)
 
-        assert parent.user._scenario.variables['date_variable'] == expected
+        assert parent.user.variables['date_variable'] == expected
 
         parent.user.set_variable('date_value', '2022-01-17T10:48:37.000')
         task_factory = DateTask('date_variable', '{{ date_value }} | timezone=UTC, offset=-22Y2M3D, format="%d/%m %y %H:%M:%S"')
         task = task_factory()
         task(parent)
 
-        assert parent.user._scenario.variables['date_variable'] == '20/03 00 09:48:37'
+        assert parent.user.variables['date_variable'] == '20/03 00 09:48:37'
 
         task_factory.arguments['offset'] = 'asdf'
 
@@ -102,9 +102,9 @@ class TestDateTask:
 
         task(parent)
 
-        assert parent.user._scenario.variables['date_variable'] == datetime.now().strftime('%Y')
+        assert parent.user.variables['date_variable'] == datetime.now().strftime('%Y')
 
-        parent.user._scenario.variables.update({
+        parent.user.variables.update({
             'to_year': '2022',
             'to_month': '01',
             'to_day': '18',
@@ -115,7 +115,7 @@ class TestDateTask:
 
         task(parent)
 
-        assert parent.user._scenario.variables['date_variable'] == '2022'
+        assert parent.user.variables['date_variable'] == '2022'
 
         expected_datetime = dateparser('2022-05-19 07:20:00.123456+0200')
 
@@ -124,21 +124,21 @@ class TestDateTask:
         )
         datetime_mock.now.return_value = expected_datetime
 
-        parent.user._scenario.variables.update({'datetime': datetime_mock})
+        parent.user.variables.update({'datetime': datetime_mock})
 
         task_factory = DateTask('date_variable', '{{ datetime.now() }} | format="ISO-8601:DateTime"')
         task = task_factory()
 
         task(parent)
 
-        assert parent.user._scenario.variables['date_variable'] == '2022-05-19T07:20:00+02:00'
+        assert parent.user.variables['date_variable'] == '2022-05-19T07:20:00+02:00'
 
         task_factory = DateTask('date_variable', '{{ datetime.now() }} | format="ISO-8601:DateTime:ms"')
         task = task_factory()
 
         task(parent)
 
-        assert parent.user._scenario.variables['date_variable'] == '2022-05-19T07:20:00.123456+02:00'
+        assert parent.user.variables['date_variable'] == '2022-05-19T07:20:00.123456+02:00'
 
         task_factory = DateTask('date_variable', '{{ datetime.now() }} | format="ISO-8601:Time"')
         task = task_factory()
@@ -148,25 +148,25 @@ class TestDateTask:
         expected = expected_datetime.replace(microsecond=0).isoformat()
         _, expected = expected.split('T', 1)
 
-        assert parent.user._scenario.variables['date_variable'] == '07:20:00+02:00'
+        assert parent.user.variables['date_variable'] == '07:20:00+02:00'
 
         task_factory = DateTask('date_variable', '{{ datetime.now() }} | format="ISO-8601:Time:ms"')
         task = task_factory()
 
         task(parent)
 
-        assert parent.user._scenario.variables['date_variable'] == '07:20:00.123456+02:00'
+        assert parent.user.variables['date_variable'] == '07:20:00.123456+02:00'
 
         task_factory = DateTask('date_variable', '{{ datetime.now() }} | format="ISO-8601:DateTime:ms:no-sep"')
         task = task_factory()
 
         task(parent)
 
-        assert parent.user._scenario.variables['date_variable'] == '20220519T072000123456+02:00'
+        assert parent.user.variables['date_variable'] == '20220519T072000123456+02:00'
 
         task_factory = DateTask('date_variable', '{{ datetime.now() }} | format="ISO-8601:DateTime:no-sep"')
         task = task_factory()
 
         task(parent)
 
-        assert parent.user._scenario.variables['date_variable'] == '20220519T072000+02:00'
+        assert parent.user.variables['date_variable'] == '20220519T072000+02:00'

--- a/tests/unit/test_grizzly/tasks/test_keystore.py
+++ b/tests/unit/test_grizzly/tasks/test_keystore.py
@@ -52,8 +52,7 @@ class TestKeystoreTask:
             KeystoreTask('foobar', 'unknown', None)  # type: ignore[arg-type]
 
     def test___call___get(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
-        behave = grizzly_fixture.behave.context
-        grizzly = cast(GrizzlyContext, behave.grizzly)
+        grizzly = grizzly_fixture.grizzly
 
         parent = grizzly_fixture()
 
@@ -63,6 +62,7 @@ class TestKeystoreTask:
         parent.consumer = consumer_mock
 
         grizzly.scenario.variables.update({'foobar': 'none'})
+        parent.user.variables.update({'foobar': 'none'})
 
         # key does not exist in keystore
         setattr(parent.consumer.keystore_get, 'return_value', None)  # noqa: B010
@@ -76,7 +76,7 @@ class TestKeystoreTask:
         with pytest.raises(RestartScenario):
             task(parent)
 
-        assert parent.user._scenario.variables.get('foobar', None) == 'none'
+        assert parent.user.variables.get('foobar', None) == 'none'
 
         request_spy.assert_called_once_with(
             request_type='KEYS',
@@ -95,7 +95,7 @@ class TestKeystoreTask:
 
         request_spy.assert_not_called()
 
-        assert parent.user._scenario.variables.get('foobar', None) == ['hello', 'world']
+        assert parent.user.variables.get('foobar', None) == ['hello', 'world']
 
         # key does not exist in keystore, but has a default value
         setattr(parent.consumer.keystore_get, 'return_value', None)  # noqa: B010
@@ -108,7 +108,7 @@ class TestKeystoreTask:
 
         request_spy.assert_not_called()
         consumer_mock.keystore_set.assert_called_with('foobar', {'hello': 'world'})
-        assert parent.user._scenario.variables.get('foobar', None) == {'hello': 'world'}
+        assert parent.user.variables.get('foobar', None) == {'hello': 'world'}
 
     def test___call___set(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
         parent = grizzly_fixture()

--- a/tests/unit/test_grizzly/tasks/test_keystore.py
+++ b/tests/unit/test_grizzly/tasks/test_keystore.py
@@ -1,11 +1,10 @@
 """Unit tests of grizzly.tasks.keystore."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 import pytest
 
-from grizzly.context import GrizzlyContext
 from grizzly.exceptions import RestartScenario
 from grizzly.tasks import KeystoreTask
 from tests.helpers import ANY

--- a/tests/unit/test_grizzly/tasks/test_loop.py
+++ b/tests/unit/test_grizzly/tasks/test_loop.py
@@ -91,6 +91,7 @@ class TestLoopTask:
         grizzly.scenarios.append(scenario_context)
         parent.user._scenario = scenario_context
 
+        parent.user._scenario.variables.update({'foobar': 'none'})
         parent.user.set_variable('foobar', 'none')
 
         task_factory = LoopTask('test', '["hello", "world"]', 'foobar')
@@ -201,7 +202,7 @@ class TestLoopTask:
         }
 
         request_spy.reset_mock()
-        del parent.user._scenario.variables['json_input']
+        del parent.user.variables['json_input']
 
         # not a valid json input
         task_factory.values = '"hello'
@@ -290,6 +291,7 @@ class TestLoopTask:
         scenario_context = GrizzlyContextScenario(3, behave=grizzly_fixture.behave.create_scenario('test scenario'), grizzly=grizzly)
         scenario_context.name = scenario_context.description = 'test scenario'
 
+        parent.user._scenario.variables.update({'foobar': 'none'})
         parent.user.set_variable('foobar', 'none')
 
         task_factory = LoopTask('test', '[1, 2, 3, 4]', 'foobar')

--- a/tests/unit/test_grizzly/tasks/test_request.py
+++ b/tests/unit/test_grizzly/tasks/test_request.py
@@ -82,7 +82,6 @@ class TestRequestTask:
         assert not hasattr(task_factory, 'scenario')
 
         assert task_factory.source is None
-        assert task_factory.template is None
 
         task = task_factory()
         assert callable(task)
@@ -98,7 +97,6 @@ class TestRequestTask:
 
         # automagically create template if not set
         task_factory.source = 'hello {{ world }}'
-        assert task_factory.template is None
 
     def test_arguments(self) -> None:
         task_factory = RequestTask(RequestMethod.GET, 'test-name', endpoint='/api/test | content_type="application/json", foo=bar')

--- a/tests/unit/test_grizzly/tasks/test_set_variable.py
+++ b/tests/unit/test_grizzly/tasks/test_set_variable.py
@@ -69,15 +69,16 @@ class TestSetVariableTask:
 
             task = task_factory()
 
-            assert 'foobar' not in parent.user._scenario.variables
+            assert 'foobar' not in parent.user.variables
 
+            parent.user._scenario.variables.update({'value': 'none', 'AtomicCsvWriter.output': 'output.csv | headers="foo,bar"', 'bar': 'none'})
             parent.user.set_variable('value', 'hello world!')
 
             task(parent)
 
-            assert parent.user._scenario.variables.get('foobar', None) == 'hello world!'
+            assert parent.user.variables.get('foobar', None) == 'hello world!'
 
-            parent.user._scenario.jinja2.globals = GrizzlyVariables(**parent.user._scenario.jinja2._globals)
+            parent.user.variables = GrizzlyVariables()
 
             # settable Atomic variable
             set_value_mock = mocker.patch('grizzly.testdata.variables.csv_writer.AtomicCsvWriter.__setitem__', return_value=None)
@@ -91,7 +92,7 @@ class TestSetVariableTask:
             task(parent)
 
             set_value_mock.assert_called_once_with('output', 'file.csv | headers="foo,bar"')
-            assert 'AtomicCsvWriter.output.foo' not in parent.user._scenario.variables
+            assert 'AtomicCsvWriter.output.foo' not in parent.user.variables
 
             # set value from file runtime, and render file contents
             test_file = grizzly_fixture.test_context / 'requests' / 'test' / 'hello.foo.txt'
@@ -104,6 +105,6 @@ class TestSetVariableTask:
 
             task(parent)
 
-            assert parent.user._scenario.variables['foobar'] == 'file.csv'
+            assert parent.user.variables['foobar'] == 'file.csv'
         finally:
             cleanup()

--- a/tests/unit/test_grizzly/tasks/test_timer.py
+++ b/tests/unit/test_grizzly/tasks/test_timer.py
@@ -41,13 +41,13 @@ class TestTimerTask:
         parent.tasks += [dummy_task] * 7
 
         request_fire_spy.assert_not_called()
-        assert parent.user._scenario.variables == parent.user._scenario.jinja2._globals
+        assert parent.user.variables == {}
 
         parent._task_index = 1
         task(parent)
 
         request_fire_spy.assert_not_called()
-        assert parent.user._scenario.variables.get(f'{expected_variable_prefix}::test-timer-1', None) == {
+        assert parent.user.variables.get(f'{expected_variable_prefix}::test-timer-1', None) == {
             'start': 2.0,
             'task-index': 1,
         }
@@ -55,7 +55,7 @@ class TestTimerTask:
         parent._task_index = 9
         task(parent)
 
-        assert parent.user._scenario.variables == parent.user._scenario.jinja2._globals
+        assert parent.user.variables == {}
 
         request_fire_spy.assert_called_once_with(
             request_type='TIMR',
@@ -81,13 +81,13 @@ class TestTimerTask:
         parent.tasks += [task_2, task_1]
 
         request_fire_spy.assert_not_called()
-        assert parent.user._scenario.variables == parent.user._scenario.jinja2._globals
+        assert parent.user.variables == {}
 
         parent._task_index = 1
         task_1(parent)
 
         request_fire_spy.assert_not_called()
-        assert parent.user._scenario.variables == SOME(dict, {
+        assert parent.user.variables == SOME(dict, {
             f'{expected_variable_prefix_1}::test-timer-1': {
                 'start': 2.0,
                 'task-index': 1,
@@ -98,7 +98,7 @@ class TestTimerTask:
         task_2(parent)
 
         request_fire_spy.assert_not_called()
-        assert parent.user._scenario.variables == SOME(dict, {
+        assert parent.user.variables == SOME(dict, {
             f'{expected_variable_prefix_1}::test-timer-1': {
                 'start': 2.0,
                 'task-index': 1,
@@ -121,7 +121,7 @@ class TestTimerTask:
             exception=None,
         )
         request_fire_spy.reset_mock()
-        assert parent.user._scenario.variables == SOME(dict, {
+        assert parent.user.variables == SOME(dict, {
             f'{expected_variable_prefix_1}::test-timer-1': {
                 'start': 2.0,
                 'task-index': 1,
@@ -139,4 +139,4 @@ class TestTimerTask:
             context=parent.user._context,
             exception=None,
         )
-        assert parent.user._scenario.variables == parent.user._scenario.jinja2._globals
+        assert parent.user.variables == {}

--- a/tests/unit/test_grizzly/tasks/test_transformer.py
+++ b/tests/unit/test_grizzly/tasks/test_transformer.py
@@ -31,6 +31,7 @@ class TestTransformerTask:
             )
 
         grizzly.scenario.variables.update({'test_variable': 'none'})
+        parent.user.variables.update({'test_variable': 'none'})
 
         json_transformer = transformer.available[TransformerContentType.JSON]
         del transformer.available[TransformerContentType.JSON]
@@ -84,13 +85,14 @@ class TestTransformerTask:
 
         assert callable(task)
 
-        assert parent.user._scenario.variables.get('test_variable', None) == 'none'
+        assert parent.user.variables.get('test_variable', None) == 'none'
 
         task(parent)
 
-        assert parent.user._scenario.variables.get('test_variable', None) == 'hello world!'
+        assert parent.user.variables.get('test_variable', None) == 'hello world!'
 
         parent.user.set_variable('payload_url', 'none')
+        parent.user._scenario.variables.update({'payload_url': 'none'})
         content = jsondumps({
             "entityType": "contract",
             "entityConcreteType": "contract",
@@ -117,9 +119,9 @@ class TestTransformerTask:
 
         task(parent)
 
-        assert parent.user._scenario.variables.get('payload_url', None) == 'https://mystorageaccount.blob.core.windows.net/mycontainer/myfile'
+        assert parent.user.variables.get('payload_url', None) == 'https://mystorageaccount.blob.core.windows.net/mycontainer/myfile'
 
-        parent.user._scenario.variables.update({
+        parent.user.variables.update({
             'payload_url': None,
             'payload': content,
         })
@@ -137,7 +139,7 @@ class TestTransformerTask:
 
         task(parent)
 
-        assert parent.user._scenario.variables.get('payload_url', None) == 'https://mystorageaccount.blob.core.windows.net/mycontainer/myfile'
+        assert parent.user.variables.get('payload_url', None) == 'https://mystorageaccount.blob.core.windows.net/mycontainer/myfile'
 
         task_factory = TransformerTask(
             variable='test_variable',
@@ -181,11 +183,12 @@ class TestTransformerTask:
         task = task_factory()
         task(parent)
 
-        assert parent.user._scenario.variables['test_variable'] == """{"value": "hello world!"}
+        assert parent.user.variables['test_variable'] == """{"value": "hello world!"}
 {"value": "hello world!"}
 {"value": "hello world!"}"""
 
         parent.user._scenario.variables.update({'test_bool': 'none'})
+        parent.user.variables.update({'test_bool': 'none'})
         task_factory = TransformerTask(
             variable='test_bool',
             expression='$.success',
@@ -197,7 +200,7 @@ class TestTransformerTask:
         task = task_factory()
         task(parent)
 
-        assert parent.user._scenario.variables['test_bool']
+        assert parent.user.variables['test_bool']
 
         task_factory = TransformerTask(
             variable='test_variable',
@@ -223,8 +226,9 @@ class TestTransformerTask:
 
         task(parent)
 
-        assert parent.user._scenario.variables['test_variable'] == '<actor id="9">Michael Caine</actor>'
+        assert parent.user.variables['test_variable'] == '<actor id="9">Michael Caine</actor>'
 
+        parent.user._scenario.variables.update({'child_elem': 'none'})
         parent.user.set_variable('child_elem', 'none')
 
         task_factory = TransformerTask(
@@ -251,6 +255,6 @@ class TestTransformerTask:
 
         task(parent)
 
-        assert parent.user._scenario.variables['child_elem'] == """<actor id="7">Christian Bale</actor>
+        assert parent.user.variables['child_elem'] == """<actor id="7">Christian Bale</actor>
 <actor id="8">Liam Neeson</actor>
 <actor id="9">Michael Caine</actor>"""

--- a/tests/unit/test_grizzly/tasks/test_until.py
+++ b/tests/unit/test_grizzly/tasks/test_until.py
@@ -163,6 +163,7 @@ class TestUntilRequestTask:
 
         # -->
         parent.grizzly.scenario.variables.update({'wait': 100.0, 'retries': 10})
+        parent.user.variables.update({'wait': 100.0, 'retries': 10})
         task_factory = UntilRequestTask(meta_request_task, "$.`this`[?status='ready'] | wait='{{ wait }}', retries='{{ retries }}'")
         task = task_factory()
 

--- a/tests/unit/test_grizzly/tasks/test_write_file.py
+++ b/tests/unit/test_grizzly/tasks/test_write_file.py
@@ -28,6 +28,7 @@ class TestWriteFile:
         task = task_factory()
         assert callable(task)
 
+        parent.user._scenario.variables.update({'hello': 'none'})
         parent.user.set_variable('hello', 'foobar')
 
         expected_file = Path(task_factory._context_root) / 'requests' / 'test' / 'output.log'
@@ -54,7 +55,7 @@ class TestWriteFile:
 
         assert expected_file.read_text() == f'foobar{linesep}foobar{linesep}foobar{linesep}'
 
-        mocker.patch.object(parent, 'render', side_effect=['test/output.log', RuntimeError('no no')])
+        mocker.patch.object(parent.user, 'render', side_effect=['test/output.log', RuntimeError('no no')])
         request_fire_spy = mocker.spy(parent.user.environment.events.request, 'fire')
 
         task(parent)

--- a/tests/unit/test_grizzly/test_context.py
+++ b/tests/unit/test_grizzly/test_context.py
@@ -387,7 +387,6 @@ class TestGrizzlyContextScenario:
 
         second_request = RequestTask(RequestMethod.POST, name='Second Request', endpoint='/api/test/2')
         second_request.source = '{"hello": "world!"}'
-        assert second_request.template is None
 
         scenario.tasks.add(second_request)
         assert scenario.tasks() == [request, second_request]

--- a/tests/unit/test_grizzly/testdata/test_ast.py
+++ b/tests/unit/test_grizzly/testdata/test_ast.py
@@ -396,10 +396,7 @@ def test_get_template_variables_expressions(grizzly_fixture: GrizzlyFixture, cap
     grizzly.scenario.tasks.clear()
     grizzly.scenario.orphan_templates.clear()
     grizzly.scenario.tasks().clear()
-
-    for name in grizzly.scenario.variables:
-        if name not in grizzly.scenario.jinja2._globals:
-            del grizzly.scenario.variables[name]
+    grizzly.scenario.variables.clear()
 
     bob_csv = (grizzly_fixture.test_context / 'requests' / 'bob.csv')
     bob_csv.parent.mkdir(exist_ok=True)
@@ -429,10 +426,7 @@ def test_get_template_variables___doc___example(grizzly_fixture: GrizzlyFixture,
     grizzly.scenario.tasks.clear()
     grizzly.scenario.orphan_templates.clear()
     grizzly.scenario.tasks().clear()
-
-    for name in grizzly.scenario.variables:
-        if name not in grizzly.scenario.jinja2._globals:
-            del grizzly.scenario.variables[name]
+    grizzly.scenario.variables.clear()
 
     input_csv = (grizzly_fixture.test_context / 'requests' / 'input.csv')
     input_csv.parent.mkdir(exist_ok=True)

--- a/tests/unit/test_grizzly/testdata/test_communication.py
+++ b/tests/unit/test_grizzly/testdata/test_communication.py
@@ -679,7 +679,7 @@ class TestTestdataConsumer:
         parent = grizzly_fixture()
         grizzly = grizzly_fixture.grizzly
 
-        consumer = TestdataConsumer(parent, identifier='test')
+        consumer = TestdataConsumer(parent)
 
         try:
             mock_recv_json({})
@@ -759,7 +759,7 @@ class TestTestdataConsumer:
 
         parent = grizzly_fixture()
 
-        consumer = TestdataConsumer(parent, identifier='test')
+        consumer = TestdataConsumer(parent)
 
         with caplog.at_level(logging.DEBUG):
             consumer.stop()
@@ -789,7 +789,7 @@ class TestTestdataConsumer:
 
         parent = grizzly_fixture()
 
-        consumer = TestdataConsumer(parent, identifier='test')
+        consumer = TestdataConsumer(parent)
 
         with pytest.raises(ZMQAgain):
             consumer.testdata('test')
@@ -807,7 +807,7 @@ class TestTestdataConsumer:
         noop_zmq('grizzly.testdata.communication')
         parent = grizzly_fixture()
 
-        consumer = TestdataConsumer(parent, identifier='test')
+        consumer = TestdataConsumer(parent)
 
         def echo(value: dict[str, Any]) -> dict[str, Any]:
             return value

--- a/tests/unit/test_grizzly/testdata/test_communication.py
+++ b/tests/unit/test_grizzly/testdata/test_communication.py
@@ -98,7 +98,6 @@ value3,value4
             grizzly.scenario.context['host'] = 'http://test.nu'
 
             request.source = json.dumps(source)
-            request._template = grizzly.scenario.jinja2.from_string(request.source)
 
             grizzly.scenario.tasks.add(request)
             grizzly.scenario.tasks.add(LogMessageTask(message='hello {{ world }}'))
@@ -309,7 +308,6 @@ value3,value4
             source['result'].update({'File': '{{ AtomicDirectoryContents.file }}'})
 
             request.source = json.dumps(source)
-            request._template = grizzly.scenario.jinja2.from_string(request.source)
 
             grizzly.scenarios.clear()
             grizzly.scenarios.create(grizzly_fixture.behave.create_scenario(parent.__class__.__name__))

--- a/tests/unit/test_grizzly/testdata/test_utils.py
+++ b/tests/unit/test_grizzly/testdata/test_utils.py
@@ -178,7 +178,6 @@ value3,value4
         grizzly.scenario.orphan_templates.append('{{ AtomicCsvWriter.output.foo }}')
 
         request.source = jsondumps(source)
-        request._template = grizzly.scenario.jinja2.from_string(request.source)
 
         grizzly.scenario.tasks.add(request)
 

--- a/tests/unit/test_grizzly/users/test___init__.py
+++ b/tests/unit/test_grizzly/users/test___init__.py
@@ -180,7 +180,13 @@ class TestGrizzlyUser:
     def test_context(self, behave_fixture: BehaveFixture) -> None:
         behave_fixture.grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
         DummyGrizzlyUser.__scenario__ = behave_fixture.grizzly.scenario
+        original_id = id(DummyGrizzlyUser.__scenario__._jinja2)
         user = DummyGrizzlyUser(behave_fixture.locust.environment)
+
+        assert user._scenario is not DummyGrizzlyUser.__scenario__
+        assert id(user._scenario._jinja2) != original_id
+        assert id(user._scenario._jinja2.globals) != id(DummyGrizzlyUser.__scenario__._jinja2.globals)
+        assert user._scenario._jinja2.globals.keys() == DummyGrizzlyUser.__scenario__._jinja2.globals.keys()
 
         context = user.context()
 

--- a/tests/unit/test_grizzly/users/test___init__.py
+++ b/tests/unit/test_grizzly/users/test___init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import logging
 from contextlib import suppress
 from json import loads as jsonloads
-from os import environ
 from typing import TYPE_CHECKING
 
 import pytest

--- a/tests/unit/test_grizzly/users/test_messagequeue.py
+++ b/tests/unit/test_grizzly/users/test_messagequeue.py
@@ -481,7 +481,7 @@ class TestMessageQueueUser:
         add_save_handler(grizzly, ResponseTarget.PAYLOAD, '$.test', '.*', 'payload_variable', default_value=None)
         mq_parent.user.request(request)
 
-        assert mq_parent.user._scenario.variables['payload_variable'] == ''
+        assert mq_parent.user.variables['payload_variable'] == ''
         request_event_spy.assert_called_once_with(
             request_type='GET',
             exception=ANY(ResponseHandlerError, message='failed to transform input as JSON:'),
@@ -521,7 +521,7 @@ class TestMessageQueueUser:
         request.response.content_type = TransformerContentType.JSON
         mq_parent.user.request(request)
 
-        assert mq_parent.user._scenario.variables['payload_variable'] == 'payload_variable value'
+        assert mq_parent.user.variables['payload_variable'] == 'payload_variable value'
 
         request_event_spy.assert_called_once_with(
             request_type='GET',
@@ -779,7 +779,7 @@ class TestMessageQueueUser:
 
         mq_parent.user.add_context(remote_variables)
 
-        request = mq_parent.user.render(template)
+        request = mq_parent.user.render_request(template)
 
         assert request.source is not None
 

--- a/tests/unit/test_grizzly/users/test_restapi.py
+++ b/tests/unit/test_grizzly/users/test_restapi.py
@@ -382,7 +382,7 @@ class TestRestApiUser:
 
         assert parent.user.request(request) == ({'x-bar': 'foo'}, 'success')
 
-        expected_source = parent.user.render(request).source
+        expected_source = parent.user.render_request(request).source
         assert expected_source is not None
         expected_source_json = json.loads(expected_source)
 
@@ -477,7 +477,7 @@ class TestRestApiUser:
         assert parent.user._context['auth']['provider'] == 'http://auth.example.org'
         assert parent.user._context['auth']['refresh_time'] == 3000
 
-        AAD.initialize(parent.user)
+        AAD.initialize(parent.user, parent.user)
 
         parent.user.add_context({'auth': {'user': {'password': 'other'}}})
 


### PR DESCRIPTION
the original #335 turned out to be a mess in reality.

the variables has now been separated even more. when declaring variables `GrizzlyContextScenario.variables` is used, and during runtime `GrizzlyUser.variables` is used.

`GrizzlyScenario.render` has moved to `GrizzlyUser.render`.