### PR TITLE
PUT support in `HttpClientTask` and file contents when declaring variables

### DIFF
--- a/grizzly/steps/__init__.py
+++ b/grizzly/steps/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import parse
 
+from grizzly.types import RequestDirection, RequestMethod
 from grizzly.types.behave import register_type
 from grizzly_extras.text import permutation
 
@@ -15,6 +16,8 @@ def parse_user_gramatical_number(text: str) -> str:
 
 register_type(
     UserGramaticalNumber=parse_user_gramatical_number,
+    Direction=RequestDirection.from_string,
+    Method=RequestMethod.from_string,
 )
 
 

--- a/grizzly/steps/_helpers.py
+++ b/grizzly/steps/_helpers.py
@@ -5,7 +5,7 @@ import logging
 import re
 from errno import ENAMETOOLONG
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, cast
+from typing import TYPE_CHECKING, Optional, Union, cast
 from urllib.parse import urlparse
 
 import jinja2 as j2
@@ -13,7 +13,7 @@ import jinja2 as j2
 from grizzly.context import GrizzlyContext
 from grizzly.events.response_handler import ResponseHandlerAction, SaveHandlerAction, ValidationHandlerAction
 from grizzly.tasks import RequestTask
-from grizzly.tasks.clients import ClientTask, client
+from grizzly.tasks.clients import ClientTask, HttpClientTask, client
 from grizzly.testdata.utils import resolve_variable
 from grizzly.types import RequestMethod, ResponseAction, ResponseTarget
 from grizzly.utils import has_template
