### PR TITLE
sub-render variables if they contain templates in `SetVariableTask` and `HttpClientTask`

### DIFF
--- a/grizzly/tasks/clients/http.py
+++ b/grizzly/tasks/clients/http.py
@@ -57,7 +57,7 @@ from grizzly.auth import AAD, GrizzlyHttpAuthClient, refresh_token
 from grizzly.tasks import RequestTaskResponse
 from grizzly.testdata.utils import read_file
 from grizzly.types import GrizzlyResponse, RequestDirection, RequestMethod, bool_type
-from grizzly.utils import is_file, merge_dicts
+from grizzly.utils import has_template, is_file, merge_dicts
 from grizzly.utils.protocols import http_populate_cookiejar
 from grizzly_extras.arguments import parse_arguments, split_value
 from grizzly_extras.text import has_separator
@@ -209,6 +209,9 @@ class HttpClientTask(ClientTask, GrizzlyHttpAuthClient):
     @refresh_token(AAD)
     def request_to(self, parent: GrizzlyScenario) -> GrizzlyResponse:
         source = parent.user.render(cast(str, self.source))
+
+        if has_template(source):
+            source = parent.user.render(source)
 
         with self.action(parent) as meta:
             url = parent.user.render(self.endpoint)

--- a/grizzly/tasks/set_variable.py
+++ b/grizzly/tasks/set_variable.py
@@ -82,6 +82,9 @@ class SetVariableTask(GrizzlyTask):
             if is_file(value):
                 value = parent.user.render(read_file(value))
 
+            if has_template(value):
+                value = parent.user.render(value)
+
             parent.logger.debug('%s: variable=%s, value=%r, type=%s', self.__class__.__name__, self.variable, value, self.variable_type.name)
 
             if self.variable_type == VariableType.VARIABLES:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -22,7 +22,6 @@ from behave.runner import Runner as BehaveRunner
 from behave.step_registry import registry as step_registry
 from geventhttpclient.header import Headers
 from geventhttpclient.response import HTTPSocketPoolResponse
-from jinja2.filters import FILTERS
 from locust.contrib.fasthttp import FastRequest, FastResponse
 from locust.contrib.fasthttp import ResponseContextManager as FastResponseContextManager
 from pytest_mock.plugin import MockerFixture
@@ -354,15 +353,6 @@ class GrizzlyFixture:
 
         with suppress(Exception):
             GrizzlyContext.destroy()
-
-        # clean up filters, since we might've added custom ones
-        filter_keys = reversed(list(FILTERS.keys()))
-        for key in filter_keys:
-            if key == 'tojson':
-                break
-
-            with suppress(KeyError):
-                del FILTERS[key]
 
         return True
 

--- a/tests/unit/test_grizzly/steps/test__helpers.py
+++ b/tests/unit/test_grizzly/steps/test__helpers.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 
 import json
 import os
+from contextlib import suppress
 from itertools import product
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Union, cast
 
 import pytest
+from jinja2.filters import FILTERS
 
 from grizzly.context import GrizzlyContext
 from grizzly.exceptions import ResponseHandlerError
