### PR TITLE
`IotHubUser` support for receiving (C2D) messages

### DIFF
--- a/grizzly/behave.py
+++ b/grizzly/behave.py
@@ -64,7 +64,7 @@ def before_feature(context: Context, feature: Feature, *_args: Any, **_kwargs: A
 
     context.grizzly = grizzly
     context.start = time()
-    context.started = datetime.now(tz=None)
+    context.started = datetime.now().astimezone()
     context.last_task_count = {}
     context.exceptions = {}
     context.background_steps = getattr(feature.background, 'steps', None) or []

--- a/grizzly/context.py
+++ b/grizzly/context.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from os import environ
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union, cast
@@ -140,7 +140,10 @@ def jinja2_environment_factory() -> Environment:
     """Create a Jinja2 environment, so same instance is used throughout each grizzly scenario, with custom filters."""
     environment = Environment(autoescape=False, loader=FileSystemLoader(Path(environ['GRIZZLY_CONTEXT_ROOT']) / 'requests'), undefined=DebugChainableUndefined)
 
-    environment.globals.update({'datetime': datetime})
+    environment.globals.update({
+        'datetime': datetime,
+        'timezone': timezone,
+    })
 
     return environment
 

--- a/grizzly/context.py
+++ b/grizzly/context.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union, cast
 
 import yaml
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import DebugUndefined, Environment, FileSystemLoader
 from jinja2.filters import FILTERS
 
 from grizzly.testdata import GrizzlyVariables
@@ -115,7 +115,7 @@ class GrizzlyContext:
 
 def jinja2_environment_factory() -> Environment:
     """Create a Jinja2 environment, so same instance is used throughout each grizzly scenario, with custom filters."""
-    environment = Environment(autoescape=False, loader=FileSystemLoader(Path(environ['GRIZZLY_CONTEXT_ROOT']) / 'requests'))
+    environment = Environment(autoescape=False, loader=FileSystemLoader(Path(environ['GRIZZLY_CONTEXT_ROOT']) / 'requests'), undefined=DebugUndefined)
 
     environment.globals.update({'datetime': datetime})
 

--- a/grizzly/context.py
+++ b/grizzly/context.py
@@ -20,6 +20,7 @@ from grizzly.utils import MergeYamlTag, flatten, merge_dicts
 if TYPE_CHECKING:  # pragma: no cover
     from locust.dispatch import UsersDispatcher
 
+    from grizzly.events import GrizzlyEvents
     from grizzly.types.behave import Scenario
     from grizzly.types.locust import LocalRunner, MasterRunner, WorkerRunner
 
@@ -68,6 +69,8 @@ class GrizzlyContext:
     _state: GrizzlyContextState
     _setup: GrizzlyContextSetup
     _scenarios: GrizzlyContextScenarios
+    _events: GrizzlyEvents
+
 
     def __new__(cls, *_args: Any, **_kwargs: Any) -> GrizzlyContext:  # noqa: PYI034
         """Class is a singleton, there should only be once instance of it."""
@@ -87,9 +90,11 @@ class GrizzlyContext:
 
     def __init__(self) -> None:
         if not self._initialized:
+            from grizzly.events import events
             self._setup = GrizzlyContextSetup()
             self._scenarios = GrizzlyContextScenarios(self)
             self._state = GrizzlyContextState()
+            self._events = events
             self._initialized = True
 
     @property
@@ -112,6 +117,10 @@ class GrizzlyContext:
     @property
     def scenarios(self) -> GrizzlyContextScenarios:
         return self._scenarios
+
+    @property
+    def events(self) -> GrizzlyEvents:
+        return self._events
 
 
 class DebugChainableUndefined(DebugUndefined):

--- a/grizzly/events/__init__.py
+++ b/grizzly/events/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from locust.event import EventHook
 
@@ -10,6 +10,32 @@ if TYPE_CHECKING:  # pragma: no cover
     from grizzly.tasks import RequestTask
     from grizzly.types import GrizzlyResponse
     from grizzly.users import GrizzlyUser
+
+
+GrizzlyEventHandlerFunc = Callable[..., None]
+
+
+class GrizzlyEventHandlerClass(metaclass=ABCMeta):
+    user: GrizzlyUser
+    event_hook: EventHook
+
+    def __init__(self, user: GrizzlyUser) -> None:
+        self.user = user
+        self.event_hook = user.events.request
+
+    @abstractmethod
+    def __call__(
+        self,
+        name: str,
+        context: GrizzlyResponse,
+        request: RequestTask,
+        exception: Optional[Exception] = None,
+        **kwargs: Any,
+    ) -> None:
+        ...
+
+
+GrizzlyEventHandler = GrizzlyEventHandlerFunc | GrizzlyEventHandlerClass
 
 class GrizzlyEventHook(EventHook):
     """Override locust.events.EventHook to get types, and not to catch any exceptions."""
@@ -30,26 +56,6 @@ class GrizzlyEventHook(EventHook):
 
         for handler in handlers:
             handler(**kwargs)
-
-
-class GrizzlyEventHandler(metaclass=ABCMeta):
-    user: GrizzlyUser
-    event_hook: EventHook
-
-    def __init__(self, user: GrizzlyUser) -> None:
-        self.user = user
-        self.event_hook = user.event_hook
-
-    @abstractmethod
-    def __call__(
-        self,
-        name: str,
-        context: GrizzlyResponse,
-        request: RequestTask,
-        exception: Optional[Exception] = None,
-        **kwargs: Any,
-    ) -> None:
-        ...
 
 
 from .request_logger import RequestLogger

--- a/grizzly/events/__init__.py
+++ b/grizzly/events/__init__.py
@@ -2,11 +2,12 @@
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
+from contextlib import suppress
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from functools import wraps
 from time import perf_counter
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional, Protocol
 
 from locust.event import EventHook
 
@@ -42,6 +43,15 @@ class GrizzlyEventHandlerClass(metaclass=ABCMeta):
 GrizzlyEventHandler = GrizzlyEventHandlerFunc | GrizzlyEventHandlerClass
 
 
+class GrizzlyInternalEventHandler(Protocol):
+    def __call__(self, *,
+        timestamp: str,
+        metrics: dict[str, Any],
+        tags: dict[str, str | None],
+        measurement: str,
+    ) -> None: ...
+
+
 class GrizzlyEventHook(EventHook):
     """Override locust.events.EventHook to get types, and not to catch any exceptions."""
 
@@ -63,34 +73,109 @@ class GrizzlyEventHook(EventHook):
             handler(**kwargs)
 
 
+class GrizzlyInternalEventHook(GrizzlyEventHook):
+    name: str
+
+    def __init__(self, *args: Any, name: str, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+        self.name = name
+
+    def add_listener(
+            self,
+            handler: GrizzlyInternalEventHandler,  # type: ignore[override]
+    ) -> None:
+        return super().add_listener(handler)
+
+    def fire(  # type: ignore[override]
+        self,
+        *,
+        reverse: bool = False,
+        timestamp: str,
+        metrics: dict[str, Any],
+        tags: dict[str, str | None],
+        measurement: str | None,
+    ) -> None:
+        super().fire(
+            reverse=reverse,
+            timestamp=timestamp,
+            metrics=metrics,
+            tags=tags,
+            measurement=measurement,
+        )
+
+def grizzly_internal_event_hook_factory(name: str) -> Callable[[], GrizzlyInternalEventHook]:
+    def wrapper() -> GrizzlyInternalEventHook:
+        return GrizzlyInternalEventHook(name=name)
+
+    return wrapper
+
 @dataclass
 class GrizzlyEvents:
-    keystore_request: GrizzlyEventHook = field(init=False, default_factory=GrizzlyEventHook)
-    testdata_request: GrizzlyEventHook = field(init=False, default_factory=GrizzlyEventHook)
+    keystore_request: GrizzlyInternalEventHook = field(init=False, default_factory=grizzly_internal_event_hook_factory('request_keystore'))
+    testdata_request: GrizzlyInternalEventHook = field(init=False, default_factory=grizzly_internal_event_hook_factory('request_testdata'))
+    user_event: GrizzlyInternalEventHook = field(init=False, default_factory=grizzly_internal_event_hook_factory('user_event'))
 
 
-def event(hook: GrizzlyEventHook, measurement: str | None = None, tags: dict[str, str] | None = None) -> Callable[..., Any]:
+class GrizzlyEventDecoder(metaclass=ABCMeta):
+    arg: str | int
+
+    def __init__(self, arg: str | int) -> None:
+        self.arg = arg
+
+    @abstractmethod
+    def __call__(
+        self,
+        *args: Any,
+        tags: dict[str, str | None] | None,
+        return_value: Any,
+        exception: Exception | None,
+        **kwargs: Any,
+    ) -> tuple[dict[str, Any], dict[str, str | None]]:
+        ...
+
+
+def event(
+        hook: GrizzlyInternalEventHook,
+        *,
+        decoder: GrizzlyEventDecoder,
+        measurement: str | None = None,
+        tags: dict[str, str | None] | None = None,
+    ) -> Callable[..., Any]:
+
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
         @wraps(func)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> Any:
             start = perf_counter()
             return_value: Any = None
+            exception: Exception | None = None
 
             try:
                 return_value = func(*args, **kwargs)
+            except Exception as e:
+                exception = e
+                raise
             finally:
                 response_time = (perf_counter() - start) * 1000
                 timestamp = datetime.now(timezone.utc).isoformat()
 
-                hook.fire(
-                    reverse=False,
-                    timestamp=timestamp,
-                    response_time=response_time,
-                    return_value=return_value,
-                    tags=tags,
-                    measurement=measurement,
-                    kwargs=kwargs,
-                )
+                with suppress(Exception):
+                    metrics, decoded_tags = decoder(*args, tags=tags, return_value=return_value, exception=exception, **kwargs)
+
+                    if tags is not None:
+                        decoded_tags.update(tags)
+
+                    _measurement = hook.name if measurement is None else measurement
+
+                    metrics.update({'response_time': response_time})
+
+                    hook.fire(
+                        reverse=False,
+                        timestamp=timestamp,
+                        tags=decoded_tags,
+                        measurement=_measurement,
+                        metrics=metrics,
+                    )
 
             return return_value
 

--- a/grizzly/events/__init__.py
+++ b/grizzly/events/__init__.py
@@ -2,13 +2,17 @@
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from functools import wraps
+from time import perf_counter
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from locust.event import EventHook
 
 if TYPE_CHECKING:  # pragma: no cover
     from grizzly.tasks import RequestTask
-    from grizzly.types import GrizzlyResponse
+    from grizzly.types import GrizzlyResponse, P
     from grizzly.users import GrizzlyUser
 
 
@@ -59,8 +63,45 @@ class GrizzlyEventHook(EventHook):
             handler(**kwargs)
 
 
+@dataclass
+class GrizzlyEvents:
+    keystore_request: GrizzlyEventHook = field(init=False, default_factory=GrizzlyEventHook)
+    testdata_request: GrizzlyEventHook = field(init=False, default_factory=GrizzlyEventHook)
+
+
+def event(hook: GrizzlyEventHook, measurement: str | None = None, tags: dict[str, str] | None = None) -> Callable[..., Any]:
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        @wraps(func)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> Any:
+            start = perf_counter()
+            return_value: Any = None
+
+            try:
+                return_value = func(*args, **kwargs)
+            finally:
+                response_time = (perf_counter() - start) * 1000
+                timestamp = datetime.now(timezone.utc).isoformat()
+
+                hook.fire(
+                    reverse=False,
+                    timestamp=timestamp,
+                    response_time=response_time,
+                    return_value=return_value,
+                    tags=tags,
+                    measurement=measurement,
+                    kwargs=kwargs,
+                )
+
+            return return_value
+
+        return wrapper
+
+    return decorator
+
 from .request_logger import RequestLogger
 from .response_handler import ResponseHandler
+
+events = GrizzlyEvents()
 
 __all__ = [
     'RequestLogger',

--- a/grizzly/events/__init__.py
+++ b/grizzly/events/__init__.py
@@ -37,6 +37,7 @@ class GrizzlyEventHandlerClass(metaclass=ABCMeta):
 
 GrizzlyEventHandler = GrizzlyEventHandlerFunc | GrizzlyEventHandlerClass
 
+
 class GrizzlyEventHook(EventHook):
     """Override locust.events.EventHook to get types, and not to catch any exceptions."""
 

--- a/grizzly/events/__init__.py
+++ b/grizzly/events/__init__.py
@@ -1,8 +1,8 @@
 """Logic for grizzly specific events."""
 from __future__ import annotations
 
+import logging
 from abc import ABCMeta, abstractmethod
-from contextlib import suppress
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from functools import wraps
@@ -18,6 +18,9 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 GrizzlyEventHandlerFunc = Callable[..., None]
+
+
+logger = logging.getLogger('grizzly.events')
 
 
 class GrizzlyEventHandlerClass(metaclass=ABCMeta):
@@ -159,7 +162,7 @@ def event(
                 response_time = (perf_counter() - start) * 1000
                 timestamp = datetime.now(timezone.utc).isoformat()
 
-                with suppress(Exception):
+                try:
                     metrics, decoded_tags = decoder(*args, tags=tags, return_value=return_value, exception=exception, **kwargs)
 
                     if tags is not None:
@@ -176,6 +179,8 @@ def event(
                         measurement=_measurement,
                         metrics=metrics,
                     )
+                except:
+                    logger.exception('failed to trigger event')
 
             return return_value
 

--- a/grizzly/events/request_logger.py
+++ b/grizzly/events/request_logger.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 from urllib.parse import urlparse, urlunparse
 
-from grizzly.events import GrizzlyEventHandler
+from grizzly.events import GrizzlyEventHandlerClass
 from grizzly.utils import normalize
 from grizzly_extras.transformer import JsonBytesEncoder
 
@@ -38,7 +38,7 @@ payload:
 """  # noqa: E501
 
 
-class RequestLogger(GrizzlyEventHandler):
+class RequestLogger(GrizzlyEventHandlerClass):
     _context: dict[str, Any]
 
     log_dir: Path

--- a/grizzly/events/response_handler.py
+++ b/grizzly/events/response_handler.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Optional
 from locust.exception import ResponseError
 
 from grizzly.context import GrizzlyContext
-from grizzly.events import GrizzlyEventHandler
+from grizzly.events import GrizzlyEventHandlerClass
 from grizzly.exceptions import ResponseHandlerError
 from grizzly_extras.transformer import PlainTransformer, TransformerContentType, TransformerError, transformer
 
@@ -168,7 +168,7 @@ class SaveHandlerAction(ResponseHandlerAction):
             raise ResponseHandlerError(message)
 
 
-class ResponseHandler(GrizzlyEventHandler):
+class ResponseHandler(GrizzlyEventHandlerClass):
     def __call__(
         self,
         name: str,

--- a/grizzly/events/response_handler.py
+++ b/grizzly/events/response_handler.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from locust.exception import ResponseError
 
-from grizzly.context import GrizzlyContext
 from grizzly.events import GrizzlyEventHandlerClass
 from grizzly.exceptions import ResponseHandlerError
 from grizzly_extras.transformer import PlainTransformer, TransformerContentType, TransformerError, transformer
@@ -19,8 +18,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from grizzly.users import GrizzlyUser
 
 class ResponseHandlerAction(ABC):
-    grizzly = GrizzlyContext()
-
     def __init__(self, /, expression: str, match_with: str, expected_matches: str = '1', *, as_json: bool = False) -> None:
         self.expression = expression
         self.match_with = match_with

--- a/grizzly/listeners/__init__.py
+++ b/grizzly/listeners/__init__.py
@@ -136,7 +136,7 @@ def spawning_complete(grizzly: GrizzlyContext) -> Callable[..., None]:
 
 
 def worker_report(client_id: str, data: dict[str, Any]) -> None:  # noqa: ARG001
-    logger.info('received worker_report from %s', client_id)
+    logger.debug('received worker_report from %s', client_id)
 
 
 def quitting(**_kwargs: Any) -> None:

--- a/grizzly/scenarios/__init__.py
+++ b/grizzly/scenarios/__init__.py
@@ -77,6 +77,7 @@ class GrizzlyScenario(SequentialTaskSet):
                 scenario=self,
                 address=producer_address,
             )
+            self.user.consumer = self.consumer
             self.user.scenario_state = ScenarioState.RUNNING
         else:
             self.logger.error('no address to testdata producer specified')

--- a/grizzly/scenarios/iterator.py
+++ b/grizzly/scenarios/iterator.py
@@ -249,7 +249,7 @@ class IteratorScenario(GrizzlyScenario):
         # scenario timer
         self.start = perf_counter()
 
-        remote_context = self.consumer.testdata(self.user._scenario.class_name)
+        remote_context = self.consumer.testdata()
 
         if remote_context is None:
             self.logger.debug('no iteration data available, stop scenario')

--- a/grizzly/steps/_helpers.py
+++ b/grizzly/steps/_helpers.py
@@ -41,8 +41,6 @@ def create_request_task(
     if source is not None:
         original_source = source
 
-        print(f'{source=}')
-
         try:
             possible_file = path / source
             if possible_file.is_file():

--- a/grizzly/tasks/clients/__init__.py
+++ b/grizzly/tasks/clients/__init__.py
@@ -306,7 +306,6 @@ class ClientTask(GrizzlyMetaRequestTask):
                 raise StopUser
 
             if exception is not None and parent.user._scenario.failure_exception is not None:
-                parent.logger.error('%s raising %s', self.__class__.__name__, parent.user._scenario.failure_exception)
                 raise parent.user._scenario.failure_exception
             elif exception is not None:
                 parent.logger.warning('%s ignoring %s', self.__class__.__name__, exception)

--- a/grizzly/tasks/request.py
+++ b/grizzly/tasks/request.py
@@ -35,7 +35,8 @@ Executions of this task will be visible in `locust` request statistics with requ
 
 ### `endpoint`
 
-All arguments will be removed from `endpoint` before creating the task instance.
+All pipe arguments will be removed from `endpoint` before creating the task instance. Depending on the {@pylink grizzly.users}, other
+pipe arguments might be supported.
 
 ```plain
 <endpoint> [| content_type=<content_type>]

--- a/grizzly/tasks/wait_explicit.py
+++ b/grizzly/tasks/wait_explicit.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any
 from gevent import sleep as gsleep
 
 from grizzly.exceptions import StopUser
+from grizzly.utils import has_template
 
 from . import GrizzlyTask, grizzlytask, template
 
@@ -37,7 +38,7 @@ class ExplicitWaitTask(GrizzlyTask):
         def task(parent: GrizzlyScenario) -> Any:
             try:
                 time_rendered = parent.user.render(self.time_expression)
-                if len(time_rendered.strip()) < 1:
+                if len(time_rendered.strip()) < 1 or has_template(time_rendered):
                     message = f'"{self.time_expression}" rendered into "{time_rendered}" which is not valid'
                     raise RuntimeError(message)
 

--- a/grizzly/testdata/ast.py
+++ b/grizzly/testdata/ast.py
@@ -119,6 +119,10 @@ def get_template_variables(grizzly: GrizzlyContext) -> dict[GrizzlyContextScenar
 
     We must then align the declared and found variables, so that `TestdataProducer` only gets variables that actually has been declared.
 
+    Also there are support for "internal" variables, which can be implementation specific that we should ignore here. These variables have dunder names, e.g.
+    a prefix and suffix being double underscore (`__`), and example is `__message__.id`, these templates will be left as-is, and needs to be rendered just in
+    time before they are used.
+
     """
     templates: dict[GrizzlyContextScenario, set[str]] = {}
 
@@ -365,7 +369,7 @@ def _parse_templates(templates: dict[GrizzlyContextScenario, set[str]]) -> AstVa
             for body in getattr(parsed, 'body', []):
                 for attributes in _getattr(body):
                     variable = _build_variable(attributes)
-                    if variable is None:
+                    if variable is None or (len(variable) > 4 and variable[:2] == '__' and variable[-2:] == '__'):
                         continue
 
                     variables.register(scenario, variable)

--- a/grizzly/testdata/ast.py
+++ b/grizzly/testdata/ast.py
@@ -369,7 +369,14 @@ def _parse_templates(templates: dict[GrizzlyContextScenario, set[str]]) -> AstVa
             for body in getattr(parsed, 'body', []):
                 for attributes in _getattr(body):
                     variable = _build_variable(attributes)
-                    if variable is None or (len(variable) > 4 and variable[:2] == '__' and variable[-2:] == '__'):
+                    if (
+                        variable is None
+                        or (  # check if variable is has a dunder name, and ignore it (internal variable)
+                            len(variable) > 4
+                            and variable.startswith('__')
+                            and variable.index('__') != variable.rindex('__')
+                        )
+                    ):
                         continue
 
                     variables.register(scenario, variable)

--- a/grizzly/users/__init__.py
+++ b/grizzly/users/__init__.py
@@ -42,6 +42,7 @@ T = TypeVar('T', bound=UserMeta)
 if TYPE_CHECKING:  # pragma: no cover
     from grizzly.context import GrizzlyContextScenario
     from grizzly.tasks import RequestTask
+    from grizzly.testdata.communication import TestdataConsumer
 
 class AsyncRequests(metaclass=ABCMeta):
     @abstractmethod
@@ -90,6 +91,7 @@ class GrizzlyUser(User, metaclass=GrizzlyUserMeta):
     grizzly = GrizzlyContext()
     sticky_tag: Optional[str] = None
     variables: GrizzlyVariables
+    consumer: TestdataConsumer
 
     def __init__(self, environment: Environment, *args: Any, **kwargs: Any) -> None:
         super().__init__(environment, *args, **kwargs)

--- a/grizzly/users/dummy.py
+++ b/grizzly/users/dummy.py
@@ -1,6 +1,4 @@
-"""Does nothing.
-
-Can be used with any tasks except {@pylink grizzly.tasks.request}.
+"""Does nothing (noop).
 
 ## Format
 

--- a/grizzly/users/iothub.py
+++ b/grizzly/users/iothub.py
@@ -171,7 +171,7 @@ class IotHubUser(GrizzlyUser):
 
         if self._startup_ignore:
             self._startup_ignore_count += 1
-            self.logger.info('ignoring message: %s', serialized_message)  # @TODO: debug
+            self.logger.debug('ignoring message: %s', serialized_message)
             return
 
         if any(expression is not None for expression in [self._expression_unique, self._expression_metadata, self._expression_payload]):
@@ -181,32 +181,32 @@ class IotHubUser(GrizzlyUser):
                 values = self._extract(metadata, self._expression_metadata)
 
                 if len(values) < 1:
-                    self.logger.info('message id %s metadata did not match "%s"', message.message_id, self._expression_metadata)  # @TODO: debug
+                    self.logger.debug('message id %s metadata did not match "%s"', message.message_id, self._expression_metadata)
                     return
 
             if self._expression_payload is not None:
                 values = self._extract(payload, self._expression_payload)
 
                 if len(values) < 1:
-                    self.logger.info('message id %s payload did not match "%s"', message.message_id, self._expression_payload)  # @TODO: debug
+                    self.logger.debug('message id %s payload did not match "%s"', message.message_id, self._expression_payload)
                     return
 
             if self._expression_unique is not None:
                 values = self._extract(payload, self._expression_unique)
 
                 if len(values) < 1:
-                    self.logger.info('message id %s was an unknown message, no matches for "%s"', message.message_id, self._expression_unique)  # @TODO: debug
+                    self.logger.debug('message id %s was an unknown message, no matches for "%s"', message.message_id, self._expression_unique)
                     return
 
                 value = next(iter(values))
 
                 if value in self._unique:
-                    self.logger.info('message id %s contained "%s", which has already been received within %d seconds', message.message_id, value, self._unique.timeout)
+                    self.logger.warning('message id %s contained "%s", which has already been received within %d seconds', message.message_id, value, self._unique.timeout)
                     return
 
                 self._unique.append(value)
 
-        self.logger.info('C2D message received: %s', serialized_message)  # @TODO: debug
+        self.logger.debug('C2D message received: %s', serialized_message)
         self.consumer.keystore_push(f'cloud-to-device::{self.device_id}', serialized_message)
 
     def on_start(self) -> None:
@@ -258,7 +258,7 @@ class IotHubUser(GrizzlyUser):
 
         self.iot_client.send_message(message)
 
-        self.logger.info('sent D2C message %s', str(message.message_id))  # @TODO: debug
+        self.logger.debug('sent D2C message %s', str(message.message_id))
 
         return self._unserialize_message(self._serialize_message(message))
 

--- a/grizzly/users/iothub.py
+++ b/grizzly/users/iothub.py
@@ -176,10 +176,6 @@ class IotHubUser(GrizzlyUser):
                     error_message = f'could not find a transformer for {request.response.content_type.name}'
                     raise TypeError(error_message)
 
-                if not transform.validate(payload_expression):
-                    error_message = f'"{payload_expression}" is not a valid expression for {request.response.content_type.name}'
-                    raise TypeError(error_message)
-
                 get_values = transform.parser(payload_expression)
                 values = get_values(transform.transform(payload))
 
@@ -196,10 +192,6 @@ class IotHubUser(GrizzlyUser):
 
                 if transform is None:
                     error_message = 'could not find a transformer for JSON'
-                    raise TypeError(error_message)
-
-                if not transform.validate(metadata_expression):
-                    error_message = f'"{metadata_expression}" is not a valid expression for JSON'
                     raise TypeError(error_message)
 
                 get_values = transform.parser(metadata_expression)

--- a/grizzly/users/iothub.py
+++ b/grizzly/users/iothub.py
@@ -46,7 +46,7 @@ from __future__ import annotations
 
 import gzip
 import json
-from typing import TYPE_CHECKING, Any, ClassVar, cast
+from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import parse_qs, urlparse
 from uuid import UUID, uuid4
 

--- a/grizzly_extras/novella.py
+++ b/grizzly_extras/novella.py
@@ -489,12 +489,15 @@ class GrizzlyMarkdown:
             indent = '    ' if style == 'indent' else ''
             code_lines = [f'{indent}{line}' for line in node.raw.splitlines()]
             marker = code_lines[-1].strip()[-3:]
+
             if code_lines[-1].strip() != marker:
                 raw = '\n'.join(code_lines[1:])
                 raw = raw[:-3]
             else:
                 raw = '\n'.join(code_lines[1:-1])
+
             _, info = code_lines[0].split(marker, 1)
+
             node.ast = {
                 'type': 'block_code',
                 'raw': raw,

--- a/grizzly_extras/queue.py
+++ b/grizzly_extras/queue.py
@@ -1,0 +1,97 @@
+"""Custom queue implementations."""
+from __future__ import annotations
+
+from collections import deque
+from contextlib import suppress
+from time import perf_counter
+from typing import TYPE_CHECKING, Callable, TypeVar
+from unittest.mock import ANY
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+T = TypeVar('T')
+
+
+class VolatileDeque(deque[T]):
+    timeout: float
+    queue: deque[tuple[float, T]]
+
+    def __init__(self, /, timeout: float) -> None:
+        self.timeout = timeout
+        self.queue = deque()
+
+    def __expire(self) -> None:
+        now = perf_counter()
+        for timestamp, _value in list(self.queue):
+            if now - timestamp < self.timeout:
+                continue
+
+            with suppress(Exception):
+                self.queue.remove((timestamp, _value))
+
+    def __repr__(self) -> str:
+        return repr(self.queue)
+
+    def __contains__(self, value: object) -> bool:
+        # first remove values that has timed out
+        self.__expire()
+
+        try:
+            _ = self.queue.index((ANY, value))  # type: ignore[arg-type]
+        except ValueError:
+            return False
+        else:
+            return True
+
+    def __len__(self) -> int:
+        return len(self.queue)
+
+    def __append(self, value: T, func: Callable[[tuple[float, T]], None]) -> None:
+        timestamp = perf_counter()
+
+        func((timestamp, value))
+
+    def append(self, value: T, /) -> None:
+        self.__append(value, self.queue.append)
+
+    def appendleft(self, value: T, /) -> None:
+        self.__append(value, self.queue.appendleft)
+
+    def __extend(self, iterable: Iterable[T], func: Callable[[Iterable[tuple[float, T]]], None]) -> None:
+        timestamp = perf_counter()
+        volatile_iterable: Iterable[tuple[float, T]] = iter([(timestamp, value) for value in iterable])
+
+        func(volatile_iterable)
+
+    def extend(self, iterable: Iterable[T], /) -> None:
+        self.__extend(iterable, self.queue.extend)
+
+    def extendleft(self, iterable: Iterable[T], /) -> None:
+        self.__extend(iterable, self.queue.extendleft)
+
+    def insert(self, index: int, value: T, /) -> None:
+        timestamp = perf_counter()
+        self.queue.insert(index, (timestamp, value))
+
+    def index(self, item: T, start: int = 0, *args: int) -> int:
+        return self.queue.index((ANY, item), start, *args)
+
+    def __pop(self, func: Callable[[], tuple[float, T]]) -> T:
+        value: T | None = None
+
+        while value is None:
+            timestamp, value = func()
+            if perf_counter() - timestamp >= self.timeout:
+                value = None
+
+        return value
+
+    def pop(self) -> T:  # type: ignore[override]
+        return self.__pop(self.queue.pop)
+
+    def popleft(self) -> T:
+        return self.__pop(self.queue.popleft)
+
+    def remove(self, value: T) -> None:
+        self.queue.remove((ANY, value))

--- a/grizzly_extras/text.py
+++ b/grizzly_extras/text.py
@@ -4,8 +4,14 @@ Utilities related to handling text.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from contextlib import suppress
 from enum import Enum, EnumMeta
+from json import JSONDecodeError
+from json import loads as jsonloads
 from typing import Any, Callable, Optional
+
+from dateutil.parser import ParserError
+from dateutil.parser import parse as date_parse
 
 
 class permutation:
@@ -164,3 +170,14 @@ def has_separator(separator: str, value: str) -> bool:
         return value[left_index + 1] not in operators
     except IndexError:
         return separator in value
+
+
+def caster(value: Any) -> Any:
+    with suppress(JSONDecodeError):
+        value = jsonloads(value)
+
+    if isinstance(value, str):
+        with suppress(ParserError):
+            value = date_parse(value)
+
+    return value

--- a/grizzly_extras/transformer.py
+++ b/grizzly_extras/transformer.py
@@ -33,6 +33,7 @@ class TransformerContentType(PermutationEnum):
     XML = 'application/xml'
     PLAIN = 'text/plain'
     MULTIPART_FORM_DATA = 'multipart/form-data'
+    OCTET_STREAM_UTF8 = 'application/octet-stream; charset=utf-8'
 
     @classmethod
     def from_string(cls, value: str) -> TransformerContentType:

--- a/grizzly_extras/transformer.py
+++ b/grizzly_extras/transformer.py
@@ -150,7 +150,7 @@ class JsonTransformer(Transformer):
                     expected = expected_value
 
             if not cls.validate(expression):
-                message = 'not a valid expression'
+                message = f'"{expression}" is not a valid expression'
                 raise RuntimeError(message)
 
             jsonpath = jsonpath_parse(expression)

--- a/grizzly_extras/transformer.py
+++ b/grizzly_extras/transformer.py
@@ -150,7 +150,7 @@ class JsonTransformer(Transformer):
                     expected = expected_value
 
             if not cls.validate(expression):
-                message = f'"{expression}" is not a valid expression'
+                message = 'not a valid expression'
                 raise RuntimeError(message)
 
             jsonpath = jsonpath_parse(expression)

--- a/tests/e2e/test_keystore.py
+++ b/tests/e2e/test_keystore.py
@@ -68,14 +68,14 @@ def test_e2e_keystore(e2e_fixture: End2EndFixture) -> None:
     assert "key_holder_2=hello, key_holder_3={'hello': 'world'}" in result
     assert "foobar_push: 10, 20, 30" in result
     assert (
-        result.index("producing {'action': 'push', 'key': 'foobar::push', 'data': 10, 'message': 'keystore', 'identifier': 'IteratorScenario_001'}")
-        < result.index("producing {'action': 'push', 'key': 'foobar::push', 'data': 20, 'message': 'keystore', 'identifier': 'IteratorScenario_001'}")
+        result.index("producing {'message': 'keystore', 'action': 'push', 'key': 'foobar::push', 'data': 10, 'identifier': 'IteratorScenario_001'}")
+        < result.index("producing {'message': 'keystore', 'action': 'push', 'key': 'foobar::push', 'data': 20, 'identifier': 'IteratorScenario_001'}")
     )
     assert (
-        result.index("producing {'action': 'push', 'key': 'foobar::push', 'data': 20, 'message': 'keystore', 'identifier': 'IteratorScenario_001'}")
-        < result.index("producing {'action': 'push', 'key': 'foobar::push', 'data': 30, 'message': 'keystore', 'identifier': 'IteratorScenario_001'}")
+        result.index("producing {'message': 'keystore', 'action': 'push', 'key': 'foobar::push', 'data': 20, 'identifier': 'IteratorScenario_001'}")
+        < result.index("producing {'message': 'keystore', 'action': 'push', 'key': 'foobar::push', 'data': 30, 'identifier': 'IteratorScenario_001'}")
     )
     assert (
-        result.index("producing {'action': 'push', 'key': 'foobar::push', 'data': 30, 'message': 'keystore', 'identifier': 'IteratorScenario_001'}")
-        < result.index("producing {'action': 'pop', 'key': 'foobar::push', 'message': 'keystore', 'identifier': 'IteratorScenario_002', 'data': 10}")
+        result.index("producing {'message': 'keystore', 'action': 'push', 'key': 'foobar::push', 'data': 30, 'identifier': 'IteratorScenario_001'}")
+        < result.index("producing {'message': 'keystore', 'action': 'pop', 'key': 'foobar::push', 'identifier': 'IteratorScenario_002', 'data': 10}")
     )

--- a/tests/unit/test_grizzly/events/test_request_logger.py
+++ b/tests/unit/test_grizzly/events/test_request_logger.py
@@ -8,9 +8,10 @@ from typing import TYPE_CHECKING, Callable
 
 import pytest
 
-from grizzly.events import RequestLogger
+from grizzly.events import GrizzlyEventHandlerClass, RequestLogger
 from grizzly.tasks import RequestTask
 from grizzly.types import RequestMethod
+from grizzly.users import GrizzlyUser
 from tests.helpers import rm_rf
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -43,8 +44,14 @@ class TestRequestLogger:
             assert not log_root.exists()
             parent = grizzly_fixture()
 
-            assert len(parent.user.event_hook._handlers) == 2
-            assert any(h.__class__ is RequestLogger and h.user is parent.user for h in parent.user.event_hook._handlers)
+            assert len(parent.user.events.request._handlers) == 2
+            assert any(
+                h.__class__ is RequestLogger
+                and isinstance(h, GrizzlyEventHandlerClass)
+                and isinstance(h.user, GrizzlyUser)
+                and h.user is parent.user
+                for h in parent.user.events.request._handlers
+            )
         finally:
             with suppress(KeyError):
                 del environ['GRIZZLY_LOG_DIR']

--- a/tests/unit/test_grizzly/scenarios/test_iterator.py
+++ b/tests/unit/test_grizzly/scenarios/test_iterator.py
@@ -95,7 +95,7 @@ class TestIterationScenario:
 
         assert logger_spy.call_count == 1
         args, _ = logger_spy.call_args_list[0]
-        assert args[0] == 'hello '
+        assert args[0] == 'hello {{ world }}'
 
         parent.user.set_variable('world', 'world!')
 

--- a/tests/unit/test_grizzly/scenarios/test_iterator.py
+++ b/tests/unit/test_grizzly/scenarios/test_iterator.py
@@ -168,7 +168,7 @@ class TestIterationScenario:
         parent.consumer = TestdataConsumer(parent)
 
         def mock_request(data: Optional[dict[str, Any]]) -> None:
-            def testdata_request(self: TestdataConsumer, scenario: str) -> Optional[dict[str, Any]]:  # noqa: ARG001
+            def testdata_request(self: TestdataConsumer) -> Optional[dict[str, Any]]:  # noqa: ARG001
                 if data is None or data == {}:
                     return None
 

--- a/tests/unit/test_grizzly/tasks/test_wait_explicit.py
+++ b/tests/unit/test_grizzly/tasks/test_wait_explicit.py
@@ -96,5 +96,5 @@ class TestExplicitWaitTask:
             response_time=0,
             response_length=0,
             context=parent.user._context,
-            exception=ANY(RuntimeError, message='"{{ undefined_variable }}" rendered into "" which is not valid'),
+            exception=ANY(RuntimeError, message='"{{ undefined_variable }}" rendered into "{{ undefined_variable }}" which is not valid'),
         )

--- a/tests/unit/test_grizzly/test_context.py
+++ b/tests/unit/test_grizzly/test_context.py
@@ -285,6 +285,7 @@ class TestGrizzlyContext:
             'state',
             'scenario',
             'scenarios',
+            'events',
         ]
         expected_attributes.sort()
 

--- a/tests/unit/test_grizzly/testdata/test_ast.py
+++ b/tests/unit/test_grizzly/testdata/test_ast.py
@@ -358,7 +358,7 @@ def test_get_template_variables(behave_fixture: BehaveFixture, caplog: LogCaptur
     task.source = '{{ AtomicRandomString.test[:2] }}{{ integer | string}}'
 
     grizzly.scenario.tasks.add(
-        RequestTask(RequestMethod.GET, name='{{ env }} GET request', endpoint='/api/{{ env }}/get'),
+        RequestTask(RequestMethod.GET, name='{{ env }} GET request', endpoint='/api/{{ env }}/get/{{ __internal_id__ }}'),
     )
     task = cast(RequestTask, grizzly.scenario.tasks()[-1])
     task.source = '{{ AtomicIntegerIncrementer.test }} {%- set hello = world -%}'

--- a/tests/unit/test_grizzly/testdata/test_ast.py
+++ b/tests/unit/test_grizzly/testdata/test_ast.py
@@ -358,7 +358,7 @@ def test_get_template_variables(behave_fixture: BehaveFixture, caplog: LogCaptur
     task.source = '{{ AtomicRandomString.test[:2] }}{{ integer | string}}'
 
     grizzly.scenario.tasks.add(
-        RequestTask(RequestMethod.GET, name='{{ env }} GET request', endpoint='/api/{{ env }}/get/{{ __internal_id__ }}'),
+        RequestTask(RequestMethod.GET, name='{{ env }} GET request', endpoint='/api/{{ env }}/get/{{ __internal__.id }}/{{ __external_id__ }}'),
     )
     task = cast(RequestTask, grizzly.scenario.tasks()[-1])
     task.source = '{{ AtomicIntegerIncrementer.test }} {%- set hello = world -%}'

--- a/tests/unit/test_grizzly/testdata/test_communication.py
+++ b/tests/unit/test_grizzly/testdata/test_communication.py
@@ -30,16 +30,14 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 def echo(value: dict[str, Any]) -> dict[str, Any]:
-    return value
+    return {'data': None, **value}
 
 def echo_add_data(return_value: Any | list[Any]) -> Callable[[dict[str, Any]], dict[str, Any]]:
     if not isinstance(return_value, list):
         return_value = [return_value]
 
     def wrapped(request: dict[str, Any]) -> dict[str, Any]:
-        response = request.copy()
-        response.update({'data': return_value.pop(0)})
-        return response
+        return {'data': return_value.pop(0), **request}
 
     return wrapped
 
@@ -50,6 +48,7 @@ class TestTestdataProducer:
         grizzly_fixture: GrizzlyFixture,
         cleanup: AtomicVariableCleanupFixture,
         caplog: LogCaptureFixture,
+        mocker: MockerFixture,
     ) -> None:
         producer: Optional[TestdataProducer] = None
         context: Optional[zmq.Context] = None
@@ -95,6 +94,10 @@ value3,value4
             })
 
             grizzly = grizzly_fixture.grizzly
+
+            testdata_request_spy = mocker.spy(grizzly.events.testdata_request, 'fire')
+            keystore_request_spy = mocker.spy(grizzly.events.keystore_request, 'fire')
+
             grizzly.scenarios.clear()
             grizzly.scenarios.create(grizzly_fixture.behave.create_scenario(parent.__class__.__name__))
             grizzly.scenario.orphan_templates.append('{{ AtomicCsvWriter.output }}')
@@ -147,7 +150,7 @@ value3,value4
                 def request_testdata() -> dict[str, Any]:
                     socket.send_json({
                         'message': 'testdata',
-                        'scenario': grizzly.scenario.class_name,
+                        'identifier': grizzly.scenario.class_name,
                     })
 
                     gevent.sleep(0.1)
@@ -157,6 +160,7 @@ value3,value4
                 def request_keystore(action: str, key: str, value: Optional[Any] = None) -> dict[str, Any]:
                     request = {
                         'message': 'keystore',
+                        'identifier': grizzly.scenario.class_name,
                         'action': action,
                         'key': key,
                     }
@@ -171,6 +175,25 @@ value3,value4
                     return cast(dict[str, Any], socket.recv_json())
 
                 message: dict[str, Any] = request_testdata()
+                testdata_request_spy.assert_called_once_with(
+                    reverse=False,
+                    timestamp=ANY(str),
+                    response_time=ANY(float),
+                    return_value={
+                        'action': 'consume',
+                        'data': ANY(dict),
+                    },
+                    tags={'type': 'producer'},
+                    measurement=None,
+                    kwargs={
+                        'request': {
+                            'message': 'testdata',
+                            'identifier': grizzly.scenario.class_name,
+                        },
+                    },
+                )
+                testdata_request_spy.reset_mock()
+                keystore_request_spy.assert_not_called()
                 assert message['action'] == 'consume'
                 data = message['data']
                 assert 'variables' in data
@@ -198,9 +221,34 @@ value3,value4
                 assert producer.keystore == {}
 
                 message = request_keystore('set', 'foobar', {'hello': 'world'})
+                testdata_request_spy.assert_not_called()
+                keystore_request_spy.assert_called_once_with(
+                    reverse=False,
+                    timestamp=ANY(str),
+                    response_time=ANY(float),
+                    return_value={
+                        'message': 'keystore',
+                        'identifier': grizzly.scenario.class_name,
+                        'action': 'set',
+                        'key': 'foobar',
+                        'data': {'hello': 'world'},
+                    },
+                    tags={'type': 'producer'},
+                    measurement=None,
+                    kwargs={
+                        'request': {
+                            'message': 'keystore',
+                            'identifier': grizzly.scenario.class_name,
+                            'action': 'set',
+                            'key': 'foobar',
+                            'data': {'hello': 'world'},
+                        },
+                    },
+                )
                 assert message == {
                     'message': 'keystore',
                     'action': 'set',
+                    'identifier': grizzly.scenario.class_name,
                     'key': 'foobar',
                     'data': {'hello': 'world'},
                 }
@@ -229,6 +277,7 @@ value3,value4
                 assert message == {
                     'message': 'keystore',
                     'action': 'get',
+                    'identifier': grizzly.scenario.class_name,
                     'key': 'foobar',
                     'data': {'hello': 'world'},
                 }
@@ -240,6 +289,7 @@ value3,value4
                     assert message == {
                         'message': 'keystore',
                         'action': 'inc',
+                        'identifier': grizzly.scenario.class_name,
                         'key': 'counter',
                         'data': 1,
                     }
@@ -254,6 +304,7 @@ value3,value4
                     assert message == {
                         'message': 'keystore',
                         'action': 'inc',
+                        'identifier': grizzly.scenario.class_name,
                         'key': 'counter',
                         'data': None,
                         'error': 'value asdf for key "counter" cannot be incremented',
@@ -269,6 +320,7 @@ value3,value4
                     assert message == {
                         'message': 'keystore',
                         'action': 'inc',
+                        'identifier': grizzly.scenario.class_name,
                         'key': 'counter',
                         'data': 2,
                     }
@@ -280,6 +332,7 @@ value3,value4
                     assert message == {
                         'message': 'keystore',
                         'action': 'inc',
+                        'identifier': grizzly.scenario.class_name,
                         'key': 'counter',
                         'data': 12,
                     }
@@ -835,6 +888,8 @@ class TestTestdataConsumer:
         parent = grizzly_fixture()
         grizzly = grizzly_fixture.grizzly
 
+        testdata_request_spy = mocker.spy(grizzly.events.testdata_request, 'fire')
+
         consumer = TestdataConsumer(parent)
 
         try:
@@ -849,7 +904,7 @@ class TestTestdataConsumer:
                 },
             })
 