@@ -80,7 +80,7 @@ def create_request_task(
     return request
 
 
-def add_request_task_response_status_codes(request: RequestTask, status_list: str) -> None:
+def add_request_response_status_codes(request: Union[RequestTask, HttpClientTask], status_list: str) -> None:
     for status in status_list.split(','):
         request.response.add_status_code(int(status.strip()))
 

--- a/grizzly/steps/scenario/response.py
+++ b/grizzly/steps/scenario/response.py
@@ -19,8 +19,9 @@ from typing import cast
 import parse
 
 from grizzly.context import GrizzlyContext
-from grizzly.steps._helpers import add_request_task_response_status_codes, add_save_handler, add_validation_handler
+from grizzly.steps._helpers import add_request_response_status_codes, add_save_handler, add_validation_handler
 from grizzly.tasks import RequestTask
+from grizzly.tasks.clients import HttpClientTask
 from grizzly.types import ResponseTarget
 from grizzly.types.behave import Context, register_type, then, when
 from grizzly_extras.text import permutation
@@ -235,9 +236,9 @@ def step_response_allow_status_codes(context: Context, status_list: str) -> None
 
     request = grizzly.scenario.tasks()[-1]
 
-    assert isinstance(request, RequestTask), 'previous task is not a request'
+    assert isinstance(request, (RequestTask, HttpClientTask)), 'previous task is not a request'
 
-    add_request_task_response_status_codes(request, status_list)
+    add_request_response_status_codes(request, status_list)
 
 
 @then('allow response status codes')
@@ -273,7 +274,7 @@ def step_response_allow_status_codes_table(context: Context) -> None:
     grizzly = cast(GrizzlyContext, context.grizzly)
 
     tasks = grizzly.scenario.tasks()
-    number_of_requests = len(grizzly.scenario.tasks(RequestTask))
+    number_of_requests = len(grizzly.scenario.tasks(RequestTask, HttpClientTask))
 
     assert number_of_requests > 0, 'there are no request tasks in the scenario'
     assert len(list(context.table)) <= number_of_requests, 'step table has more rows than there are request tasks'
@@ -285,9 +286,9 @@ def step_response_allow_status_codes_table(context: Context) -> None:
     try:
         for row in rows:
             task = tasks[index]
-            assert isinstance(task, RequestTask), f'task at index {index} is not a request'
+            assert isinstance(task, (RequestTask, HttpClientTask)), f'task at index {index} is not a request'
             index -= 1
-            add_request_task_response_status_codes(task, row['status'])
+            add_request_response_status_codes(task, row['status'])
     except KeyError as e:
         message = 'step table does not have column "status"'
         raise AssertionError(message) from e

--- a/grizzly/steps/scenario/setup.py
+++ b/grizzly/steps/scenario/setup.py
@@ -195,7 +195,7 @@ def step_setup_metadata(context: Context, key: str, value: str) -> None:
     Then post request ...
     And metadata "x-header" is "{{ value }}"
 
-    Then get "https://{{ client_url }}" with name "client-http" and save response payload in "payload"
+    Then get from "https://{{ client_url }}" with name "client-http" and save response payload in "payload"
     And metadata "Ocp-Apim-Subscription-Key" is "deadbeefb00f"
     ```
 

--- a/grizzly/steps/scenario/tasks/clients.py
+++ b/grizzly/steps/scenario/tasks/clients.py
@@ -148,3 +148,40 @@ def step_task_client_put_endpoint_file(context: Context, source: str, endpoint: 
         source=source,
         destination=None,
     ))
+
+
+@then('put to "{endpoint}" with name "{name}"')
+def step_task_client_put_endpoint_text(context: Context, endpoint: str, name: str) -> None:
+    """Create an instance of a {@pylink grizzly.tasks.clients} task, actual implementation of the task is determined
+    based on the URL scheme specified in `endpoint`.
+
+    Put information, source step text, to another host or endpoint than the scenario
+    is load testing and saves the response in a variable
+
+    See {@pylink grizzly.tasks.clients} task documentation for more information about client tasks.
+
+    Example:
+    ```gherkin
+    Then put to "https://api.example.com/v2/echo" with name "put-request"
+      \"\"\"
+      hello world
+      \"\"\"
+    ```
+
+    Args:
+        endpoint (str): information about where to get information, see the specific getter task implementations for more information
+        name (str): name of the request, used in request statistics
+
+    """
+    assert context.text is not None, 'step text is mandatory for this step expression'
+    assert len(context.text) > 0, 'step text cannot be an empty string'
+
+    grizzly = cast(GrizzlyContext, context.grizzly)
+
+    grizzly.scenario.tasks.add(get_task_client(grizzly, endpoint)(
+        RequestDirection.TO,
+        endpoint,
+        name,
+        source=context.text,
+        destination=None,
+    ))

--- a/grizzly/steps/scenario/tasks/clients.py
+++ b/grizzly/steps/scenario/tasks/clients.py
@@ -7,13 +7,13 @@ from typing import cast
 
 from grizzly.context import GrizzlyContext
 from grizzly.steps._helpers import get_task_client
-from grizzly.types import RequestDirection
+from grizzly.types import RequestDirection, RequestMethod
 from grizzly.types.behave import Context, then
 from grizzly.utils import has_template
 
 
-@then('get "{endpoint}" with name "{name}" and save response payload in "{payload_variable}" and metadata in "{metadata_variable}"')
-def step_task_client_get_endpoint_payload_metadata(context: Context, endpoint: str, name: str, payload_variable: str, metadata_variable: str) -> None:
+@then('{method:Method} from "{endpoint}" with name "{name}" and save response payload in "{payload_variable}" and metadata in "{metadata_variable}"')
+def step_task_client_from_endpoint_payload_metadata(context: Context, method: RequestMethod, endpoint: str, name: str, payload_variable: str, metadata_variable: str) -> None:
     """Create an instance of a {@pylink grizzly.tasks.clients} task, actual implementation of the task is determined
     based on the URL scheme specified in `endpoint`.
 
@@ -23,8 +23,8 @@ def step_task_client_get_endpoint_payload_metadata(context: Context, endpoint: s
 
     Example:
     ```gherkin
-    Then get "https://www.example.org/example.json" with name "example-1" and save response payload in "example_openapi" and metadata in "example_metadata"
-    Then get "http://{{ endpoint }}" with name "example-2" and save response payload in "endpoint_result" and metadata in "result_metadata"
+    Then get from "https://www.example.org/example.json" with name "example-1" and save response payload in "example_openapi" and metadata in "example_metadata"
+    Then get from "http://{{ endpoint }}" with name "example-2" and save response payload in "endpoint_result" and metadata in "result_metadata"
     ```
 
     Args:
@@ -36,6 +36,8 @@ def step_task_client_get_endpoint_payload_metadata(context: Context, endpoint: s
     """
     grizzly = cast(GrizzlyContext, context.grizzly)
 
+    assert method.direction == RequestDirection.FROM, 'chosen request method does not match direction "from"'
+
     grizzly.scenario.tasks.add(get_task_client(grizzly, endpoint)(
         RequestDirection.FROM,
         endpoint,
@@ -43,11 +45,12 @@ def step_task_client_get_endpoint_payload_metadata(context: Context, endpoint: s
         payload_variable=payload_variable,
         metadata_variable=metadata_variable,
         text=context.text,
+        method=method,
     ))
 
 
-@then('get "{endpoint}" with name "{name}" and save response payload in "{variable}"')
-def step_task_client_get_endpoint_payload(context: Context, endpoint: str, name: str, variable: str) -> None:
+@then('{method:Method} from "{endpoint}" with name "{name}" and save response payload in "{variable}"')
+def step_task_client_from_endpoint_payload(context: Context, method: RequestMethod, endpoint: str, name: str, variable: str) -> None:
     """Create an instance of a {@pylink grizzly.tasks.clients} task, actual implementation of the task is determined
     based on the URL scheme specified in `endpoint`.
 
@@ -57,8 +60,8 @@ def step_task_client_get_endpoint_payload(context: Context, endpoint: str, name:
 
     Example:
     ```gherkin
-    Then get "https://www.example.org/example.json" with name "example-1" and save response payload in "example_openapi"
-    Then get "http://{{ endpoint }}" with name "example-2" and save response payload in "endpoint_result"
+    Then get from "https://www.example.org/example.json" with name "example-1" and save response payload in "example_openapi"
+    Then get from "http://{{ endpoint }}" with name "example-2" and save response payload in "endpoint_result"
     ```
 
     Args:
@@ -69,6 +72,8 @@ def step_task_client_get_endpoint_payload(context: Context, endpoint: str, name:
     """
     grizzly = cast(GrizzlyContext, context.grizzly)
 
+    assert method.direction == RequestDirection.FROM, 'chosen request method does not match direction "from"'
+
     grizzly.scenario.tasks.add(get_task_client(grizzly, endpoint)(
         RequestDirection.FROM,
         endpoint,
@@ -76,11 +81,12 @@ def step_task_client_get_endpoint_payload(context: Context, endpoint: str, name:
         payload_variable=variable,
         metadata_variable=None,
         text=context.text,
+        method=method,
     ))
 
 
-@then('put "{source}" to "{endpoint}" with name "{name}" as "{destination}"')
-def step_task_client_put_endpoint_file_destination(context: Context, source: str, endpoint: str, name: str, destination: str) -> None:
+@then('{method:Method} "{source}" to "{endpoint}" with name "{name}" as "{destination}"')
+def step_task_client_to_endpoint_file_destination(context: Context, method: RequestMethod, source: str, endpoint: str, name: str, destination: str) -> None:
     """Create an instance of a {@pylink grizzly.tasks.clients} task, actual implementation of the task is
     determined based on the URL scheme specified in `endpoint`.
 
@@ -103,6 +109,7 @@ def step_task_client_put_endpoint_file_destination(context: Context, source: str
     """
     assert context.text is None, 'step text is not allowed for this step expression'
     assert not has_template(source), 'source file cannot be a template'
+    assert method.direction == RequestDirection.TO, 'chosen request method does not match direction "to"'
 
     grizzly = cast(GrizzlyContext, context.grizzly)
 
@@ -112,11 +119,12 @@ def step_task_client_put_endpoint_file_destination(context: Context, source: str
         name,
         source=source,
         destination=destination,
+        method=method,
     ))
 
 
-@then('put "{source}" to "{endpoint}" with name "{name}"')
-def step_task_client_put_endpoint_file(context: Context, source: str, endpoint: str, name: str) -> None:
+@then('{method:Method} "{source}" to "{endpoint}" with name "{name}"')
+def step_task_client_to_endpoint_file(context: Context, method: RequestMethod, source: str, endpoint: str, name: str) -> None:
     """Create an instance of a {@pylink grizzly.tasks.clients} task, actual implementation of the task is determined
     based on the URL scheme specified in `endpoint`.
 
@@ -138,6 +146,7 @@ def step_task_client_put_endpoint_file(context: Context, source: str, endpoint: 
     """
     assert context.text is None, 'step text is not allowed for this step expression'
     assert not has_template(source), 'source file cannot be a template'
+    assert method.direction == RequestDirection.TO, 'chosen request method does not match direction "to"'
 
     grizzly = cast(GrizzlyContext, context.grizzly)
 
@@ -147,11 +156,12 @@ def step_task_client_put_endpoint_file(context: Context, source: str, endpoint: 
         name,
         source=source,
         destination=None,
+        method=method,
     ))
 
 
-@then('put to "{endpoint}" with name "{name}"')
-def step_task_client_put_endpoint_text(context: Context, endpoint: str, name: str) -> None:
+@then('{method:Method} to "{endpoint}" with name "{name}"')
+def step_task_client_to_endpoint_text(context: Context, method: RequestMethod, endpoint: str, name: str) -> None:
     """Create an instance of a {@pylink grizzly.tasks.clients} task, actual implementation of the task is determined
     based on the URL scheme specified in `endpoint`.
 
@@ -175,6 +185,7 @@ def step_task_client_put_endpoint_text(context: Context, endpoint: str, name: st
     """
     assert context.text is not None, 'step text is mandatory for this step expression'
     assert len(context.text) > 0, 'step text cannot be an empty string'
+    assert method.direction == RequestDirection.TO, 'chosen request method does not match direction "to"'
 
     grizzly = cast(GrizzlyContext, context.grizzly)
 
@@ -184,4 +195,5 @@ def step_task_client_put_endpoint_text(context: Context, endpoint: str, name: st
         name,
         source=context.text,
         destination=None,
+        method=method,
     ))

--- a/grizzly/steps/scenario/tasks/until.py
+++ b/grizzly/steps/scenario/tasks/until.py
@@ -54,7 +54,7 @@ def step_task_request_with_name_endpoint_until(context: Context, method: Request
         ))
 
 
-@then('get "{endpoint}" with name "{name}" until "{condition}"')
+@then('get from "{endpoint}" with name "{name}" until "{condition}"')
 def step_task_client_get_endpoint_until(context: Context, endpoint: str, name: str, condition: str) -> None:
     """Create an instance of a {@pylink grizzly.tasks.clients} task, actual implementation of the task is determined
     based on the URL scheme specified in `endpoint`.
@@ -66,8 +66,8 @@ def step_task_client_get_endpoint_until(context: Context, endpoint: str, name: s
 
     Example:
     ```gherkin
-    Then get "https://www.example.org/example.json" with name "example-1" until "$.response[status='Success']
-    Then get "http://{{ endpoint }}" with name "example-2" until "//*[@status='Success']"
+    Then get from "https://www.example.org/example.json" with name "example-1" until "$.response[status='Success']
+    Then get from "http://{{ endpoint }}" with name "example-2" until "//*[@status='Success']"
     ```
 
     Args:
@@ -83,6 +83,7 @@ def step_task_client_get_endpoint_until(context: Context, endpoint: str, name: s
         endpoint,
         name,
         text=context.text,
+        method=RequestMethod.GET,
     )
 
     grizzly.scenario.tasks.add(UntilRequestTask(

--- a/grizzly/tasks/clients/blobstorage.py
+++ b/grizzly/tasks/clients/blobstorage.py
@@ -7,7 +7,7 @@ Only supports `RequestDirection.TO`.
 
 ## Step implementations
 
-* {@pylink grizzly.steps.scenario.tasks.clients.step_task_client_put_endpoint_file_destination}
+* {@pylink grizzly.steps.scenario.tasks.clients.step_task_client_to_endpoint_file_destination}
 
 ## Arguments
 
@@ -68,7 +68,7 @@ from urllib.parse import parse_qs, quote, urlparse
 
 from azure.storage.blob import BlobServiceClient, ContentSettings
 
-from grizzly.types import GrizzlyResponse, RequestDirection, bool_type
+from grizzly.types import GrizzlyResponse, RequestDirection, RequestMethod, bool_type
 from grizzly_extras.azure.aad import AuthMethod, AzureAadCredential
 
 from . import ClientTask, client
@@ -100,6 +100,7 @@ class BlobStorageClientTask(ClientTask):
         source: Optional[str] = None,
         destination: Optional[str] = None,
         text: Optional[str] = None,
+        method: Optional[RequestMethod] = None,
     ) -> None:
         super().__init__(
             direction,
@@ -110,6 +111,7 @@ class BlobStorageClientTask(ClientTask):
             destination=destination,
             source=source,
             text=text,
+            method=method,
         )
 
         parsed = urlparse(self.endpoint)
@@ -163,11 +165,11 @@ class BlobStorageClientTask(ClientTask):
 
         self.overwrite = bool_type(fragments.get('Overwrite', ['False'])[0])
 
-    def get(self, _: GrizzlyScenario) -> GrizzlyResponse:  # pragma: no cover
+    def request_from(self, _: GrizzlyScenario) -> GrizzlyResponse:  # pragma: no cover
         message = f'{self.__class__.__name__} has not implemented GET'
         raise NotImplementedError(message)
 
-    def put(self, parent: GrizzlyScenario) -> GrizzlyResponse:
+    def request_to(self, parent: GrizzlyScenario) -> GrizzlyResponse:
         source = parent.user.render(cast(str, self.source))
 
         destination = parent.user.render(self.destination) if self.destination is not None else Path(source).name

--- a/grizzly/tasks/clients/http.py
+++ b/grizzly/tasks/clients/http.py
@@ -3,13 +3,15 @@ This task performs a HTTP request to a specified endpoint.
 
 This is useful if the scenario is using a non-HTTP user or a request to a URL other than the one under testing is needed, e.g. for testdata.
 
-Only supports `RequestDirection.FROM`.
-
 ## Step implementations
 
 * {@pylink grizzly.steps.scenario.tasks.clients.step_task_client_get_endpoint_payload}
 
 * {@pylink grizzly.steps.scenario.tasks.clients.step_task_client_get_endpoint_payload_metadata}
+
+* {@pylink grizzly.steps.scenario.tasks.clients.step_task_client_put_endpoint_text}
+
+* {@pylink grizzly.steps.scenario.tasks.clients.step_task_client_put_endpoint_file} (`source` will become contents of the specified file)
 
 ## Arguments
 
@@ -46,14 +48,16 @@ from __future__ import annotations
 import logging
 from json import dumps as jsondumps
 from time import time
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 from geventhttpclient import Session
 from locust.exception import CatchResponseError
 
 from grizzly.auth import AAD, GrizzlyHttpAuthClient, refresh_token
+from grizzly.tasks import RequestTaskResponse
+from grizzly.testdata.utils import read_file
 from grizzly.types import GrizzlyResponse, RequestDirection, bool_type
-from grizzly.utils import merge_dicts
+from grizzly.utils import is_file, merge_dicts
 from grizzly.utils.protocols import http_populate_cookiejar
 from grizzly_extras.arguments import parse_arguments, split_value
 from grizzly_extras.text import has_separator
@@ -61,6 +65,8 @@ from grizzly_extras.text import has_separator
 from . import ClientTask, client
 
 if TYPE_CHECKING:  # pragma: no cover
+    from geventhttpclient.useragent import CompatResponse
+
     from grizzly.scenarios import GrizzlyScenario
 
 
@@ -71,6 +77,7 @@ class HttpClientTask(ClientTask, GrizzlyHttpAuthClient):
     session_started: Optional[float]
     host: str
     verify: bool
+    response: RequestTaskResponse
 
     def __init__(
         self,
@@ -96,6 +103,9 @@ class HttpClientTask(ClientTask, GrizzlyHttpAuthClient):
 
             if len(arguments) > 0:
                 endpoint = f'{endpoint} | {", ".join([f"{key}={value}" for key, value in arguments.items()])}'
+
+        if source is not None and is_file(source):
+            source = read_file(source)
 
         super().__init__(
             direction,
@@ -127,6 +137,8 @@ class HttpClientTask(ClientTask, GrizzlyHttpAuthClient):
         if not hasattr(self, 'logger'):
             self.logger = logging.getLogger(f'{self.__class__.__name__}/{id(self)}')
 
+        self.response = RequestTaskResponse()
+
     def on_start(self, parent: GrizzlyScenario) -> None:
         super().on_start(parent)
 
@@ -135,6 +147,38 @@ class HttpClientTask(ClientTask, GrizzlyHttpAuthClient):
         self.session_started = time()
         metadata = self._context.get('metadata', None) or {}
         self.metadata.update(metadata)
+
+    def _handle_response(self, parent: GrizzlyScenario, meta: dict[str, Any], url: str, response: CompatResponse) -> GrizzlyResponse:
+        text = response.text
+        payload = text.decode() if isinstance(text, (bytearray, bytes)) else text
+
+        metadata = dict(response.headers)
+
+        exception: Optional[Exception] = None
+
+        if response.status_code not in self.response.status_codes or response.url != url:
+            parent.logger.error('%s returned %d', response.url, response.status_code)
+            message = f'{response.status_code} not in {self.response.status_codes}: {payload}'
+            exception = CatchResponseError(message)
+        else:
+            if self.payload_variable is not None:
+                parent.user.set_variable(self.payload_variable, payload)
+
+            if self.metadata_variable is not None:
+                parent.user.set_variable(self.metadata_variable, jsondumps(metadata))
+
+        meta.update({
+            'response_length': len(payload.encode()),
+            'response': {
+                'url': response.url,
+                'metadata': metadata,
+                'payload': payload,
+                'status': response.status_code,
+            },
+            'exception': exception,
+        })
+
+        return metadata, payload
 
     @refresh_token(AAD)
     def get(self, parent: GrizzlyScenario) -> GrizzlyResponse:
@@ -152,37 +196,23 @@ class HttpClientTask(ClientTask, GrizzlyHttpAuthClient):
                 http_populate_cookiejar(client, self.cookies, url=url)
                 response = client.get(url, headers=self.metadata, **self.arguments)
 
-            text = response.text
-            payload = text.decode() if isinstance(text, (bytearray, bytes)) else text
+            return self._handle_response(parent, meta, url, response)
 
-            metadata = dict(response.headers)
+    @refresh_token(AAD)
+    def put(self, parent: GrizzlyScenario) -> GrizzlyResponse:
+        source = parent.user.render(cast(str, self.source))
 
-            exception: Optional[Exception] = None
+        with self.action(parent) as meta:
+            url = parent.user.render(self.endpoint)
 
-            if response.status_code != 200 or response.url != url:
-                parent.logger.error('%s returned %d', response.url, response.status_code)
-                message = f'{response.status_code} not in [200]: {payload}'
-                exception = CatchResponseError(message)
-            else:
-                if self.payload_variable is not None:
-                    parent.user.set_variable(self.payload_variable, payload)
+            meta.update({'request': {
+                'url': url,
+                'metadata': self.metadata,
+                'payload': source,
+            }})
 
-                if self.metadata_variable is not None:
-                    parent.user.set_variable(self.metadata_variable, jsondumps(metadata))
+            with Session(insecure=not self.verify) as client:
+                http_populate_cookiejar(client, self.cookies, url=url)
+                response = client.put(url, data=source, headers=self.metadata, **self.arguments)
 
-            meta.update({
-                'response_length': len(payload.encode()),
-                'response': {
-                    'url': response.url,
-                    'metadata': metadata,
-                    'payload': payload,
-                    'status': response.status_code,
-                },
-                'exception': exception,
-            })
-
-            return metadata, payload
-
-    def put(self, _: GrizzlyScenario) -> GrizzlyResponse:
-        message = f'{self.__class__.__name__} has not implemented PUT'
-        raise NotImplementedError(message)
+            return self._handle_response(parent, meta, url, response)

--- a/grizzly/tasks/clients/messagequeue.py
+++ b/grizzly/tasks/clients/messagequeue.py
@@ -12,11 +12,11 @@ pip3 install grizzly-loadtester[mq]
 
 ## Step implementations
 
-* {@pylink grizzly.steps.scenario.tasks.clients.step_task_client_get_endpoint_payload}
+* {@pylink grizzly.steps.scenario.tasks.clients.step_task_client_from_endpoint_payload}
 
-* {@pylink grizzly.steps.scenario.tasks.clients.step_task_client_get_endpoint_payload_metadata}
+* {@pylink grizzly.steps.scenario.tasks.clients.step_task_client_from_endpoint_payload_metadata}
 
-* {@pylink grizzly.steps.scenario.tasks.clients.step_task_client_put_endpoint_file}
+* {@pylink grizzly.steps.scenario.tasks.clients.step_task_client_to_endpoint_file}
 
 ## Arguments
 
@@ -83,7 +83,7 @@ import zmq.green as zmq
 from zmq.error import ZMQError
 
 from grizzly.testdata.utils import resolve_variable
-from grizzly.types import GrizzlyResponse, RequestDirection, RequestType
+from grizzly.types import GrizzlyResponse, RequestDirection, RequestMethod, RequestType
 from grizzly.utils.protocols import zmq_disconnect
 from grizzly_extras.async_message import AsyncMessageContext, AsyncMessageRequest, AsyncMessageResponse
 from grizzly_extras.async_message.utils import async_message_request
@@ -124,6 +124,7 @@ class MessageQueueClientTask(ClientTask):
         source: Optional[str] = None,
         destination: Optional[str] = None,
         text: Optional[str] = None,
+        method: Optional[RequestMethod] = None,
     ) -> None:
         if pymqi.__name__ == 'grizzly_extras.dummy_pymqi':
             pymqi.raise_for_error(self.__class__)
@@ -139,6 +140,7 @@ class MessageQueueClientTask(ClientTask):
             destination=destination,
             source=source,
             text=text,
+            method=method,
         )
 
         self.create_context()
@@ -320,7 +322,7 @@ class MessageQueueClientTask(ClientTask):
 
                 return response
 
-    def get(self, parent: GrizzlyScenario) -> GrizzlyResponse:
+    def request_from(self, parent: GrizzlyScenario) -> GrizzlyResponse:
         endpoint: list[str] = [self.endpoint_path]
         if self.max_message_size is not None:
             endpoint.append(f'max_message_size:{self.max_message_size}')
@@ -347,7 +349,7 @@ class MessageQueueClientTask(ClientTask):
 
         return metadata, payload
 
-    def put(self, parent: GrizzlyScenario) -> GrizzlyResponse:
+    def request_to(self, parent: GrizzlyScenario) -> GrizzlyResponse:
         source = parent.user.render(cast(str, self.source))
         source_file = Path(self._context_root) / 'requests' / source
 

--- a/grizzly/tasks/clients/servicebus.py
+++ b/grizzly/tasks/clients/servicebus.py
@@ -3,11 +3,11 @@ This task performs Azure SerciceBus operations to a specified endpoint.
 
 ## Step implementations
 
-* {@pylink grizzly.steps.scenario.tasks.clients.step_task_client_get_endpoint_payload}
+* {@pylink grizzly.steps.scenario.tasks.clients.step_task_client_from_endpoint_payload}
 
-* {@pylink grizzly.steps.scenario.tasks.clients.step_task_client_get_endpoint_payload_metadata}
+* {@pylink grizzly.steps.scenario.tasks.clients.step_task_client_from_endpoint_payload_metadata}
 
-* {@pylink grizzly.steps.scenario.tasks.clients.step_task_client_put_endpoint_file}
+* {@pylink grizzly.steps.scenario.tasks.clients.step_task_client_to_endpoint_file}
 
 ## Arguments
 
@@ -104,7 +104,7 @@ from urllib.parse import parse_qs, quote_plus, unquote_plus, urlparse
 import zmq.green as zmq
 
 from grizzly.tasks import template
-from grizzly.types import GrizzlyResponse, RequestDirection, RequestType
+from grizzly.types import GrizzlyResponse, RequestDirection, RequestMethod, RequestType
 from grizzly.utils.protocols import async_message_request_wrapper, zmq_disconnect
 from grizzly_extras.arguments import parse_arguments
 from grizzly_extras.transformer import TransformerContentType
@@ -163,6 +163,7 @@ class ServiceBusClientTask(ClientTask):
         source: Optional[str] = None,
         destination: Optional[str] = None,
         text: Optional[str] = None,
+        method: Optional[RequestMethod] = None,
     ) -> None:
         super().__init__(
             direction,
@@ -173,6 +174,7 @@ class ServiceBusClientTask(ClientTask):
             destination=destination,
             source=source,
             text=text,
+            method=method,
         )
 
         # expression can contain characters which are not URL safe, e.g. ?
@@ -415,7 +417,7 @@ class ServiceBusClientTask(ClientTask):
 
         return response or {}
 
-    def get(self, parent: GrizzlyScenario) -> GrizzlyResponse:
+    def request_from(self, parent: GrizzlyScenario) -> GrizzlyResponse:
         state = self.get_state(parent)
 
         request: AsyncMessageRequest = {
@@ -438,7 +440,7 @@ class ServiceBusClientTask(ClientTask):
 
         return metadata, payload
 
-    def put(self, parent: GrizzlyScenario) -> GrizzlyResponse:
+    def request_to(self, parent: GrizzlyScenario) -> GrizzlyResponse:
         state = self.get_state(parent)
 
         source = parent.user.render(cast(str, self.source))

--- a/grizzly/tasks/write_file.py
+++ b/grizzly/tasks/write_file.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
 from grizzly.testdata.utils import resolve_parameters
-from grizzly.utils import has_parameter
+from grizzly.utils import has_parameter, has_template
 
 from . import GrizzlyTask, grizzlytask, template
 
@@ -55,7 +55,6 @@ class WriteFileTask(GrizzlyTask):
             file_name = parent.user.render(self.file_name)
             file = Path(self._context_root) / 'requests' / file_name
 
-
             # file has already been created
             if self.temp_file and self.file is not None and file.exists():
                 return
@@ -66,6 +65,13 @@ class WriteFileTask(GrizzlyTask):
 
             try:
                 content = parent.user.render(self.content)
+
+                # sub render variable content
+                if has_template(content):
+                    content = parent.user.render(content)
+
+                if has_parameter(content):
+                    content = resolve_parameters(parent.user._scenario, content)
 
                 self.file.parent.mkdir(parents=True, exist_ok=True)
 

--- a/grizzly/testdata/filters.py
+++ b/grizzly/testdata/filters.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import json
 from base64 import b64decode as base64_b64decode
 from base64 import b64encode as base64_b64encode
-from collections import namedtuple
 from typing import Any, Callable, NamedTuple, Optional, Union
 
 from jinja2.filters import FILTERS

--- a/grizzly/testdata/utils.py
+++ b/grizzly/testdata/utils.py
@@ -193,6 +193,17 @@ def resolve_variable(
     if len(value) < 1:
         return value
 
+    # if variable value starts with `file://`, the file should be read
+    if len(value) > 7 and value[:7] == 'file://' and not try_file:
+        try_file = True
+        value = value[7:]
+
+        if value[0] == '/':
+            value = value[1:]
+
+        if value[:2] == './':
+            value = value[2:]
+
     quote_char: Optional[str] = None
     if value[0] in ['"', "'"] and value[0] == value[-1]:
         quote_char = value[0]

--- a/grizzly/testdata/utils.py
+++ b/grizzly/testdata/utils.py
@@ -195,7 +195,8 @@ def resolve_variable(
 
     # if variable value starts with `file://`, the file should be read
     if len(value) > 7 and value[:7] == 'file://' and not try_file:
-        try_file = True
+        try_file = True  # explicitly stated as a file, we should read its contents
+        try_template = False  # but not try to render any variables...
         value = value[7:]
 
         if value[0] == '/':

--- a/tests/e2e/steps/scenario/test_tasks.py
+++ b/tests/e2e/steps/scenario/test_tasks.py
@@ -420,7 +420,7 @@ def test_e2e_step_task_transform(e2e_fixture: End2EndFixture) -> None:
     assert rc == 0
 
 
-def test_e2e_step_task_client_get_endpoint(e2e_fixture: End2EndFixture) -> None:
+def test_e2e_step_task_client_from_endpoint(e2e_fixture: End2EndFixture) -> None:
     def validate_client_task(context: Context) -> None:
         from grizzly.tasks.clients import HttpClientTask
         from grizzly.types import RequestDirection
@@ -475,8 +475,8 @@ def test_e2e_step_task_client_get_endpoint(e2e_fixture: End2EndFixture) -> None:
             'And value for variable "endpoint_payload" is "none"',
             'And value for variable "endpoint_metadata" is "none"',
             f'And value for variable "endpoint" is "http://{e2e_fixture.host}"',
-            f'Then get "http://{e2e_fixture.host}/api/echo?foo=bar" with name "https-get" and save response payload in "example_openapi"',
-            'Then get "http://{{ endpoint }}/api/echo?bar=foo" with name "http-get" and save response payload in "endpoint_payload" and metadata in "endpoint_metadata"',
+            f'Then get from "http://{e2e_fixture.host}/api/echo?foo=bar" with name "https-get" and save response payload in "example_openapi"',
+            'Then get from "http://{{ endpoint }}/api/echo?bar=foo" with name "http-get" and save response payload in "endpoint_payload" and metadata in "endpoint_metadata"',
             'Then log message "example_openapi={{ example_openapi }}, endpoint_payload={{ endpoint_payload }}, endpoint_metadata={{ endpoint_metadata }}"',
         ],
     )