@@ -200,6 +202,9 @@ def test_add_request_task(grizzly_fixture: GrizzlyFixture, tmp_path_factory: Tem
     finally:
         del os.environ['GRIZZLY_CONTEXT_ROOT']
         rm_rf(test_context_root)
+
+        with suppress(KeyError):
+            del FILTERS['uppercase']
 
     with pytest.raises(ValueError, match='incorrect format in arguments: "world:False"'):
         add_request_task(behave, method=RequestMethod.GET, endpoint='hello | world:False', source=None, name='hello-world')

--- a/tests/unit/test_grizzly/testdata/test_filters.py
+++ b/tests/unit/test_grizzly/testdata/test_filters.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 
 from base64 import b64encode as base64_b64encode
 from collections import namedtuple
+from contextlib import suppress
 from typing import TYPE_CHECKING
 
 import pytest
 from jinja2.filters import FILTERS
 
-from grizzly.testdata.filters import b64decode, b64encode, fromtestdata, stringify, templatingfilter
+from grizzly.testdata.filters import templatingfilter
 
 if TYPE_CHECKING:  # pragma: no cover
     from tests.fixtures import GrizzlyFixture
@@ -17,39 +18,43 @@ if TYPE_CHECKING:  # pragma: no cover
 def test_templatingfilter(grizzly_fixture: GrizzlyFixture) -> None:
     parent = grizzly_fixture()
 
-    def testuppercase(value: str) -> str:
-        return value.upper()
+    try:
+        def testuppercase(value: str) -> str:
+            return value.upper()
 
-    assert FILTERS.get('testuppercase', None) is None
+        assert FILTERS.get('testuppercase', None) is None
 
-    templatingfilter(testuppercase)
+        templatingfilter(testuppercase)
 
-    assert FILTERS.get('testuppercase', None) is testuppercase
+        assert FILTERS.get('testuppercase', None) is testuppercase
 
-    actual = parent.user._scenario.jinja2.from_string('{{ variable | testuppercase }}').render(variable='foobar')
+        actual = parent.user._scenario.jinja2.from_string('{{ variable | testuppercase }}').render(variable='foobar')
 
-    assert actual == 'FOOBAR'
+        assert actual == 'FOOBAR'
 
-    def _testuppercase(value: str) -> str:
-        return value.upper()
+        def _testuppercase(value: str) -> str:
+            return value.upper()
 
-    uc = _testuppercase
-    uc.__name__ = 'testuppercase'
+        uc = _testuppercase
+        uc.__name__ = 'testuppercase'
 
-    with pytest.raises(AssertionError, match='testuppercase is already registered as a filter'):
-        templatingfilter(uc)
+        with pytest.raises(AssertionError, match='testuppercase is already registered as a filter'):
+            templatingfilter(uc)
 
-    assert FILTERS.get('testuppercase', None) is testuppercase
-
-    del FILTERS['testuppercase']
+        assert FILTERS.get('testuppercase', None) is testuppercase
+    finally:
+        with suppress(Exception):
+            del FILTERS['testuppercase']
 
 
 def test_fromtestdata() -> None:
-    sub_value = namedtuple('Testdata', ['foz', 'baz'])(**{'foz': 'foo', 'baz': 'bar'})  # noqa: PYI024, PIE804
+    func = FILTERS.get('fromtestdata', None)
+    assert func is not None
 
+    sub_value = namedtuple('Testdata', ['foz', 'baz'])(**{'foz': 'foo', 'baz': 'bar'})  # noqa: PYI024, PIE804
     value = namedtuple('Testdata', ['foo', 'bar'])(**{'foo': sub_value, 'bar': 'bar'})  # noqa: PYI024, PIE804
 
-    assert fromtestdata(value) == {
+    assert func(value) == {
         'foo': {
             'foz': 'foo',
             'baz': 'bar',
@@ -59,17 +64,24 @@ def test_fromtestdata() -> None:
 
 
 def test_stringify() -> None:
-    assert stringify('foobar') == '"foobar"'
-    assert stringify(1337) == '1337'
-    assert stringify(0.1337) == '0.1337'
-    assert stringify(['foo', 'bar']) == '["foo", "bar"]'
-    assert stringify({'foo': 'bar'}) == '{"foo": "bar"}'
-    assert stringify(None) == 'null'
+    func = FILTERS.get('stringify', None)
+    assert func is not None
+
+    assert func('foobar') == '"foobar"'
+    assert func(1337) == '1337'
+    assert func(0.1337) == '0.1337'
+    assert func(['foo', 'bar']) == '["foo", "bar"]'
+    assert func({'foo': 'bar'}) == '{"foo": "bar"}'
+    assert func(None) == 'null'
 
 
 def test_b64encode() -> None:
-    assert b64encode('foobar') == base64_b64encode(b'foobar').decode()
+    func = FILTERS.get('b64encode', None)
+    assert func is not None
+    assert func('foobar') == base64_b64encode(b'foobar').decode()
 
 
 def test_b64decode() -> None:
-    assert b64decode(base64_b64encode(b'foobar').decode()) == 'foobar'
+    func = FILTERS.get('b64decode', None)
+    assert func is not None
+    assert func(base64_b64encode(b'foobar').decode()) == 'foobar'


### PR DESCRIPTION
this is needed when the value of a variable contains a template (string) that we want to be rendered., e.g.:

```gherkin
Given value for variable "template" is "file://./template.j2.xml"  # template.j2.xml itself contains templates, variable "template" is now the content of the file, hence unrendered

...

Given value for variable "payload" is "{{ template }}"  # this will, runtime render the template and save it in variable "payload"
```


don't touch global `jinja2.filters.FILTERS` when testing filters, and make sure to always remove any test filters during tests.