-            assert consumer.testdata('test') == {
+            assert consumer.testdata() == {
                 'auth': {
                     'user': {
                         'username': 'username',
@@ -862,6 +917,24 @@ class TestTestdataConsumer:
                 }),
             }
 
+            testdata_request_spy.assert_called_once_with(
+                reverse=False,
+                timestamp=ANY(str),
+                response_time=ANY(float),
+                return_value={
+                    'action': 'consume',
+                    'data': ANY(dict),
+                },
+                tags={'type': 'consumer'},
+                measurement=None,
+                kwargs={
+                    'request': {
+                        'identifier': consumer.identifier,
+                    },
+                },
+            )
+            testdata_request_spy.reset_mock()
+
             mock_recv_json({
                 'variables': {
                     'AtomicIntegerIncrementer.messageID': 100,
@@ -870,7 +943,7 @@ class TestTestdataConsumer:
             }, 'stop')
 
             with caplog.at_level(logging.DEBUG):
-                assert consumer.testdata('test') is None
+                assert consumer.testdata() is None
             assert caplog.messages[-1] == 'received stop command'
 
             caplog.clear()
@@ -883,7 +956,7 @@ class TestTestdataConsumer:
             }, 'asdf')
 
             with caplog.at_level(logging.DEBUG), pytest.raises(StopUser):