@@ -486,7 +486,7 @@ def test_e2e_step_task_client_get_endpoint(e2e_fixture: End2EndFixture) -> None:
     assert rc == 0
 
 
-def test_e2e_step_task_client_get_endpoint_until(e2e_fixture: End2EndFixture) -> None:  # noqa: PLR0915
+def test_e2e_step_task_client_from_endpoint_until(e2e_fixture: End2EndFixture) -> None:  # noqa: PLR0915
     def after_feature(context: Context, *_args: Any, **_kwargs: Any) -> None:
         from grizzly.locust import on_master
 
@@ -515,7 +515,7 @@ def test_e2e_step_task_client_get_endpoint_until(e2e_fixture: End2EndFixture) ->
     def validate_client_task_until(context: Context) -> None:  # noqa: PLR0915
         from grizzly.tasks import UntilRequestTask
         from grizzly.tasks.clients import HttpClientTask
-        from grizzly.types import RequestDirection
+        from grizzly.types import RequestDirection, RequestMethod
         from grizzly_extras.transformer import TransformerContentType
 
         grizzly = cast(GrizzlyContext, context.grizzly)
@@ -538,6 +538,7 @@ def test_e2e_step_task_client_get_endpoint_until(e2e_fixture: End2EndFixture) ->
         assert task.arguments == {}
         assert task.content_type == TransformerContentType.JSON
         assert task.direction == RequestDirection.FROM