-                consumer.testdata('test')
+                consumer.testdata()
             assert 'unknown action "asdf" received, stopping user' in caplog.text
 
             caplog.clear()
@@ -895,7 +968,7 @@ class TestTestdataConsumer:
                 },
             }, 'consume')
 
-            assert consumer.testdata('test') == {
+            assert consumer.testdata() == {
                 'variables': transform(grizzly.scenario, {
                     'AtomicIntegerIncrementer.messageID': 100,
                     'test': None,
@@ -948,26 +1021,51 @@ class TestTestdataConsumer:
         consumer = TestdataConsumer(parent)
 
         with pytest.raises(ZMQAgain):
-            consumer.testdata('test')
+            consumer.testdata()
 
         gsleep_mock.assert_called_once_with(0.1)
 
         mocker.patch.object(consumer, '_request', return_value=None)
 
         with caplog.at_level(logging.ERROR):
-            assert consumer.testdata('test') is None
+            assert consumer.testdata() is None
 
         assert caplog.messages == ['no testdata received']
 
     def test_keystore_get(self, mocker: MockerFixture, noop_zmq: NoopZmqFixture, grizzly_fixture: GrizzlyFixture) -> None:
         noop_zmq('grizzly.testdata.communication')
         parent = grizzly_fixture()
+        grizzly = grizzly_fixture.grizzly
 
         consumer = TestdataConsumer(parent)
+
+        keystore_request_spy = mocker.spy(grizzly.events.keystore_request, 'fire')
 
         request_spy = mocker.patch.object(consumer, '_request', side_effect=echo)
 
         assert consumer.keystore_get('hello') is None
+        keystore_request_spy.assert_called_once_with(
+            reverse=False,
+            timestamp=ANY(str),
+            response_time=ANY(float),
+            return_value={
+                'action': 'get',
+                'key': 'hello',
+                'message': 'keystore',
+                'identifier': consumer.identifier,
+                'data': None,
+            },
+            tags={'type': 'consumer'},
+            measurement=None,
+            kwargs={
+                'request': {
+                    'action': 'get',
+                    'key': 'hello',
+                    'identifier': consumer.identifier,
+                },
+            },
+        )
+        keystore_request_spy.reset_mock()
 
         request_spy.assert_called_once_with({
             'action': 'get',
@@ -989,28 +1087,55 @@ class TestTestdataConsumer:
     def test_keystore_set(self, mocker: MockerFixture, noop_zmq: NoopZmqFixture, grizzly_fixture: GrizzlyFixture) -> None:
         noop_zmq('grizzly.testdata.communication')
         parent = grizzly_fixture()
+        grizzly = grizzly_fixture.grizzly
 
         consumer = TestdataConsumer(parent)
 
         request_spy = mocker.patch.object(consumer, '_request', side_effect=echo)
+        keystore_request_spy = mocker.spy(grizzly.events.keystore_request, 'fire')
 
         consumer.keystore_set('world', {'hello': 'world'})
 
         request_spy.assert_called_once_with({
+            'message': 'keystore',
             'action': 'set',
             'key': 'world',
-            'message': 'keystore',
             'identifier': consumer.identifier,
             'data': {'hello': 'world'},
         })
+        keystore_request_spy.assert_called_once_with(
+            reverse=False,
+            timestamp=ANY(str),
+            response_time=ANY(float),
+            return_value={
+                'action': 'set',
+                'key': 'world',
+                'message': 'keystore',
+                'identifier': consumer.identifier,
+                'data': {'hello': 'world'},
+            },
+            tags={'type': 'consumer'},
+            measurement=None,
+            kwargs={
+                'request': {
+                    'action': 'set',
+                    'key': 'world',
+                    'identifier': consumer.identifier,
+                    'data': {'hello': 'world'},
+                },
+            },
+        )
+        keystore_request_spy.reset_mock()
 
     def test_keystore_inc(self, mocker: MockerFixture, noop_zmq: NoopZmqFixture, grizzly_fixture: GrizzlyFixture) -> None:
         noop_zmq('grizzly.testdata.communication')
         parent = grizzly_fixture()
+        grizzly = grizzly_fixture.grizzly
 
         consumer = TestdataConsumer(parent)
 
         request_spy = mocker.patch.object(consumer, '_request', side_effect=echo)
+        keystore_request_spy = mocker.spy(grizzly.events.keystore_request, 'fire')
 
         assert consumer.keystore_inc('counter') == 1
 
@@ -1022,6 +1147,7 @@ class TestTestdataConsumer:
             'data': 1,
         })
         request_spy.reset_mock()
+        keystore_request_spy.reset_mock()
 
         assert consumer.keystore_inc('counter', step=10) == 10
 
@@ -1032,14 +1158,39 @@ class TestTestdataConsumer:
             'identifier': consumer.identifier,
             'data': 10,
         })
+        keystore_request_spy.assert_called_once_with(
+            reverse=False,
+            timestamp=ANY(str),
+            response_time=ANY(float),
+            return_value={
+                'action': 'inc',
+                'key': 'counter',
+                'message': 'keystore',
+                'identifier': consumer.identifier,
+                'data': 10,
+            },
+            tags={'type': 'consumer'},
+            measurement=None,
+            kwargs={
+                'request': {
+                    'action': 'inc',
+                    'key': 'counter',
+                    'identifier': consumer.identifier,
+                    'data': 10,
+                },
+            },
+        )
+        keystore_request_spy.reset_mock()
 
     def test_keystore_push(self, mocker: MockerFixture, noop_zmq: NoopZmqFixture, grizzly_fixture: GrizzlyFixture) -> None:
         noop_zmq('grizzly.testdata.communication')
         parent = grizzly_fixture()
+        grizzly = grizzly_fixture.grizzly
 
         consumer = TestdataConsumer(parent)
 
         request_spy = mocker.patch.object(consumer, '_request', side_effect=echo)
+        keystore_request_spy = mocker.spy(grizzly.events.keystore_request, 'fire')
 
         consumer.keystore_push('foobar', 'hello')
 
@@ -1051,28 +1202,55 @@ class TestTestdataConsumer:
             'data': 'hello',
         })
         request_spy.reset_mock()
+        keystore_request_spy.assert_called_once_with(
+            reverse=False,
+            timestamp=ANY(str),
+            response_time=ANY(float),
+            return_value={
+                'action': 'push',
+                'key': 'foobar',
+                'message': 'keystore',
+                'identifier': consumer.identifier,
+                'data': 'hello',
+            },
+            tags={'type': 'consumer'},
+            measurement=None,
+            kwargs={
+                'request': {
+                    'action': 'push',
+                    'key': 'foobar',
+                    'identifier': consumer.identifier,
+                    'data': 'hello',
+                },
+            },
+        )
 
     def test_keystore_pop(self, mocker: MockerFixture, noop_zmq: NoopZmqFixture, grizzly_fixture: GrizzlyFixture) -> None:
         noop_zmq('grizzly.testdata.communication')
         parent = grizzly_fixture()
+        grizzly = grizzly_fixture.grizzly
 
         consumer = TestdataConsumer(parent)
 
         request_spy = mocker.patch.object(consumer, '_request', side_effect=echo_add_data([None, None, 'hello']))
         gsleep_mock = mocker.patch('grizzly.testdata.communication.gsleep', return_value=None)
+        keystore_request_spy = mocker.spy(grizzly.events.keystore_request, 'fire')
 
         assert consumer.keystore_pop('foobar') == 'hello'
 
         assert gsleep_mock.call_count == 2
         assert request_spy.call_count == 3