+        assert task.method == RequestMethod.GET
         assert task.endpoint == f'http://{e2e_fixture_host}/api/until/id?nth=2&wrong=bar&right=foo&as_array=True', f'{task.name=}, {task.endpoint=}'
         assert task.name == 'https-get'
         assert task.payload_variable is None
@@ -557,6 +558,7 @@ def test_e2e_step_task_client_get_endpoint_until(e2e_fixture: End2EndFixture) ->
         assert task.arguments == {}
         assert task.content_type == TransformerContentType.JSON
         assert task.direction == RequestDirection.FROM
+        assert task.method == RequestMethod.GET
         assert task.endpoint == '{{ endpoint }}/api/until/success?nth=2&wrong=false&right=true&as_array=True', f'{task.name=}, {task.endpoint=}'
         assert task.name == 'http-get'
         assert task.payload_variable is None
@@ -576,6 +578,7 @@ def test_e2e_step_task_client_get_endpoint_until(e2e_fixture: End2EndFixture) ->
         assert not task.verify
         assert task.content_type == TransformerContentType.JSON
         assert task.direction == RequestDirection.FROM
+        assert task.method == RequestMethod.GET
         assert task.endpoint == f'http://{e2e_fixture_host}/api/until/hello?nth=2&wrong=foobar&right=world&as_array=True', f'{task.name=}, {task.endpoint=}'
         assert task.name == 'https-env-get'
         assert task.payload_variable is None
@@ -595,16 +598,16 @@ def test_e2e_step_task_client_get_endpoint_until(e2e_fixture: End2EndFixture) ->
         scenario=[
             f'And value for variable "endpoint" is "http://{e2e_fixture.host}"',
             (
-                f'Then get "http://{e2e_fixture.host}/api/until/id?nth=2&wrong=bar&right=foo&as_array=True | '
+                f'Then get from "http://{e2e_fixture.host}/api/until/id?nth=2&wrong=bar&right=foo&as_array=True | '
                 'content_type=json" with name "https-get" until "$.`this`[?id="foo"] | wait=0.11"'
             ),
             (
-                'Then get "http://{{ endpoint }}/api/until/success?nth=2&wrong=false&right=true&as_array=True | '
+                'Then get from "http://{{ endpoint }}/api/until/success?nth=2&wrong=false&right=true&as_array=True | '
                 'content_type=json" with name "http-get" until "$.`this`[?success="true"] | wait=0.12"'
             ),
             (
-                'Then get "https://$conf::test.host$/api/until/hello?nth=2&wrong=foobar&right=world&as_array=True | content_type=json, verify=False" with name "https-env-get" '
-                'until "$.`this`[?hello="world"] | retries=1, expected_matches=1, wait=0.1"'
+                'Then get from "https://$conf::test.host$/api/until/hello?nth=2&wrong=foobar&right=world&as_array=True | content_type=json, '
+                'verify=False" with name "https-env-get" until "$.`this`[?hello="world"] | retries=1, expected_matches=1, wait=0.1"'
             ),
         ],
     )
@@ -625,7 +628,7 @@ def test_e2e_step_task_client_get_endpoint_until(e2e_fixture: End2EndFixture) ->
     assert 'HOOK-ERROR in after_feature: RuntimeError: locust test failed' in result
 
 
-def test_e2e_step_task_client_put_endpoint_file_destination(e2e_fixture: End2EndFixture) -> None:
+def test_e2e_step_task_client_to_endpoint_file_destination(e2e_fixture: End2EndFixture) -> None:
     def after_feature(context: Context, *_args: Any, **_kwargs: Any) -> None:
         from grizzly.locust import on_master
 