+        assert keystore_request_spy.call_count == 3
 
     def test_keystore_del(self, mocker: MockerFixture, noop_zmq: NoopZmqFixture, grizzly_fixture: GrizzlyFixture) -> None:
         noop_zmq('grizzly.testdata.communication')
         parent = grizzly_fixture()
+        grizzly = grizzly_fixture.grizzly
 
         consumer = TestdataConsumer(parent)
 
         request_spy = mocker.patch.object(consumer, '_request', side_effect=echo)
+        keystore_request_spy = mocker.spy(grizzly.events.keystore_request, 'fire')
 
         consumer.keystore_del('foobar')
 
@@ -1083,3 +1261,24 @@ class TestTestdataConsumer:
             'identifier': consumer.identifier,
         })
         request_spy.reset_mock()
+        keystore_request_spy.assert_called_once_with(
+            reverse=False,
+            timestamp=ANY(str),
+            response_time=ANY(float),
+            return_value={
+                'action': 'del',
+                'key': 'foobar',
+                'message': 'keystore',
+                'identifier': consumer.identifier,
+                'data': None,
+            },
+            tags={'type': 'consumer'},
+            measurement=None,
+            kwargs={
+                'request': {
+                    'action': 'del',
+                    'key': 'foobar',
+                    'identifier': consumer.identifier,
+                },
+            },
+        )