@@ -644,7 +647,7 @@ def test_e2e_step_task_client_put_endpoint_file_destination(e2e_fixture: End2End
 
     def validate_client_task(context: Context) -> None:
         from grizzly.tasks.clients import BlobStorageClientTask
-        from grizzly.types import RequestDirection
+        from grizzly.types import RequestDirection, RequestMethod
 
         grizzly = cast(GrizzlyContext, context.grizzly)
 
@@ -656,6 +659,7 @@ def test_e2e_step_task_client_put_endpoint_file_destination(e2e_fixture: End2End
         task = tasks[0]
         assert isinstance(task, BlobStorageClientTask)
         assert task.direction == RequestDirection.TO
+        assert task.method == RequestMethod.PUT
         assert task.endpoint == 'bs://my-unsecure-storage/my-container?AccountKey=aaaabbb='
         assert task.name == 'bs-put'
         assert task.payload_variable is None
@@ -670,6 +674,7 @@ def test_e2e_step_task_client_put_endpoint_file_destination(e2e_fixture: End2End
         task = tasks[1]
         assert isinstance(task, BlobStorageClientTask)
         assert task.direction == RequestDirection.TO
+        assert task.method == RequestMethod.PUT
         assert task.endpoint == 'bss://my-storage/my-container?AccountKey=aaaabbb='
         assert task.name == 'bss-put'
         assert task.payload_variable is None
@@ -698,7 +703,78 @@ def test_e2e_step_task_client_put_endpoint_file_destination(e2e_fixture: End2End
     assert 'HOOK-ERROR in after_feature: RuntimeError: locust test failed' in result
 
 
-def test_e2e_step_task_client_put_endpoint_file(e2e_fixture: End2EndFixture) -> None:
+def test_e2e_step_task_client_to_endpoint_text(e2e_fixture: End2EndFixture) -> None:
+    def validate_client_task(context: Context) -> None:
+        from grizzly.tasks.clients import HttpClientTask
+        from grizzly.types import RequestDirection, RequestMethod
+
+        grizzly = cast(GrizzlyContext, context.grizzly)
+
+        data = next(iter(context.table)).as_dict()
+        e2e_fixture_host = data['e2e_fixture.host']
+
+        tasks = grizzly.scenario.tasks()
+        tasks.pop()
+
+        assert len(tasks) == 2
+
+        task = tasks[0]
+        assert isinstance(task, HttpClientTask)
+        assert task.direction == RequestDirection.TO, f'1: {task.direction=}'
+        assert task.method == RequestMethod.PUT, f'1: {task.method=}'
+        assert task.endpoint == f'http://{e2e_fixture_host}/api/echo', f'1: {task.endpoint=}'
+        assert task.name == 'http-put', f'1: {task.name=}'
+        assert task.payload_variable is None, f'1: {task.payload_variable=}'
+        assert task.metadata_variable is None, f'1: {task.metadata_variable=}'
+        assert task.source == '{"foo": "bar"}', f'1: {task.source=}'
+        assert task.destination is None, f'1: {task.destination=}'
+        assert task._short_name == 'Http', f'1: {task._short_name=}'
+        assert task.get_templates() == [], f'1: {task.get_templates()=}'
+
+        task = tasks[1]
+        assert isinstance(task, HttpClientTask)
+        assert task.direction == RequestDirection.TO, f'2: {task.direction=}'
+        assert task.method == RequestMethod.POST, f'2: {task.method=}'
+        assert task.endpoint == f'http://{e2e_fixture_host}/api/echo', f'2: {task.endpoint=}'
+        assert task.name == 'http-post', f'2: {task.name=}'
+        assert task.payload_variable is None, f'2: {task.payload_variable=}'
+        assert task.metadata_variable is None, f'2: {task.metadata_variable=}'
+        assert task.source == '{"foo": "bar"}', f'2: {task.source=}'
+        assert task.destination is None, f'2: {task.destination=}'
+        assert task._short_name == 'Http', f'2: {task._short_name=}'
+        assert task.get_templates() == [], f'2: {task.get_templates()=}'
+
+    table: list[dict[str, str]] = [{
+        'e2e_fixture.host': e2e_fixture.host,
+    }]
+
+    e2e_fixture.add_validator(validate_client_task, table=table)
+
+    feature_file = e2e_fixture.test_steps(
+        scenario=[
+            f"""
+            Then put to "http://{e2e_fixture.host}/api/echo | content_type=json" with name "http-put"
+                \"\"\"
+                {{"foo": "bar"}}
+                \"\"\"
+            """
+            ,
+            f"""
+            Then post to "http://{e2e_fixture.host}/api/echo | content_type=json" with name "http-post"
+                \"\"\"
+                {{"foo": "bar"}}
+                \"\"\"
+            """
+            ,
+        ],
+    )
+
+    rc, _ = e2e_fixture.execute(feature_file)
+
+    assert rc == 0
+
+
+def test_e2e_step_task_client_to_endpoint_file(e2e_fixture: End2EndFixture) -> None:
     def after_feature(context: Context, *_args: Any, **_kwargs: Any) -> None:
         from grizzly.locust import on_master
 
@@ -717,7 +793,7 @@ def test_e2e_step_task_client_put_endpoint_file(e2e_fixture: End2EndFixture) -> 
 
     def validate_client_task(context: Context) -> None:
         from grizzly.tasks.clients import BlobStorageClientTask
-        from grizzly.types import RequestDirection
+        from grizzly.types import RequestDirection, RequestMethod
 
         grizzly = cast(GrizzlyContext, context.grizzly)
 
@@ -729,6 +805,7 @@ def test_e2e_step_task_client_put_endpoint_file(e2e_fixture: End2EndFixture) -> 
         task = tasks[0]
         assert isinstance(task, BlobStorageClientTask)
         assert task.direction == RequestDirection.TO
+        assert task.method == RequestMethod.PUT
         assert task.endpoint == 'bs://my-unsecure-storage/my-container?AccountKey=aaaabbb='
         assert task.name == 'bs-put'
         assert task.payload_variable is None
@@ -743,6 +820,7 @@ def test_e2e_step_task_client_put_endpoint_file(e2e_fixture: End2EndFixture) -> 
         task = tasks[1]
         assert isinstance(task, BlobStorageClientTask)
         assert task.direction == RequestDirection.TO
+        assert task.method == RequestMethod.PUT
         assert task.endpoint == 'bss://my-storage/my-container?AccountKey=aaaabbb='
         assert task.name == 'bss-put'
         assert task.payload_variable is None

--- a/tests/e2e/test_auth.py
+++ b/tests/e2e/test_auth.py
@@ -94,7 +94,7 @@ def test_e2e_auth_user_token(e2e_fixture: End2EndFixture) -> None:
             And set context variable "{e2e_fixture.host}/auth.client.id" to "{e2e_fixture.webserver.auth['client']['id']}"
             And set context variable "{e2e_fixture.host}/auth.client.secret" to "{e2e_fixture.webserver.auth['client']['secret']}"
             And repeat for "3" iterations
-            Then get "http://{e2e_fixture.host}/api/echo" with name "httpclient-echo" and save response payload in "foobar"
+            Then get from "http://{e2e_fixture.host}/api/echo" with name "httpclient-echo" and save response payload in "foobar"
             {add_metadata()}
         """))
 

--- a/tests/e2e/test_until.py
+++ b/tests/e2e/test_until.py
@@ -67,7 +67,7 @@ def test_e2e_until(e2e_fixture: End2EndFixture) -> None:
         Given a user of type "RestApi" load testing "http://{e2e_fixture.host}"
         And repeat for "1" iteration
         And stop user on failure
-        Then get "http://$conf::test.host$/api/until/foofoo?nth=2&wrong=foobar&right=world&as_array=true | content_type=json" with name "http-client-task" until "$.`this`[?foofoo="world"] | retries=3, expected_matches=1"
+        Then get from "http://$conf::test.host$/api/until/foofoo?nth=2&wrong=foobar&right=world&as_array=true | content_type=json" with name "http-client-task" until "$.`this`[?foofoo="world"] | retries=3, expected_matches=1"
     """))  # noqa: E501
 
     rc, _ = e2e_fixture.execute(feature_file, env_conf=env_conf)

--- a/tests/e2e/test_variables.py
+++ b/tests/e2e/test_variables.py
@@ -73,7 +73,7 @@ def test_e2e_variables_atomic_json_reader(e2e_fixture: End2EndFixture) -> None:
     feature_file = e2e_fixture.test_steps(scenario=[
         'Given repeat for "3" iterations',
         'Given value for variable "AtomicJsonReader.test" is "test.json"',
-        'Then log message "object={{ AtomicJsonReader.test | fromtestdata | fromjson }}"',
+        'Then log message "object={{ AtomicJsonReader.test | fromtestdata | stringify }}"',
         'Then log message "object.username={{ AtomicJsonReader.test.username }}"',
         'Then log message "object.password={{ AtomicJsonReader.test.password }}"',
     ])

--- a/tests/unit/test_grizzly/auth/test___init__.py
+++ b/tests/unit/test_grizzly/auth/test___init__.py
@@ -325,7 +325,7 @@ def test_refresh_token_user_render(grizzly_fixture: GrizzlyFixture, mocker: Mock
         return None, None
 
     mocker.patch(
-        'grizzly.tasks.clients.http.HttpClientTask.get',
+        'grizzly.tasks.clients.http.HttpClientTask.request_from',
         decorator(get),
     )
 
@@ -348,7 +348,7 @@ def test_refresh_token_user_render(grizzly_fixture: GrizzlyFixture, mocker: Mock
     else:  # assumed that variables contains scheme
         assert client.host == f'{host}/blob/file.txt'
 
-    client.get(parent)
+    client.request_from(parent)
 
     get_token_mock.assert_not_called()
     assert client._context == {'verify_certificates': True, 'metadata': None, 'auth': None, 'host': ''}
@@ -373,7 +373,7 @@ def test_refresh_token_user_render(grizzly_fixture: GrizzlyFixture, mocker: Mock
         },
     })
 
-    client.get(parent)
+    client.request_from(parent)
 
     get_token_mock.assert_called_once_with(client.credential)
 

--- a/tests/unit/test_grizzly/steps/scenario/tasks/test_clients.py
+++ b/tests/unit/test_grizzly/steps/scenario/tasks/test_clients.py
@@ -7,62 +7,62 @@ import pytest
 
 from grizzly.context import GrizzlyContext
 from grizzly.steps import (
-    step_task_client_get_endpoint_payload,
-    step_task_client_get_endpoint_payload_metadata,
-    step_task_client_put_endpoint_file,
-    step_task_client_put_endpoint_file_destination,
-    step_task_client_put_endpoint_text,
+    step_task_client_from_endpoint_payload,
+    step_task_client_from_endpoint_payload_metadata,
+    step_task_client_to_endpoint_file,
+    step_task_client_to_endpoint_file_destination,
+    step_task_client_to_endpoint_text,
 )
 from grizzly.tasks.clients import HttpClientTask
-from grizzly.types import pymqi
+from grizzly.types import RequestMethod, pymqi
 from tests.helpers import ANY
 
 if TYPE_CHECKING:  # pragma: no cover
     from tests.fixtures import BehaveFixture, GrizzlyFixture
 
 
-def test_step_task_client_get_endpoint_payload_metadata(behave_fixture: BehaveFixture) -> None:
+def test_step_task_client_from_endpoint_payload_metadata(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
     grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
     behave.scenario = grizzly.scenario.behave
 
-    step_task_client_get_endpoint_payload_metadata(behave, 'obscure.example.com', 'step-name', 'test', 'metadata')
+    step_task_client_from_endpoint_payload_metadata(behave, RequestMethod.GET, 'obscure.example.com', 'step-name', 'test', 'metadata')
     assert behave.exceptions == {behave.scenario.name: [ANY(AssertionError, message='could not find scheme in "obscure.example.com"')]}
     delattr(behave, 'exceptions')
 
-    step_task_client_get_endpoint_payload_metadata(behave, 'obscure://obscure.example.com', 'step-name', 'test', 'metadata')
+    step_task_client_from_endpoint_payload_metadata(behave, RequestMethod.GET, 'obscure://obscure.example.com', 'step-name', 'test', 'metadata')
     assert behave.exceptions == {behave.scenario.name: [ANY(AssertionError, message='no client task registered for obscure')]}
     delattr(behave, 'exceptions')
 
-    step_task_client_get_endpoint_payload_metadata(behave, 'http://www.example.org', 'step-name', 'test', 'metadata')
+    step_task_client_from_endpoint_payload_metadata(behave, RequestMethod.GET, 'http://www.example.org', 'step-name', 'test', 'metadata')
     assert behave.exceptions == {behave.scenario.name: [ANY(AssertionError, message='HttpClientTask: variable test has not been initialized')]}
     delattr(behave, 'exceptions')
 
     if pymqi.__name__ != 'grizzly_extras.dummy_pymqi':
-        step_task_client_get_endpoint_payload_metadata(behave, 'mq://mq.example.org', 'step-name', 'test', 'metadata')
+        step_task_client_from_endpoint_payload_metadata(behave, RequestMethod.GET, 'mq://mq.example.org', 'step-name', 'test', 'metadata')
         assert behave.exceptions == {behave.scenario.name: [ANY(AssertionError, message='MessageQueueClientTask: variable test has not been initialized')]}
         delattr(behave, 'exceptions')
 
     grizzly.scenario.variables['test'] = 'none'
 
-    step_task_client_get_endpoint_payload_metadata(behave, 'http://www.example.org', 'step-name', 'test', 'metadata')
+    step_task_client_from_endpoint_payload_metadata(behave, RequestMethod.GET, 'http://www.example.org', 'step-name', 'test', 'metadata')
     assert behave.exceptions == {behave.scenario.name: [ANY(AssertionError, message='HttpClientTask: variable metadata has not been initialized')]}
     delattr(behave, 'exceptions')
 
     if pymqi.__name__ != 'grizzly_extras.dummy_pymqi':
-        step_task_client_get_endpoint_payload_metadata(behave, 'mq://mq.example.org', 'step-name', 'test', 'metadata')
+        step_task_client_from_endpoint_payload_metadata(behave, RequestMethod.GET, 'mq://mq.example.org', 'step-name', 'test', 'metadata')
         assert behave.exceptions == {behave.scenario.name: [ANY(AssertionError, message='MessageQueueClientTask: variable metadata has not been initialized')]}
         delattr(behave, 'exceptions')
 
     grizzly.scenario.variables['metadata'] = 'none'
 
     assert len(grizzly.scenario.tasks()) == 0
-    step_task_client_get_endpoint_payload_metadata(behave, 'http://www.example.org', 'step-name', 'test', 'metadata')
+    step_task_client_from_endpoint_payload_metadata(behave, RequestMethod.GET, 'http://www.example.org', 'step-name', 'test', 'metadata')
     assert len(grizzly.scenario.tasks()) == 1
 
     grizzly.scenario.variables['endpoint_url'] = 'https://example.org'
-    step_task_client_get_endpoint_payload_metadata(behave, 'https://{{ endpoint_url }}', 'step-name', 'test', 'metadata')
+    step_task_client_from_endpoint_payload_metadata(behave, RequestMethod.GET, 'https://{{ endpoint_url }}', 'step-name', 'test', 'metadata')
 
     task = grizzly.scenario.tasks()[-1]
     assert isinstance(task, HttpClientTask)
@@ -71,42 +71,51 @@ def test_step_task_client_get_endpoint_payload_metadata(behave_fixture: BehaveFi
 
     behave.text = '1=1'
     with pytest.raises(NotImplementedError, match='HttpClientTask has not implemented support for step text'):
-        step_task_client_get_endpoint_payload_metadata(behave, 'https://{{ endpoint_url }}', 'step-name', 'test', 'metadata')
+        step_task_client_from_endpoint_payload_metadata(behave, RequestMethod.GET, 'https://{{ endpoint_url }}', 'step-name', 'test', 'metadata')
     assert behave.exceptions == {behave.scenario.name: [ANY(NotImplementedError, message='HttpClientTask has not implemented support for step text')]}
     delattr(behave, 'exceptions')
 
+    print('=' * 200)
 
-def test_step_task_client_get_endpoint_payload(behave_fixture: BehaveFixture) -> None:
+    behave.text = None
+    step_task_client_from_endpoint_payload_metadata(behave, RequestMethod.POST, 'https://{{ endpoint_url }}', 'step-name', 'test', 'metadata')
+    assert behave.exceptions == {behave.scenario.name: [
+        ANY(AssertionError, message='chosen request method does not match direction "from"'),
+    ]}
+    delattr(behave, 'exceptions')
+
+
+def test_step_task_client_from_endpoint_payload(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = cast(GrizzlyContext, behave.grizzly)
     grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
     behave.scenario = grizzly.scenario.behave
 
-    step_task_client_get_endpoint_payload(behave, 'obscure.example.com', 'step-name', 'test')
+    step_task_client_from_endpoint_payload(behave, RequestMethod.GET, 'obscure.example.com', 'step-name', 'test')
     assert behave.exceptions == {behave.scenario.name: [ANY(AssertionError, message='could not find scheme in "obscure.example.com"')]}
     delattr(behave, 'exceptions')
 
-    step_task_client_get_endpoint_payload(behave, 'obscure://obscure.example.com', 'step-name', 'test')
+    step_task_client_from_endpoint_payload(behave, RequestMethod.GET, 'obscure://obscure.example.com', 'step-name', 'test')
     assert behave.exceptions == {behave.scenario.name: [ANY(AssertionError, message='no client task registered for obscure')]}
     delattr(behave, 'exceptions')
 
-    step_task_client_get_endpoint_payload(behave, 'http://www.example.org', 'step-name', 'test')
+    step_task_client_from_endpoint_payload(behave, RequestMethod.GET, 'http://www.example.org', 'step-name', 'test')
     assert behave.exceptions == {behave.scenario.name: [ANY(AssertionError, message='HttpClientTask: variable test has not been initialized')]}
     delattr(behave, 'exceptions')
 
     if pymqi.__name__ != 'grizzly_extras.dummy_pymqi':
-        step_task_client_get_endpoint_payload(behave, 'mq://mq.example.org', 'step-name', 'test')
+        step_task_client_from_endpoint_payload(behave, RequestMethod.GET, 'mq://mq.example.org', 'step-name', 'test')
         assert behave.exceptions == {behave.scenario.name: [ANY(AssertionError, message='MessageQueueClientTask: variable test has not been initialized')]}
         delattr(behave, 'exceptions')
 
     grizzly.scenario.variables['test'] = 'none'
 
     assert len(grizzly.scenario.tasks()) == 0
-    step_task_client_get_endpoint_payload(behave, 'http://www.example.org', 'step-name', 'test')
+    step_task_client_from_endpoint_payload(behave, RequestMethod.GET, 'http://www.example.org', 'step-name', 'test')
     assert len(grizzly.scenario.tasks()) == 1
 
     grizzly.scenario.variables['endpoint_url'] = 'https://example.org'
-    step_task_client_get_endpoint_payload(behave, 'https://{{ endpoint_url }}', 'step-name', 'test')
+    step_task_client_from_endpoint_payload(behave, RequestMethod.GET, 'https://{{ endpoint_url }}', 'step-name', 'test')
 
     task = grizzly.scenario.tasks()[-1]
     assert isinstance(task, HttpClientTask)
@@ -115,12 +124,13 @@ def test_step_task_client_get_endpoint_payload(behave_fixture: BehaveFixture) ->
 
     behave.text = '1=1'
     with pytest.raises(NotImplementedError, match='HttpClientTask has not implemented support for step text'):
-        step_task_client_get_endpoint_payload(behave, 'https://{{ endpoint_url }}', 'step-name', 'test')
+        step_task_client_from_endpoint_payload(behave, RequestMethod.GET, 'https://{{ endpoint_url }}', 'step-name', 'test')
     assert behave.exceptions == {behave.scenario.name: [ANY(NotImplementedError, message='HttpClientTask has not implemented support for step text')]}
     delattr(behave, 'exceptions')
 
 
-def test_step_task_client_put_endpoint_file(grizzly_fixture: GrizzlyFixture) -> None:
+@pytest.mark.parametrize('request_method', [RequestMethod.PUT, RequestMethod.POST])
+def test_step_task_client_to_endpoint_file(grizzly_fixture: GrizzlyFixture, request_method: RequestMethod) -> None:
     behave = grizzly_fixture.behave.context
     grizzly = grizzly_fixture.grizzly
     grizzly.scenario.tasks.clear()
@@ -130,20 +140,17 @@ def test_step_task_client_put_endpoint_file(grizzly_fixture: GrizzlyFixture) -> 
     assert len(grizzly.scenario.orphan_templates) == 0
     assert len(grizzly.scenario.tasks()) == 0
 
-    step_task_client_put_endpoint_file(behave, 'file.json', 'http://example.org/put', 'step-name')
-    for exceptions in behave.exceptions.values():
-        for exception in exceptions:
-            print(exception)
+    step_task_client_to_endpoint_file(behave, request_method, 'file.json', 'http://example.org/put', 'step-name')
     assert behave.exceptions == {behave.scenario.name: [ANY(AssertionError, message='step text is not allowed for this step expression')]}
     delattr(behave, 'exceptions')
 
     behave.text = None
 
-    step_task_client_put_endpoint_file(behave, 'file-{{ suffix }}.json', 'http://{{ url }}', 'step-name')
+    step_task_client_to_endpoint_file(behave, request_method, 'file-{{ suffix }}.json', 'http://{{ url }}', 'step-name')
     assert behave.exceptions == {behave.scenario.name: [ANY(AssertionError, message='source file cannot be a template')]}
     delattr(behave, 'exceptions')
 
-    step_task_client_put_endpoint_file(behave, 'file-test.json', 'http://{{ url }}', 'step-name')
+    step_task_client_to_endpoint_file(behave, request_method, 'file-test.json', 'http://{{ url }}', 'step-name')
 
     assert len(grizzly.scenario.tasks()) == 1
     task = grizzly.scenario.tasks()[-1]
@@ -163,7 +170,7 @@ def test_step_task_client_put_endpoint_file(grizzly_fixture: GrizzlyFixture) -> 
     test_file.write_text('foobar {{ foo }}!')
 
     try:
-        step_task_client_put_endpoint_file(behave, 'file-test.json', 'http://{{ url }}', 'step-name-2')
+        step_task_client_to_endpoint_file(behave, request_method, 'file-test.json', 'http://{{ url }}', 'step-name-2')
 
         assert len(grizzly.scenario.tasks()) == 2
         task = grizzly.scenario.tasks()[-1]
@@ -182,7 +189,8 @@ def test_step_task_client_put_endpoint_file(grizzly_fixture: GrizzlyFixture) -> 
         test_file.unlink()
 
 
-def test_step_task_client_put_endpoint_file_destination(grizzly_fixture: GrizzlyFixture) -> None:
+@pytest.mark.parametrize('request_method', [RequestMethod.PUT, RequestMethod.POST])
+def test_step_task_client_to_endpoint_file_destination(grizzly_fixture: GrizzlyFixture, request_method: RequestMethod) -> None:
     behave = grizzly_fixture.behave.context
     grizzly = grizzly_fixture.grizzly
 
@@ -193,17 +201,17 @@ def test_step_task_client_put_endpoint_file_destination(grizzly_fixture: Grizzly
     assert len(grizzly.scenario.orphan_templates) == 0
     assert len(grizzly.scenario.tasks()) == 0
 
-    step_task_client_put_endpoint_file_destination(behave, 'file.json', 'http://example.org/put', 'step-name', 'uploaded-file.json')
+    step_task_client_to_endpoint_file_destination(behave, request_method, 'file.json', 'http://example.org/put', 'step-name', 'uploaded-file.json')
     assert behave.exceptions == {behave.scenario.name: [ANY(AssertionError, message='step text is not allowed for this step expression')]}
     delattr(behave, 'exceptions')
 
     behave.text = None
 
-    step_task_client_put_endpoint_file_destination(behave, 'file-{{ suffix }}.json', 'http://{{ url }}', 'step-name', 'uploaded-file-{{ suffix }}.json')
+    step_task_client_to_endpoint_file_destination(behave, request_method, 'file-{{ suffix }}.json', 'http://{{ url }}', 'step-name', 'uploaded-file-{{ suffix }}.json')
     assert behave.exceptions == {behave.scenario.name: [ANY(AssertionError, message='source file cannot be a template')]}
     delattr(behave, 'exceptions')
 
-    step_task_client_put_endpoint_file_destination(behave, 'file-test.json', 'http://{{ url }}', 'step-name', 'uploaded-file-{{ suffix }}.json')
+    step_task_client_to_endpoint_file_destination(behave, request_method, 'file-test.json', 'http://{{ url }}', 'step-name', 'uploaded-file-{{ suffix }}.json')
 
     assert len(grizzly.scenario.tasks()) == 1
     task = grizzly.scenario.tasks()[-1]
@@ -224,7 +232,7 @@ def test_step_task_client_put_endpoint_file_destination(grizzly_fixture: Grizzly
     test_file.write_text('foobar {{ foo }}!')
 
     try:
-        step_task_client_put_endpoint_file_destination(behave, 'file-test.json', 'http://{{ url }}', 'step-name', 'uploaded-file-{{ suffix }}.json')
+        step_task_client_to_endpoint_file_destination(behave, request_method, 'file-test.json', 'http://{{ url }}', 'step-name', 'uploaded-file-{{ suffix }}.json')
 
         assert len(grizzly.scenario.tasks()) == 2
         task = grizzly.scenario.tasks()[-1]
@@ -243,7 +251,8 @@ def test_step_task_client_put_endpoint_file_destination(grizzly_fixture: Grizzly
     finally:
         test_file.unlink()
 
-def test_step_task_client_put_endpoint_text(grizzly_fixture: GrizzlyFixture) -> None:
+@pytest.mark.parametrize('request_method', [RequestMethod.PUT, RequestMethod.POST])
+def test_step_task_client_to_endpoint_text(grizzly_fixture: GrizzlyFixture, request_method: RequestMethod) -> None:
     behave = grizzly_fixture.behave.context
     grizzly = grizzly_fixture.grizzly
     grizzly.scenario.tasks.clear()
@@ -252,18 +261,18 @@ def test_step_task_client_put_endpoint_text(grizzly_fixture: GrizzlyFixture) -> 
     assert len(grizzly.scenario.tasks()) == 0
 
     behave.text = None
-    step_task_client_put_endpoint_text(behave, 'http://example.org/put', 'step-name')
+    step_task_client_to_endpoint_text(behave, request_method, 'http://example.org/put', 'step-name')
     assert behave.exceptions == {behave.scenario.name: [ANY(AssertionError, message='step text is mandatory for this step expression')]}
     delattr(behave, 'exceptions')
 
     behave.text = ''
-    step_task_client_put_endpoint_text(behave, 'http://example.org/put', 'step-name')
+    step_task_client_to_endpoint_text(behave, request_method, 'http://example.org/put', 'step-name')
     assert behave.exceptions == {behave.scenario.name: [ANY(AssertionError, message='step text cannot be an empty string')]}
     delattr(behave, 'exceptions')
 
     behave.text = 'foobar {{ foo }}!'
 
-    step_task_client_put_endpoint_text(behave, 'http://{{ url }}', 'step-name')
+    step_task_client_to_endpoint_text(behave, request_method, 'http://{{ url }}', 'step-name')
     assert len(grizzly.scenario.tasks()) == 1
     task = grizzly.scenario.tasks()[-1]
 

--- a/tests/unit/test_grizzly/tasks/clients/test___init__.py
+++ b/tests/unit/test_grizzly/tasks/clients/test___init__.py
@@ -27,12 +27,12 @@ def test_task_failing(grizzly_fixture: GrizzlyFixture, mocker: MockerFixture, ca
         class TestClientTask(ClientTask):
             __scenario__ = grizzly_fixture.grizzly.scenario
 
-            def get(self, parent: GrizzlyScenario) -> GrizzlyResponse:
+            def request_from(self, parent: GrizzlyScenario) -> GrizzlyResponse:
                 with self.action(parent):
                     message = 'failed get'
                     raise RuntimeError(message)
 
-            def put(self, _: GrizzlyScenario) -> GrizzlyResponse:
+            def request_to(self, _: GrizzlyScenario) -> GrizzlyResponse:
                 return None, 'put'
 
         if log_prefix:

--- a/tests/unit/test_grizzly/tasks/clients/test_blobstorage.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_blobstorage.py
@@ -314,7 +314,7 @@ class TestBlobStorageClientTask:
                 text='foobar',
             )
 
-    def test_get(self, behave_fixture: BehaveFixture, grizzly_fixture: GrizzlyFixture) -> None:
+    def test_request_from(self, behave_fixture: BehaveFixture, grizzly_fixture: GrizzlyFixture) -> None:
         behave = behave_fixture.context
         grizzly = cast(GrizzlyContext, behave.grizzly)
         grizzly.scenario.variables['test'] = 'none'
@@ -333,7 +333,7 @@ class TestBlobStorageClientTask:
         with pytest.raises(NotImplementedError, match='BlobStorageClientTask has not implemented GET'):
             task(parent)
 
-    def test_put(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
+    def test_request_to(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
         upload_blob_mock = mocker.patch('azure.storage.blob._blob_service_client.BlobClient.upload_blob', autospec=True)
 
         grizzly = grizzly_fixture.grizzly
@@ -405,9 +405,6 @@ class TestBlobStorageClientTask:
         )
 
         task = task_factory()
-
-        print('-' * 200)
-        print(f'test: {source_file.as_posix()}')
 
         task(parent)
 

--- a/tests/unit/test_grizzly/tasks/clients/test_messagequeue.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_messagequeue.py
@@ -410,7 +410,7 @@ class TestMessageQueueClientTask:
             if zmq_context is not None:
                 zmq_context.destroy()
 
-    def test_get(self, mocker: MockerFixture, noop_zmq: NoopZmqFixture, grizzly_fixture: GrizzlyFixture, caplog: LogCaptureFixture) -> None:  # noqa: PLR0915
+    def test_request_from(self, mocker: MockerFixture, noop_zmq: NoopZmqFixture, grizzly_fixture: GrizzlyFixture, caplog: LogCaptureFixture) -> None:  # noqa: PLR0915
         noop_zmq('grizzly.tasks.clients.messagequeue')
 
         parent = grizzly_fixture(scenario_type=IteratorScenario)
@@ -599,7 +599,7 @@ class TestMessageQueueClientTask:
             if zmq_context is not None:
                 zmq_context.destroy()
 
-    def test_put(self, mocker: MockerFixture, noop_zmq: NoopZmqFixture, grizzly_fixture: GrizzlyFixture) -> None:
+    def test_request_to(self, mocker: MockerFixture, noop_zmq: NoopZmqFixture, grizzly_fixture: GrizzlyFixture) -> None:
         noop_zmq('grizzly.tasks.clients.messagequeue')
 
         parent = grizzly_fixture()

--- a/tests/unit/test_grizzly/tasks/clients/test_servicebus.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_servicebus.py
@@ -671,7 +671,7 @@ class TestServiceBusClientTask:
             'response': {'message': 'foobar!', 'payload': '1234567890'},
         }
 
-    def test_get(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
+    def test_request_from(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
         parent = grizzly_fixture()
 
         client_mock = mocker.MagicMock()
@@ -693,7 +693,7 @@ class TestServiceBusClientTask:
         # no variables
         task.payload_variable = None
 
-        assert task.get(parent) == (None, 'foobar')
+        assert task.request_from(parent) == (None, 'foobar')
 
         request_mock.assert_called_once_with(state.parent, {
             'action': 'RECEIVE',
@@ -709,7 +709,7 @@ class TestServiceBusClientTask:
         # with payload variable
         task.payload_variable = 'foobaz'
 
-        assert task.get(parent) == (None, 'foobar')
+        assert task.request_from(parent) == (None, 'foobar')
 
         request_mock.assert_called_once_with(state.parent, {
             'action': 'RECEIVE',
@@ -725,7 +725,7 @@ class TestServiceBusClientTask:
         task.metadata_variable = 'bazfoo'
         request_mock = mocker.patch.object(task, 'request', return_value={'metadata': {'x-foo-bar': 'hello'}, 'payload': 'foobar'})
 
-        assert task.get(parent) == ({'x-foo-bar': 'hello'}, 'foobar')
+        assert task.request_from(parent) == ({'x-foo-bar': 'hello'}, 'foobar')
 
         request_mock.assert_called_once_with(state.parent, {
             'action': 'RECEIVE',
@@ -736,7 +736,7 @@ class TestServiceBusClientTask:
 
         assert parent.user.variables == SOME(dict, {'foobaz': 'foobar', 'bazfoo': jsondumps({'x-foo-bar': 'hello'})})
 
-    def test_put(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
+    def test_request_to(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
         scenario = grizzly_fixture()
 
         service_bus_client_task = type('ServiceBusClientTask_001', (ServiceBusClientTask,), {'_context': {'variables': {}}, '__scenario__': scenario.user._scenario})
@@ -757,7 +757,7 @@ class TestServiceBusClientTask:
         request_mock = mocker.patch.object(task, 'request', return_value={'metadata': None, 'payload': 'foobar'})
 
         # inline source, no file
-        assert task.put(scenario) == (None, 'foobar')
+        assert task.request_to(scenario) == (None, 'foobar')
 
         request_mock.assert_called_once_with(state.parent, {
             'action': 'SEND',
@@ -772,7 +772,7 @@ class TestServiceBusClientTask:
         task.source = '{{ foobar }}'
         scenario.user.set_variable('foobar', 'hello world')
 
-        assert task.put(scenario) == (None, 'foobar')
+        assert task.request_to(scenario) == (None, 'foobar')
 
         request_mock.assert_called_once_with(state.parent, {
             'action': 'SEND',
@@ -788,7 +788,7 @@ class TestServiceBusClientTask:
         (grizzly_fixture.test_context / 'requests' / 'source.json').write_text('hello world')
         task.source = 'source.json'
 
-        assert task.put(scenario) == (None, 'foobar')
+        assert task.request_to(scenario) == (None, 'foobar')
 
         request_mock.assert_called_once_with(state.parent, {
             'action': 'SEND',
@@ -804,7 +804,7 @@ class TestServiceBusClientTask:
         (grizzly_fixture.test_context / 'requests' / 'source.j2.json').write_text('{{ foobar }}')
         task.source = '{{ filename }}'
 
-        assert task.put(scenario) == (None, 'foobar')
+        assert task.request_to(scenario) == (None, 'foobar')
 
         request_mock.assert_called_once_with(state.parent, {
             'action': 'SEND',

--- a/tests/unit/test_grizzly/testdata/test_filters.py
+++ b/tests/unit/test_grizzly/testdata/test_filters.py
@@ -1,14 +1,14 @@
 """Unit tests for grizzly.testdata.filters."""
 from __future__ import annotations
 
-from base64 import b64encode
+from base64 import b64encode as base64_b64encode
 from collections import namedtuple
 from typing import TYPE_CHECKING
 
 import pytest
 from jinja2.filters import FILTERS
 
-from grizzly.testdata.filters import templatingfilter
+from grizzly.testdata.filters import b64decode, b64encode, fromtestdata, stringify, templatingfilter
 
 if TYPE_CHECKING:  # pragma: no cover
     from tests.fixtures import GrizzlyFixture
@@ -41,16 +41,15 @@ def test_templatingfilter(grizzly_fixture: GrizzlyFixture) -> None:
 
     assert FILTERS.get('testuppercase', None) is testuppercase
 
+    del FILTERS['testuppercase']
+
 
 def test_fromtestdata() -> None:
-    func = FILTERS.get('fromtestdata', None)
-    assert func is not None
-
     sub_value = namedtuple('Testdata', ['foz', 'baz'])(**{'foz': 'foo', 'baz': 'bar'})  # noqa: PYI024, PIE804
 
     value = namedtuple('Testdata', ['foo', 'bar'])(**{'foo': sub_value, 'bar': 'bar'})  # noqa: PYI024, PIE804
 
-    assert func(value) == {
+    assert fromtestdata(value) == {
         'foo': {
             'foz': 'foo',
             'baz': 'bar',
@@ -60,27 +59,17 @@ def test_fromtestdata() -> None:
 
 
 def test_stringify() -> None:
-    func = FILTERS.get('stringify', None)
-
-    assert func is not None
-
-    assert func('foobar') == '"foobar"'
-    assert func(1337) == '1337'
-    assert func(0.1337) == '0.1337'
-    assert func(['foo', 'bar']) == '["foo", "bar"]'
-    assert func({'foo': 'bar'}) == '{"foo": "bar"}'
-    assert func(None) == 'null'
+    assert stringify('foobar') == '"foobar"'
+    assert stringify(1337) == '1337'
+    assert stringify(0.1337) == '0.1337'
+    assert stringify(['foo', 'bar']) == '["foo", "bar"]'
+    assert stringify({'foo': 'bar'}) == '{"foo": "bar"}'
+    assert stringify(None) == 'null'
 
 
 def test_b64encode() -> None:
-    func = FILTERS.get('b64encode', None)
-
-    assert func is not None
-    assert func('foobar') == b64encode(b'foobar').decode()
+    assert b64encode('foobar') == base64_b64encode(b'foobar').decode()
 
 
 def test_b64decode() -> None:
-    func = FILTERS.get('b64decode', None)
-
-    assert func is not None
-    assert func(b64encode(b'foobar').decode()) == 'foobar'
+    assert b64decode(base64_b64encode(b'foobar').decode()) == 'foobar'

--- a/tests/unit/test_grizzly/testdata/test_filters.py
+++ b/tests/unit/test_grizzly/testdata/test_filters.py
@@ -1,6 +1,8 @@
 """Unit tests for grizzly.testdata.filters."""
 from __future__ import annotations
 
+from base64 import b64encode
+from collections import namedtuple
 from typing import TYPE_CHECKING
 
 import pytest
@@ -38,3 +40,47 @@ def test_templatingfilter(grizzly_fixture: GrizzlyFixture) -> None:
         templatingfilter(uc)
 
     assert FILTERS.get('testuppercase', None) is testuppercase
+
+
+def test_fromtestdata() -> None:
+    func = FILTERS.get('fromtestdata', None)
+    assert func is not None
+
+    sub_value = namedtuple('Testdata', ['foz', 'baz'])(**{'foz': 'foo', 'baz': 'bar'})  # noqa: PYI024, PIE804
+
+    value = namedtuple('Testdata', ['foo', 'bar'])(**{'foo': sub_value, 'bar': 'bar'})  # noqa: PYI024, PIE804
+
+    assert func(value) == {
+        'foo': {
+            'foz': 'foo',
+            'baz': 'bar',
+        },
+        'bar': 'bar',
+    }
+
+
+def test_stringify() -> None:
+    func = FILTERS.get('stringify', None)
+
+    assert func is not None
+
+    assert func('foobar') == '"foobar"'
+    assert func(1337) == '1337'
+    assert func(0.1337) == '0.1337'
+    assert func(['foo', 'bar']) == '["foo", "bar"]'
+    assert func({'foo': 'bar'}) == '{"foo": "bar"}'
+    assert func(None) == 'null'
+
+
+def test_b64encode() -> None:
+    func = FILTERS.get('b64encode', None)
+
+    assert func is not None
+    assert func('foobar') == b64encode(b'foobar').decode()
+
+
+def test_b64decode() -> None:
+    func = FILTERS.get('b64decode', None)
+
+    assert func is not None
+    assert func(b64encode(b'foobar').decode()) == 'foobar'

--- a/tests/unit/test_grizzly/testdata/test_utils.py
+++ b/tests/unit/test_grizzly/testdata/test_utils.py
@@ -435,19 +435,19 @@ write this "hello "{{ test }}"!"
         assert resolve_variable(grizzly.scenario, 'test/foobar.txt', try_file=False) == 'test/foobar.txt'
 
         assert resolve_variable(grizzly.scenario, 'file://./test/foobar.txt', try_file=False) == """
-hello world
+hello {{ hello }}
 write this "hello "{{ test }}"!"
-""".rstrip()
+"""
 
         assert resolve_variable(grizzly.scenario, 'file://test/foobar.txt', try_file=False) == """
-hello world
+hello {{ hello }}
 write this "hello "{{ test }}"!"
-""".rstrip()
+"""
 
         assert resolve_variable(grizzly.scenario, 'file:///test/foobar.txt', try_file=False) == """
-hello world
+hello {{ hello }}
 write this "hello "{{ test }}"!"
-""".rstrip()
+"""
 
     finally:
         with suppress(KeyError):

--- a/tests/unit/test_grizzly/testdata/test_utils.py
+++ b/tests/unit/test_grizzly/testdata/test_utils.py
@@ -432,6 +432,23 @@ hello world
 write this "hello "{{ test }}"!"
 """.rstrip()
 
+        assert resolve_variable(grizzly.scenario, 'test/foobar.txt', try_file=False) == 'test/foobar.txt'
+
+        assert resolve_variable(grizzly.scenario, 'file://./test/foobar.txt', try_file=False) == """
+hello world
+write this "hello "{{ test }}"!"
+""".rstrip()
+
+        assert resolve_variable(grizzly.scenario, 'file://test/foobar.txt', try_file=False) == """
+hello world
+write this "hello "{{ test }}"!"
+""".rstrip()
+
+        assert resolve_variable(grizzly.scenario, 'file:///test/foobar.txt', try_file=False) == """
+hello world
+write this "hello "{{ test }}"!"
+""".rstrip()
+
     finally:
         with suppress(KeyError):
             del environ['HELLO_WORLD']


### PR DESCRIPTION
To force the contents of a file in a variable when declaring it, prefix with `file://` schema.

Support for HTTP PUT and which status codes are valid in a request, in `HttpClientTask`