--- a/tests/unit/test_grizzly/testdata/test_communication.py
+++ b/tests/unit/test_grizzly/testdata/test_communication.py
@@ -178,18 +178,15 @@ value3,value4
                 testdata_request_spy.assert_called_once_with(
                     reverse=False,
                     timestamp=ANY(str),
-                    response_time=ANY(float),
-                    return_value={
+                    tags={
                         'action': 'consume',
-                        'data': ANY(dict),
+                        'type': 'producer',
+                        'identifier': grizzly.scenario.class_name,
                     },
-                    tags={'type': 'producer'},
                     measurement=None,
-                    kwargs={
-                        'request': {
-                            'message': 'testdata',
-                            'identifier': grizzly.scenario.class_name,
-                        },
+                    metrics={
+                        'response_time': ANY(float),
+                        'error': None,
                     },
                 )
                 testdata_request_spy.reset_mock()
@@ -225,24 +222,16 @@ value3,value4
                 keystore_request_spy.assert_called_once_with(
                     reverse=False,
                     timestamp=ANY(str),
-                    response_time=ANY(float),
-                    return_value={
-                        'message': 'keystore',
+                    tags={
                         'identifier': grizzly.scenario.class_name,
                         'action': 'set',
                         'key': 'foobar',
-                        'data': {'hello': 'world'},
+                        'type': 'producer',
                     },
-                    tags={'type': 'producer'},
                     measurement=None,
-                    kwargs={
-                        'request': {
-                            'message': 'keystore',
-                            'identifier': grizzly.scenario.class_name,
-                            'action': 'set',
-                            'key': 'foobar',
-                            'data': {'hello': 'world'},
-                        },
+                    metrics={
+                        'response_time': ANY(float),
+                        'error': None,
                     },
                 )
                 assert message == {
@@ -920,17 +909,15 @@ class TestTestdataConsumer:
             testdata_request_spy.assert_called_once_with(
                 reverse=False,
                 timestamp=ANY(str),
-                response_time=ANY(float),
-                return_value={
+                tags={
+                    'type': 'consumer',
                     'action': 'consume',
-                    'data': ANY(dict),
+                    'identifier': consumer.identifier,
                 },
-                tags={'type': 'consumer'},
                 measurement=None,
-                kwargs={
-                    'request': {
-                        'identifier': consumer.identifier,
-                    },
+                metrics={
+                    'error': None,
+                    'response_time': ANY(float),
                 },
             )
             testdata_request_spy.reset_mock()
@@ -1047,22 +1034,16 @@ class TestTestdataConsumer:
         keystore_request_spy.assert_called_once_with(
             reverse=False,
             timestamp=ANY(str),
-            response_time=ANY(float),
-            return_value={
+            tags={
                 'action': 'get',
                 'key': 'hello',
-                'message': 'keystore',
                 'identifier': consumer.identifier,
-                'data': None,
+                'type': 'consumer',
             },
-            tags={'type': 'consumer'},
             measurement=None,
-            kwargs={
-                'request': {
-                    'action': 'get',
-                    'key': 'hello',
-                    'identifier': consumer.identifier,
-                },
+            metrics={
+                'response_time': ANY(float),
+                'error': None,
             },
         )
         keystore_request_spy.reset_mock()
@@ -1106,23 +1087,16 @@ class TestTestdataConsumer:
         keystore_request_spy.assert_called_once_with(
             reverse=False,
             timestamp=ANY(str),
-            response_time=ANY(float),
-            return_value={
+            tags={
                 'action': 'set',
                 'key': 'world',
-                'message': 'keystore',
                 'identifier': consumer.identifier,
-                'data': {'hello': 'world'},
+                'type': 'consumer',
             },
-            tags={'type': 'consumer'},
             measurement=None,
-            kwargs={
-                'request': {
-                    'action': 'set',
-                    'key': 'world',
-                    'identifier': consumer.identifier,
-                    'data': {'hello': 'world'},
-                },
+            metrics={
+                'response_time': ANY(float),
+                'error': None,
             },
         )
         keystore_request_spy.reset_mock()
@@ -1161,23 +1135,16 @@ class TestTestdataConsumer:
         keystore_request_spy.assert_called_once_with(
             reverse=False,
             timestamp=ANY(str),
-            response_time=ANY(float),
-            return_value={
+            tags={
                 'action': 'inc',
                 'key': 'counter',
-                'message': 'keystore',
                 'identifier': consumer.identifier,
-                'data': 10,
+                'type': 'consumer',
             },
-            tags={'type': 'consumer'},
             measurement=None,
-            kwargs={
-                'request': {
-                    'action': 'inc',
-                    'key': 'counter',
-                    'identifier': consumer.identifier,
-                    'data': 10,
-                },
+            metrics={
+                'response_time': ANY(float),
+                'error': None,
             },
         )
         keystore_request_spy.reset_mock()
@@ -1205,23 +1172,16 @@ class TestTestdataConsumer:
         keystore_request_spy.assert_called_once_with(
             reverse=False,
             timestamp=ANY(str),
-            response_time=ANY(float),
-            return_value={
+            tags={
                 'action': 'push',
                 'key': 'foobar',
-                'message': 'keystore',
                 'identifier': consumer.identifier,
-                'data': 'hello',
+                'type': 'consumer',
             },
-            tags={'type': 'consumer'},
             measurement=None,
-            kwargs={
-                'request': {
-                    'action': 'push',
-                    'key': 'foobar',
-                    'identifier': consumer.identifier,
-                    'data': 'hello',
-                },
+            metrics={
+                'response_time': ANY(float),
+                'error': None,
             },
         )
 
@@ -1264,21 +1224,15 @@ class TestTestdataConsumer:
         keystore_request_spy.assert_called_once_with(
             reverse=False,
             timestamp=ANY(str),
-            response_time=ANY(float),
-            return_value={
+            tags={
                 'action': 'del',
                 'key': 'foobar',
-                'message': 'keystore',
                 'identifier': consumer.identifier,
-                'data': None,
+                'type': 'consumer',
             },
-            tags={'type': 'consumer'},
             measurement=None,
-            kwargs={
-                'request': {
-                    'action': 'del',
-                    'key': 'foobar',
-                    'identifier': consumer.identifier,
-                },
+            metrics={
+                'response_time': ANY(float),
+                'error': None,
             },
         )

--- a/tests/unit/test_grizzly/testdata/test_communication.py
+++ b/tests/unit/test_grizzly/testdata/test_communication.py
@@ -183,7 +183,7 @@ value3,value4
                         'type': 'producer',
                         'identifier': grizzly.scenario.class_name,
                     },
-                    measurement=None,
+                    measurement='request_testdata',
                     metrics={
                         'response_time': ANY(float),
                         'error': None,
@@ -228,7 +228,7 @@ value3,value4
                         'key': 'foobar',
                         'type': 'producer',
                     },
-                    measurement=None,
+                    measurement='request_keystore',
                     metrics={
                         'response_time': ANY(float),
                         'error': None,
@@ -914,7 +914,7 @@ class TestTestdataConsumer:
                     'action': 'consume',
                     'identifier': consumer.identifier,
                 },
-                measurement=None,
+                measurement='request_testdata',
                 metrics={
                     'error': None,
                     'response_time': ANY(float),
@@ -1040,7 +1040,7 @@ class TestTestdataConsumer:
                 'identifier': consumer.identifier,
                 'type': 'consumer',
             },
-            measurement=None,
+            measurement='request_keystore',
             metrics={
                 'response_time': ANY(float),
                 'error': None,
@@ -1093,7 +1093,7 @@ class TestTestdataConsumer:
                 'identifier': consumer.identifier,
                 'type': 'consumer',
             },
-            measurement=None,
+            measurement='request_keystore',
             metrics={
                 'response_time': ANY(float),
                 'error': None,
@@ -1141,7 +1141,7 @@ class TestTestdataConsumer:
                 'identifier': consumer.identifier,
                 'type': 'consumer',
             },
-            measurement=None,
+            measurement='request_keystore',
             metrics={
                 'response_time': ANY(float),
                 'error': None,
@@ -1178,7 +1178,7 @@ class TestTestdataConsumer:
                 'identifier': consumer.identifier,
                 'type': 'consumer',
             },
-            measurement=None,
+            measurement='request_keystore',
             metrics={
                 'response_time': ANY(float),
                 'error': None,
@@ -1230,7 +1230,7 @@ class TestTestdataConsumer:
                 'identifier': consumer.identifier,
                 'type': 'consumer',
             },
-            measurement=None,
+            measurement='request_keystore',
             metrics={
                 'response_time': ANY(float),
                 'error': None,

--- a/tests/unit/test_grizzly/users/test_iothub.py
+++ b/tests/unit/test_grizzly/users/test_iothub.py
@@ -146,14 +146,6 @@ class TestIotHubUser:
 
         assert test.host == CONNECTION_STRING
         assert test.device_id == 'my_device'
-        assert test._unique_expression is None
-
-        test_cls.host = f'{CONNECTION_STRING}#UniqueExpression=$.body.test'
-        test = test_cls(environment)
-
-        assert test.host == CONNECTION_STRING
-        assert test.device_id == 'my_device'
-        assert test._unique_expression == '$.body.test'
 
     def test_send(self, parent_fixture: ParentFixture) -> None:
         user = parent_fixture.user

--- a/tests/unit/test_grizzly/users/test_iothub.py
+++ b/tests/unit/test_grizzly/users/test_iothub.py
@@ -144,7 +144,16 @@ class TestIotHubUser:
         test_cls.host = CONNECTION_STRING
         test = test_cls(environment)
 
+        assert test.host == CONNECTION_STRING
         assert test.device_id == 'my_device'
+        assert test._unique_expression is None
+
+        test_cls.host = f'{CONNECTION_STRING}#UniqueExpression=$.body.test'
+        test = test_cls(environment)
+
+        assert test.host == CONNECTION_STRING
+        assert test.device_id == 'my_device'
+        assert test._unique_expression == '$.body.test'
 
     def test_send(self, parent_fixture: ParentFixture) -> None:
         user = parent_fixture.user

--- a/tests/unit/test_grizzly/users/test_iothub.py
+++ b/tests/unit/test_grizzly/users/test_iothub.py
@@ -2,7 +2,8 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any, cast
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, cast
 
 import pytest
 from azure.iot.device import IoTHubDeviceClient
@@ -12,13 +13,15 @@ from azure.storage.blob._models import ContentSettings
 from grizzly.context import GrizzlyContextScenario
 from grizzly.exceptions import RestartScenario
 from grizzly.tasks import RequestTask
+from grizzly.testdata.communication import TestdataConsumer
 from grizzly.testdata.utils import transform
 from grizzly.types import RequestMethod
-from grizzly.types.locust import Environment, StopUser
 from grizzly.users.iothub import IotHubUser
-from tests.helpers import ANY, SOME
+from tests.helpers import SOME
 
 if TYPE_CHECKING:  # pragma: no cover
+    from unittest.mock import MagicMock
+
     from pytest_mock import MockerFixture
 
     from grizzly.scenarios import GrizzlyScenario
@@ -26,37 +29,37 @@ if TYPE_CHECKING:  # pragma: no cover
 
 CONNECTION_STRING = 'HostName=some.hostname.nu;DeviceId=my_device;SharedAccessKey=xxxyyyzzz='
 
-IoTHubScenarioFixture = tuple[IotHubUser, GrizzlyContextScenario, Environment]
-
-
-class MockedIotHubDeviceClient(IoTHubDeviceClient):
-    def __init__(self, conn_str: str) -> None:
-        self.conn_str = conn_str
-
-    def get_storage_info_for_blob(self, _: Any) -> Any:
-        """Mock storage information for a blob."""
-        return {
-            'hostName': 'some_host',
-            'containerName': 'some_container',
-            'blobName': 'some_blob',
-            'sasToken': 'some_sas_token',
-            'correlationId': 'correlation_id',
-        }
-
+@dataclass
+class ParentFixture:
+    parent: GrizzlyScenario
+    user: IotHubUser
+    consumer_mock: MagicMock
+    iot_device_mock: MagicMock
+    blob_client_factory_mock: MagicMock
+    blob_client_mock: MagicMock
 
 @pytest.fixture()
-def iot_hub_parent(grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> GrizzlyScenario:
-    def mocked_create_from_connection_string(connection_string: Any, **_kwargs: Any) -> IoTHubDeviceClient:
-        return MockedIotHubDeviceClient(connection_string)
-
-    mocker.patch('azure.iot.device.IoTHubDeviceClient.create_from_connection_string', mocked_create_from_connection_string)
+def parent_fixture(grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> ParentFixture:
+    iot_hub_device_client_mock = mocker.MagicMock(spec=IoTHubDeviceClient)
+    mocker.patch('grizzly.users.iothub.IoTHubDeviceClient.create_from_connection_string', return_value=iot_hub_device_client_mock)
+    iot_hub_device_client_mock.get_storage_info_for_blob.return_value = {
+        'hostName': 'some_host',
+        'containerName': 'some_container',
+        'blobName': 'some_blob',
+        'sasToken': 'some_sas_token',
+        'correlationId': 'correlation_id',
+    }
 
     parent = grizzly_fixture(
         CONNECTION_STRING,
         IotHubUser,
     )
 
+    assert isinstance(parent.user, IotHubUser)
+
     request = grizzly_fixture.request_task.request
+    consumer_mock = mocker.MagicMock(spec=TestdataConsumer)
+    parent.user.consumer = consumer_mock
 
     scenario = GrizzlyContextScenario(99, behave=grizzly_fixture.behave.create_scenario(parent.__class__.__name__), grizzly=grizzly_fixture.grizzly)
     scenario.user.class_name = 'IotHubUser'
@@ -68,32 +71,40 @@ def iot_hub_parent(grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> Gr
 
     parent.user._scenario = scenario
 
-    return parent
+    blob_client_mock = mocker.MagicMock(spec=BlobClient)
+    blob_client_factory_mock = mocker.patch('azure.storage.blob._blob_client.BlobClient.from_blob_url', return_value=blob_client_mock)
+
+    return ParentFixture(
+        parent=parent,
+        user=parent.user,
+        consumer_mock=consumer_mock,
+        iot_device_mock=iot_hub_device_client_mock,
+        blob_client_factory_mock=blob_client_factory_mock,
+        blob_client_mock=blob_client_mock.__enter__.return_value,
+    )
 
 
 class TestIotHubUser:
-    @pytest.mark.usefixtures('iot_hub_parent')
-    def test_on_start(self, iot_hub_parent: GrizzlyScenario) -> None:
-        assert not hasattr(iot_hub_parent.user, 'iot_client')
+    def test_on_start(self, parent_fixture: ParentFixture) -> None:
+        assert not hasattr(parent_fixture.user, 'iot_client')
 
-        iot_hub_parent.user.on_start()
+        parent_fixture.user.on_start()
 
-        assert hasattr(iot_hub_parent.user, 'iot_client')
+        assert hasattr(parent_fixture.user, 'iot_client')
+        parent_fixture.consumer_mock.keystore_inc.assert_called_once_with(f'clients::{parent_fixture.user.device_id}')
 
-    @pytest.mark.usefixtures('iot_hub_parent')
-    def test_on_stop(self, mocker: MockerFixture, iot_hub_parent: GrizzlyScenario) -> None:
-        assert isinstance(iot_hub_parent.user, IotHubUser)
+    def test_on_stop(self, mocker: MockerFixture, parent_fixture: ParentFixture) -> None:
+        user = parent_fixture.user
+        assert isinstance(user, IotHubUser)
 
-        iot_hub_parent.user.on_start()
+        user.on_start()  # create `iot_device`
+        on_stop_spy = mocker.patch.object(user.iot_client, 'disconnect', return_value=None)
 
-        on_stop_spy = mocker.patch.object(iot_hub_parent.user.iot_client, 'disconnect', return_value=None)
+        user.on_stop()
 
-        iot_hub_parent.user.on_stop()
+        on_stop_spy.assert_called_once_with()
 
-        assert on_stop_spy.call_count == 1
-
-    @pytest.mark.usefixtures('iot_hub_parent')
-    def test_create(self, grizzly_fixture: GrizzlyFixture) -> None:
+    def test__init__(self, grizzly_fixture: GrizzlyFixture) -> None:
         test_cls = type('IotHubTestUser', (IotHubUser, ), {'__scenario__': grizzly_fixture.grizzly.scenario})
         environment = grizzly_fixture.grizzly.state.locust.environment
 
@@ -115,12 +126,17 @@ class TestIotHubUser:
         with pytest.raises(ValueError, match='needs SharedAccessKey in the query string'):
             test_cls(environment)
 
-    @pytest.mark.usefixtures('iot_hub_parent')
-    def test_send(self, iot_hub_parent: GrizzlyScenario, mocker: MockerFixture, grizzly_fixture: GrizzlyFixture) -> None:
-        assert isinstance(iot_hub_parent.user, IotHubUser)
-        iot_hub_parent.user.on_start()
+        test_cls.host = CONNECTION_STRING
+        test = test_cls(environment)
 
-        grizzly = grizzly_fixture.grizzly
+        assert test.device_id == 'my_device'
+
+    def test_send(self, parent_fixture: ParentFixture) -> None:
+        user = parent_fixture.user
+        assert isinstance(user, IotHubUser)
+        user.on_start()
+
+        grizzly = user._scenario.grizzly
 
         remote_variables = {
             'variables': transform(grizzly.scenario, {
@@ -129,12 +145,9 @@ class TestIotHubUser:
                 'messageID': 137,
             }),
         }
-        iot_hub_parent.user.add_context(remote_variables)
-        request = cast(RequestTask, iot_hub_parent.user._scenario.tasks()[-1])
+        user.add_context(remote_variables)
+        request = cast(RequestTask, user._scenario.tasks()[-1])
         request.endpoint = 'not_relevant'
-
-        upload_blob = mocker.patch('azure.storage.blob._blob_client.BlobClient.upload_blob', autospec=True)
-        notify_blob_upload_status = mocker.patch('azure.iot.device.IoTHubDeviceClient.notify_blob_upload_status', autospec=True)
 
         expected_payload = {
             'result': {
@@ -147,82 +160,52 @@ class TestIotHubUser:
             },
         }
 
-        metadata, payload = iot_hub_parent.user.request(request)
+        metadata, payload = user.request(request)
 
         assert payload is not None
-        assert upload_blob.call_count == 1
-        args, _ = upload_blob.call_args_list[-1]
-        assert len(args) == 2
-        assert json.loads(args[1]) == expected_payload
-
-        blob_client = cast(BlobClient, args[0])
+        parent_fixture.blob_client_mock.upload_blob.assert_called_once_with(json.dumps(expected_payload, indent=4))
+        parent_fixture.blob_client_factory_mock.assert_called_once_with('https://some_host/some_container/some_blobsome_sas_token')
+        parent_fixture.blob_client_mock.reset_mock()
+        parent_fixture.blob_client_factory_mock.reset_mock()
 
         assert metadata == {}
 
         json_payload = json.loads(payload)
         assert json_payload['result']['id'] == 'ID-31337'
-        assert blob_client.container_name == 'some_container'
-        assert blob_client.blob_name == 'some_blobsome_sas_token'
 
-        notify_blob_upload_status.assert_called_once_with(
-            iot_hub_parent.user.iot_client,
+        parent_fixture.iot_device_mock.notify_blob_upload_status.assert_called_once_with(
             correlation_id='correlation_id',
             is_success=True,
             status_code=200,
             status_description='OK: not_relevant',
         )
+        parent_fixture.iot_device_mock.notify_blob_upload_status.reset_mock()
 
-        request = cast(RequestTask, iot_hub_parent.user._scenario.tasks()[-1])
+        request = cast(RequestTask, user._scenario.tasks()[-1])
 
-        iot_hub_parent.user.request(request)
+        user.request(request)
 
-        request_event = mocker.spy(iot_hub_parent.user.environment.events.request, 'fire')
-
-        request.method = RequestMethod.RECEIVE
-        with pytest.raises(StopUser):
-            iot_hub_parent.user.request(request)
-
-        request_event.assert_called_once_with(
-            request_type='RECV',
-            name=f'{iot_hub_parent.user._scenario.identifier} {request.name}',
-            response_time=ANY(int),
-            response_length=0,
-            context=iot_hub_parent.user._context,
-            exception=ANY(NotImplementedError, message=f'{iot_hub_parent.user.__class__.__name__} has not implemented RECEIVE'),
-        )
-
-        iot_hub_parent.user._scenario.failure_exception = None
-        with pytest.raises(StopUser):
-            iot_hub_parent.user.request(request)
-
-        iot_hub_parent.user._scenario.failure_exception = StopUser
-        with pytest.raises(StopUser):
-            iot_hub_parent.user.request(request)
-
-        iot_hub_parent.user._scenario.failure_exception = RestartScenario
-        with pytest.raises(StopUser):
-            iot_hub_parent.user.request(request)
-
-        upload_blob = mocker.patch('azure.storage.blob._blob_client.BlobClient.upload_blob', side_effect=[RuntimeError('failed to upload blob')])
-        notify_blob_upload_status.reset_mock()
+        user._scenario.failure_exception = RestartScenario
+        parent_fixture.blob_client_mock.upload_blob.side_effect=[RuntimeError('failed to upload blob')]
+        parent_fixture.iot_device_mock.notify_blob_upload_status.reset_mock()
 
         request.method = RequestMethod.SEND
 
         with pytest.raises(RestartScenario):
-            iot_hub_parent.user.request(request)
+            user.request(request)
 
-        notify_blob_upload_status.assert_called_once_with(
-            iot_hub_parent.user.iot_client,
+        parent_fixture.iot_device_mock.notify_blob_upload_status.assert_called_once_with(
             correlation_id='correlation_id',
             is_success=False,
             status_code=500,
             status_description='Failed: not_relevant',
         )
+        parent_fixture.iot_device_mock.notify_blob_upload_status.reset_mock()
 
-    @pytest.mark.usefixtures('iot_hub_parent')
-    def test_send_gzip(self, iot_hub_parent: GrizzlyScenario, mocker: MockerFixture, grizzly_fixture: GrizzlyFixture) -> None:
-        assert isinstance(iot_hub_parent.user, IotHubUser)
-        iot_hub_parent.user.on_start()
+    def test_send_gzip(self, parent_fixture: ParentFixture, mocker: MockerFixture, grizzly_fixture: GrizzlyFixture) -> None:
+        user = parent_fixture.user
+        assert isinstance(parent_fixture.user, IotHubUser)
+        user.on_start()
         grizzly = grizzly_fixture.grizzly
 
         remote_variables = {
@@ -232,23 +215,20 @@ class TestIotHubUser:
                 'messageID': 137,
             }),
         }
-        iot_hub_parent.user.add_context(remote_variables)
-        request = cast(RequestTask, iot_hub_parent.user._scenario.tasks()[-1])
+        user.add_context(remote_variables)
+        request = cast(RequestTask, user._scenario.tasks()[-1])
         request.endpoint = 'not_relevant'
 
-        upload_blob = mocker.patch('azure.storage.blob._blob_client.BlobClient.upload_blob')
-        notify_blob_upload_status = mocker.patch('azure.iot.device.IoTHubDeviceClient.notify_blob_upload_status', autospec=True)
+        request = cast(RequestTask, user._scenario.tasks()[-1])
 
-        request = cast(RequestTask, iot_hub_parent.user._scenario.tasks()[-1])
-
-        gzip_compress = mocker.patch('gzip.compress', autospec=True, return_value = 'this_is_compressed')
+        gzip_compress = mocker.patch('gzip.compress', autospec=True, return_value='this_is_compressed')
         request.metadata = {}
         request.metadata['content_type'] = 'application/octet-stream; charset=utf-8'
         request.metadata['content_encoding'] = 'gzip'
-        iot_hub_parent.user.request(request)
+        user.request(request)
 
         gzip_compress.assert_called_once()
-        upload_blob.assert_called_once_with(
+        parent_fixture.blob_client_mock.upload_blob.assert_called_once_with(
             'this_is_compressed',
             content_settings=SOME(
                 ContentSettings,
@@ -257,18 +237,18 @@ class TestIotHubUser:
             ),
         )
 
-        notify_blob_upload_status.assert_called_once_with(
-            iot_hub_parent.user.iot_client,
+        parent_fixture.iot_device_mock.notify_blob_upload_status.assert_called_once_with(
             correlation_id='correlation_id',
             is_success=True,
             status_code=200,
             status_description='OK: not_relevant',
         )
 
-    @pytest.mark.usefixtures('iot_hub_parent')
-    def test_send_unhandled_encoding(self, iot_hub_parent: GrizzlyScenario, mocker: MockerFixture, grizzly_fixture: GrizzlyFixture) -> None:
-        assert isinstance(iot_hub_parent.user, IotHubUser)
-        iot_hub_parent.user.on_start()
+    def test_send_unhandled_encoding(self, parent_fixture: ParentFixture, mocker: MockerFixture, grizzly_fixture: GrizzlyFixture) -> None:
+        user = parent_fixture.user
+
+        assert isinstance(user, IotHubUser)
+        user.on_start()
         grizzly = grizzly_fixture.grizzly
 
         remote_variables = {
@@ -278,37 +258,31 @@ class TestIotHubUser:
                 'messageID': 137,
             }),
         }
-        iot_hub_parent.user.add_context(remote_variables)
-        request = cast(RequestTask, iot_hub_parent.user._scenario.tasks()[-1])
+        user.add_context(remote_variables)
+        request = cast(RequestTask, user._scenario.tasks()[-1])
         request.endpoint = 'not_relevant'
-        upload_blob = mocker.patch('azure.storage.blob._blob_client.BlobClient.upload_blob', autospec=True)
-        notify_blob_upload_status = mocker.patch('azure.iot.device.IoTHubDeviceClient.notify_blob_upload_status', autospec=True)
-
-        request = cast(RequestTask, iot_hub_parent.user._scenario.tasks()[-1])
 
         gzip_compress = mocker.patch('gzip.compress', autospec=True, return_value = 'this_is_compressed')
         request.metadata = {}
         request.metadata['content_type'] = 'application/octet-stream; charset=utf-8'
         request.metadata['content_encoding'] = 'vulcan'
 
-        iot_hub_parent.user._scenario.failure_exception = RestartScenario
+        user._scenario.failure_exception = RestartScenario
         with pytest.raises(RestartScenario):
-            iot_hub_parent.user.request(request)
+            user.request(request)
 
         gzip_compress.assert_not_called()
-        upload_blob.assert_not_called()
-        notify_blob_upload_status.assert_called_once_with(
-            iot_hub_parent.user.iot_client,
+        parent_fixture.blob_client_mock.upload_blob.assert_not_called()
+        parent_fixture.iot_device_mock.notify_blob_upload_status.assert_called_once_with(
             correlation_id='correlation_id',
             is_success=False,
             status_code=500,
             status_description='Failed: not_relevant',
         )
 
-    @pytest.mark.usefixtures('iot_hub_parent')
-    def test_send_empty_payload(self, iot_hub_parent: GrizzlyScenario, mocker: MockerFixture, grizzly_fixture: GrizzlyFixture) -> None:
-        assert isinstance(iot_hub_parent.user, IotHubUser)
-        iot_hub_parent.user.on_start()
+    def test_send_empty_payload(self, parent_fixture: ParentFixture, mocker: MockerFixture, grizzly_fixture: GrizzlyFixture) -> None:
+        assert isinstance(parent_fixture.user, IotHubUser)
+        parent_fixture.user.on_start()
         grizzly = grizzly_fixture.grizzly
 
         remote_variables = {
@@ -318,21 +292,17 @@ class TestIotHubUser:
                 'messageID': 137,
             }),
         }
-        iot_hub_parent.user.add_context(remote_variables)
-        request = cast(RequestTask, iot_hub_parent.user._scenario.tasks()[-1])
+        parent_fixture.user.add_context(remote_variables)
+        request = cast(RequestTask, parent_fixture.user._scenario.tasks()[-1])
         request.endpoint = 'not_relevant'
-        upload_blob = mocker.patch('azure.storage.blob._blob_client.BlobClient.upload_blob', autospec=True)
-        notify_blob_upload_status = mocker.patch('azure.iot.device.IoTHubDeviceClient.notify_blob_upload_status', autospec=True)
 
-        request = cast(RequestTask, iot_hub_parent.user._scenario.tasks()[-1])
-
-        gzip_compress = mocker.patch('gzip.compress', autospec=True, return_value = 'this_is_compressed')
+        gzip_compress = mocker.patch('gzip.compress', autospec=True, return_value='this_is_compressed')
         request.source = None
 
-        iot_hub_parent.user._scenario.failure_exception = RestartScenario
+        parent_fixture.user._scenario.failure_exception = RestartScenario
         with pytest.raises(RestartScenario):
-            iot_hub_parent.user.request(request)
+            parent_fixture.user.request(request)
 
         gzip_compress.assert_not_called()
-        upload_blob.assert_not_called()
-        notify_blob_upload_status.assert_not_called()
+        parent_fixture.blob_client_mock.upload_blob.assert_not_called()
+        parent_fixture.iot_device_mock.notify_blob_upload_status.assert_not_called()

--- a/tests/unit/test_grizzly/users/test_messagequeue.py
+++ b/tests/unit/test_grizzly/users/test_messagequeue.py
@@ -427,7 +427,7 @@ class TestMessageQueueUser:
         })
 
         request_event_spy = mocker.spy(mq_parent.user.environment.events.request, 'fire')
-        response_event_spy = mocker.spy(mq_parent.user.event_hook, 'fire')
+        response_event_spy = mocker.spy(mq_parent.user.events.request, 'fire')
 
         request = cast(RequestTask, mq_parent.user._scenario.tasks()[-1])
         request.endpoint = 'queue:test-queue'

--- a/tests/unit/test_grizzly/users/test_servicebus.py
+++ b/tests/unit/test_grizzly/users/test_servicebus.py
@@ -362,7 +362,7 @@ class TestServiceBusUser:
         send_json_spy = noop_zmq.get_mock('send_json')
         say_hello_spy = mocker.patch.object(parent.user, 'say_hello', side_effect=[None] * 10)
         request_fire_spy = mocker.spy(parent.user.environment.events.request, 'fire')
-        response_event_fire_spy = mocker.spy(parent.user.event_hook, 'fire')
+        response_event_fire_spy = mocker.spy(parent.user.events.request, 'fire')
 
         def mock_recv_json(response: AsyncMessageResponse) -> None:
             mocker.patch.object(

--- a/tests/unit/test_grizzly/utils/test_protocols.py
+++ b/tests/unit/test_grizzly/utils/test_protocols.py
@@ -236,7 +236,7 @@ def test_async_message_request_wrapper(grizzly_fixture: GrizzlyFixture, mocker: 
 
     async_message_request_wrapper(parent, client_mock, request)
 
-    async_message_request_mock.assert_called_once_with(client_mock, {'context': {'endpoint': 'hello !'}, 'client': id(parent.user)})
+    async_message_request_mock.assert_called_once_with(client_mock, {'context': {'endpoint': 'hello {{ world }}!'}, 'client': id(parent.user)})
     async_message_request_mock.reset_mock()
 
     # template to render, variable set


### PR DESCRIPTION
Added support to be able to receive cloud-to-device (C2D) messages.

Also new internal grizzly events, which `grizzly.listeners.influx` adds handlers for, to get statistics about keystore and testdata request, as well as C2D messages received by `IotHubUser`.
