### PR TITLE
Async-messaged fixes;

### DIFF
--- a/grizzly_extras/async_message/__init__.py
+++ b/grizzly_extras/async_message/__init__.py
@@ -81,6 +81,7 @@ class AsyncMessageContext(TypedDict, total=False):
 
 
 class AsyncMessageRequest(TypedDict, total=False):
+    request_id: str
     action: str
     worker: Optional[str]
     client: int
@@ -89,6 +90,7 @@ class AsyncMessageRequest(TypedDict, total=False):
 
 
 class AsyncMessageResponse(TypedDict, total=False):
+    request_id: str
     success: bool
     worker: str
     message: Optional[str]
@@ -133,9 +135,9 @@ class AsyncMessageHandler(ABC):
     @final
     def handle(self, request: AsyncMessageRequest) -> AsyncMessageResponse:
         start_time = time()
+        action = request.get('action', None)
 
         try:
-            action = request.get('action', None)
             if action is None:
                 message = 'no action in request'
                 raise RuntimeError(message)
@@ -162,6 +164,7 @@ class AsyncMessageHandler(ABC):
             response.update({
                 'worker': self.worker,
                 'response_time': total_time,
+                'action': action,
             })
 
             self.logger.debug('handled %s, response=\n%s', action, jsondumps(response, indent=2, cls=JsonBytesEncoder))

--- a/grizzly_extras/async_message/__init__.py
+++ b/grizzly_extras/async_message/__init__.py
@@ -98,6 +98,7 @@ class AsyncMessageResponse(TypedDict, total=False):
     metadata: AsyncMessageMetadata
     response_length: int
     response_time: int
+    action: str
 
 
 class AsyncMessageError(Exception):
@@ -164,7 +165,7 @@ class AsyncMessageHandler(ABC):
             response.update({
                 'worker': self.worker,
                 'response_time': total_time,
-                'action': action,
+                'action': action or 'UNKNOWN',
             })
 
             self.logger.debug('handled %s, response=\n%s', action, jsondumps(response, indent=2, cls=JsonBytesEncoder))

--- a/grizzly_extras/async_message/daemon.py
+++ b/grizzly_extras/async_message/daemon.py
@@ -60,81 +60,86 @@ class Worker:
         self.context = context
         self.integration = None
         self._event = Event() if event is None else event
-
-    def run(self) -> None:
         self.socket = self.context.socket(zmq.REQ)
         self.socket.setsockopt_string(zmq.IDENTITY, self.identity)
         self.socket.connect('inproc://workers')
         self.socket.send_string(LRU_READY)
 
-        while not self._event.is_set():
-            received = False
-            try:
-                request_proto = self.socket.recv_multipart(flags=zmq.NOBLOCK)
-                received = True
-            except zmq.Again:
-                sleep(0.1)
-                continue
+    def run(self) -> None:
+        connected = True
+        try:
+            while not self._event.is_set() and connected:
+                received = False
+                try:
+                    request_proto = self.socket.recv_multipart(flags=zmq.NOBLOCK)
+                    received = True
+                except zmq.Again:
+                    sleep(0.1)
+                    continue
 
-            self.logger.debug("i'm alive! run_daemon=%r, received=%r", self._event.is_set(), received)
+                self.logger.debug("i'm alive! run_daemon=%r, received=%r", self._event.is_set(), received)
 
-            if not request_proto:
-                continue
+                if not request_proto:
+                    continue
 
-            request = cast(
-                AsyncMessageRequest,
-                jsonloads(request_proto[-1].decode()),
-            )
+                request = cast(
+                    AsyncMessageRequest,
+                    jsonloads(request_proto[-1].decode()),
+                )
 
-            response: Optional[AsyncMessageResponse] = None
+                request_request_id = request.get('request_id', None)
 
-            try:
-                if request['worker'] != self.identity:
-                    message = f'got {request["worker"]}, expected {self.identity}'
-                    raise RuntimeError(message)
+                response: Optional[AsyncMessageResponse] = None
 
-                if self.integration is None:
-                    integration_url = request.get('context', {}).get('url', None)
-                    if integration_url is None:
-                        message = 'no url found in request context'
+                try:
+                    if request['worker'] != self.identity:
+                        message = f'got {request["worker"]}, expected {self.identity}'
                         raise RuntimeError(message)
 
-                    parsed = urlparse(integration_url)
+                    if self.integration is None:
+                        integration_url = request.get('context', {}).get('url', None)
+                        if integration_url is None:
+                            message = 'no url found in request context'
+                            raise RuntimeError(message)
 
-                    if parsed.scheme in ['mq', 'mqs']:
-                        from .mq import AsyncMessageQueueHandler
-                        self.integration = AsyncMessageQueueHandler(self.identity)
-                    elif parsed.scheme == 'sb':
-                        from .sb import AsyncServiceBusHandler
-                        self.integration = AsyncServiceBusHandler(self.identity)
-                    else:
-                        message = f'integration for {parsed.scheme}:// is not implemented'
-                        raise RuntimeError(message)
-            except Exception as e:
-                response = {
-                    'worker': self.identity,
-                    'response_time': 0,
-                    'success': False,
-                    'message': str(e),
-                }
+                        parsed = urlparse(integration_url)
 
-            if response is None and self.integration is not None:
-                response = self.integration.handle(request)
+                        if parsed.scheme in ['mq', 'mqs']:
+                            from .mq import AsyncMessageQueueHandler
+                            self.integration = AsyncMessageQueueHandler(self.identity)
+                        elif parsed.scheme == 'sb':
+                            from .sb import AsyncServiceBusHandler
+                            self.integration = AsyncServiceBusHandler(self.identity)
+                        else:
+                            message = f'integration for {parsed.scheme}:// is not implemented'
+                            raise RuntimeError(message)
+                except Exception as e:
+                    response = {
+                        'request_id': str(request_request_id),
+                        'worker': self.identity,
+                        'response_time': 0,
+                        'success': False,
+                        'message': str(e),
+                    }
 
-            response_proto = [
-                request_proto[0],
-                SPLITTER_FRAME,
-                jsondumps(response, cls=JsonBytesEncoder).encode(),
-            ]
+                if response is None and self.integration is not None:
+                    response = self.integration.handle(request)
+                    response.update({
+                        'request_id': str(request_request_id),
+                    })
+                    if response.get('action', None) in ['DISC', 'DISCONNECT']:
+                        connected = False
 
-            self.socket.send_multipart(response_proto)
+                response_proto = [
+                    request_proto[0],
+                    SPLITTER_FRAME,
+                    jsondumps(response, cls=JsonBytesEncoder).encode(),
+                ]
 
-        self.logger.info('stopping')
-        if self.integration is not None:
-            self.integration.close()
-
-        self.socket.close()
-        self.logger.info('stopped')
+                self.socket.send_multipart(response_proto)
+        except Exception as e:
+            err_msg = f'unhandled exception in worker: {e}'
+            self.logger.exception(err_msg)
 
 
 def create_router_socket(context: zmq.Context) -> zmq.Socket:
@@ -161,9 +166,13 @@ def router(run_daemon: Event) -> None:  # noqa: C901, PLR0915
     poller.register(backend, zmq.POLLIN)
 
     workers: dict[str, tuple[futures.Future, Worker]] = {}
+    workers_available: list[str] = []
 
-    with ThreadPoolExecutor() as executor:
+    with ThreadPoolExecutor(max_workers=500) as executor:
+        waiting_for_worker = False
+
         def spawn_worker() -> None:
+            nonlocal waiting_for_worker
             identity = str(uuid4())
 
             worker = Worker(context, identity, run_daemon)
@@ -171,141 +180,158 @@ def router(run_daemon: Event) -> None:  # noqa: C901, PLR0915
             future = executor.submit(worker.run)
             workers.update({identity: (future, worker)})
             logger.info('spawned worker %s', identity)
+            waiting_for_worker = True
 
-        workers_available: list[str] = []
         client_worker_map: dict[str, str] = {}
         worker_identifiers_map: dict[str, bytes] = {}
 
         spawn_worker()
 
         worker_id: str
-
-        while not run_daemon.is_set():
-            socks = dict(poller.poll(timeout=1000))
-
-            if not socks:
-                continue
-
-            logger.debug("i'm alive!")
-
-            if socks.get(backend) == zmq.POLLIN:
-                logger.debug('polling backend')
-                try:
-                    logger.debug('waiting for backend')
-                    backend_response = backend.recv_multipart(flags=zmq.NOBLOCK)
-                except zmq.Again:
-                    sleep(0.1)
-                    continue
-
-                if not backend_response:
-                    continue
-
-                logger.debug('backend_response: %r', backend_response)
-                reply = backend_response[2:]
-                worker_id = backend_response[0].decode()
-
-                worker_identifiers_map.update({worker_id: reply[0]})
-
-                if reply[0] != LRU_READY.encode():
-                    logger.debug('sending %r', reply)
-                    frontend.send_multipart(reply)
-                    logger.debug('forwarding backend response from %s', worker_id)
-                else:
-                    logger.info('worker %s ready', worker_id)
-                    workers_available.append(worker_id)
-
-            if socks.get(frontend) == zmq.POLLIN:
-                logger.debug('polling frontend')
-                try:
-                    logger.debug('waiting for frontend')
-                    msg = frontend.recv_multipart(flags=zmq.NOBLOCK)
-                except zmq.Again:
-                    sleep(0.1)
-                    continue
-
-                request_id = msg[0]
-                payload = cast(AsyncMessageRequest, jsonloads(msg[-1].decode()))
-
-                request_worker_id = payload.get('worker', None)
-                request_client_id = payload.get('client', None)
-                client_key: Optional[str] = None
-
-                logger.debug('request_worker_id=%r (%r), request_client_id=%r (%r)', request_worker_id, type(request_worker_id), request_client_id, type(request_client_id))
-
-                if request_client_id is not None:
-                    integration_url = payload.get('context', {}).get('url', None)
-                    parsed = urlparse(integration_url)
-                    scheme = parsed.scheme
-                    if isinstance(scheme, bytes):
-                        scheme = scheme.decode()
-
-                    client_key = f'{request_client_id}::{scheme}'
-
-                if request_worker_id is None and client_key is not None:
-                    request_worker_id = client_worker_map.get(client_key)
-
-                if request_worker_id is None:
-                    worker_id = workers_available.pop()
-
-                    if client_key is not None:
-                        client_worker_map.update({client_key: worker_id})
-
-                    payload['worker'] = worker_id
-                    logger.info('assigned worker %s to %s', worker_id, client_key)
-
-                    if len(workers_available) == 0:
-                        logger.debug('spawning an additional worker, for next client')
-                        spawn_worker()
-                else:
-                    logger.debug('%s is assigned %s', request_client_id, request_worker_id)
-                    worker_id = request_worker_id
-
-                    if payload.get('worker', None) is None:
-                        payload['worker'] = worker_id
-
-                request = jsondumps(payload).encode()
-                backend_request = [worker_id.encode(), SPLITTER_FRAME, request_id, SPLITTER_FRAME, request]
-                backend.send_multipart(backend_request)
-
-        logger.info('stopping')
-        for identity, (future, worker) in workers.items():
-            if not future.running():
-                continue
-
-            # tell client that we aborted
-            if worker.integration is not None:
-                response = {
-                    'success': False,
-                    'worker': identity,
-                    'message': 'abort',
-                }
-
-                response_proto = [
-                    worker_identifiers_map.get(identity),
-                    SPLITTER_FRAME,
-                    jsondumps(response, cls=JsonBytesEncoder).encode(),
-                ]
-
-                frontend.send_multipart(response_proto)
-
-                worker.logger.debug('sent abort to client')
-
-                worker.integration.close()
-                worker.socket.close()
-                worker.logger.info('socket closed')
-
-                # stop worker
-                cancelled = future.cancel()  # let's try at least...
-                logger.info('worker %s cancelled: %r', identity, cancelled)
-            else:
-                # should complete when `worker.stop()` has had effect
-                futures.wait([future])
+        request_client_id: str|None
+        request_request_id: str|None
 
         try:
-            logger.debug('destroy zmq context')
-            context.destroy(linger=0)
-        except:
-            logger.exception('failed to destroy zmq context')
+            while not run_daemon.is_set():
+                socks = dict(poller.poll(timeout=1000))
+
+                if not socks:
+                    continue
+
+                logger.debug("i'm alive!")
+
+                if socks.get(backend) == zmq.POLLIN:
+                    logger.debug('polling backend')
+                    try:
+                        logger.debug('waiting for backend')
+                        backend_response = backend.recv_multipart(flags=zmq.NOBLOCK)
+                    except zmq.Again:
+                        sleep(0.1)
+                        continue
+
+                    if not backend_response:
+                        continue
+
+                    logger.debug('backend_response: %r', backend_response)
+                    reply = backend_response[2:]
+                    worker_id = backend_response[0].decode()
+
+                    worker_identifiers_map.update({worker_id: reply[0]})
+
+                    if reply[0] == LRU_READY.encode():
+                        workers_available.append(worker_id)
+                        waiting_for_worker = False
+                    else:
+                        if len(reply) > 0 and reply[0] is not None:
+                            async_response = jsonloads(reply[-1].decode())
+                            if async_response.get('action', None) in ['DISC', 'DISCONNECT']:
+                                del workers[worker_id]
+                                del worker_identifiers_map[worker_id]
+                                client_id = async_response.get('client', None)
+                                if client_id:
+                                    del client_worker_map[client_id]
+
+                        logger.debug('sending %r', reply)
+                        frontend.send_multipart(reply)
+                        logger.debug('forwarding backend response from %s', worker_id)
+                        if waiting_for_worker:
+                            continue
+
+                if socks.get(frontend) == zmq.POLLIN:
+                    logger.debug('polling frontend')
+                    try:
+                        logger.debug('waiting for frontend')
+                        msg = frontend.recv_multipart(flags=zmq.NOBLOCK)
+                    except zmq.Again:
+                        sleep(0.1)
+                        continue
+
+                    request_id = msg[0]
+                    payload = cast(AsyncMessageRequest, jsonloads(msg[-1].decode()))
+
+                    request_worker_id = payload.get('worker', None)
+                    request_client_id = str(payload.get('client', None))
+                    request_request_id = payload.get('request_id', None)
+                    client_key: Optional[str] = None
+
+                    logger.debug('request_worker_id=%r (%r), request_client_id=%r (%r)', request_worker_id, type(request_worker_id), request_client_id, type(request_client_id))
+
+                    if request_client_id is not None:
+                        integration_url = payload.get('context', {}).get('url', None)
+                        parsed = urlparse(integration_url)
+                        scheme = parsed.scheme
+                        if isinstance(scheme, bytes):
+                            scheme = scheme.decode()
+
+                        client_key = f'{request_client_id}::{scheme}'
+
+                    if request_worker_id is None and client_key is not None:
+                        request_worker_id = client_worker_map.get(client_key)
+
+                    if request_worker_id is None:
+                        if len(workers_available) < 2:
+                            spawn_worker()
+
+                        worker_id = workers_available.pop()
+
+                        if client_key is not None:
+                            client_worker_map.update({client_key: worker_id})
+
+                        payload['worker'] = worker_id
+
+                    else:
+                        logger.debug('%s is assigned %s', request_client_id, request_worker_id)
+                        worker_id = request_worker_id
+
+                        if payload.get('worker', None) is None:
+                            payload['worker'] = worker_id
+
+                    request = jsondumps(payload).encode()
+                    backend_request = [worker_id.encode(), SPLITTER_FRAME, request_id, SPLITTER_FRAME, request]
+                    backend.send_multipart(backend_request)
+
+            logger.info('stopping')
+            for identity, (future, worker) in workers.items():
+                if not future.running():
+                    continue
+
+                # tell client that we aborted
+                if worker.integration is not None:
+                    response = {
+                        'success': False,
+                        'worker': identity,
+                        'message': 'abort',
+                    }
+
+                    response_proto = [
+                        worker_identifiers_map.get(identity),
+                        SPLITTER_FRAME,
+                        jsondumps(response, cls=JsonBytesEncoder).encode(),
+                    ]
+
+                    frontend.send_multipart(response_proto)
+
+                    worker.logger.debug('sent abort to client')
+
+                    worker.integration.close()
+                    worker.socket.close()
+                    worker.logger.info('socket closed')
+
+                    # stop worker
+                    cancelled = future.cancel()  # let's try at least...
+                    logger.info('worker %s cancelled: %r', identity, cancelled)
+                else:
+                    # should complete when `worker.stop()` has had effect
+                    futures.wait([future])
+
+            try:
+                logger.debug('destroy zmq context')
+                context.destroy(linger=0)
+            except:
+                logger.exception('failed to destroy zmq context')
+        except Exception as e:
+            err_msg = f'unhandled exception in router for client_id {request_client_id}, request_id {request_request_id}: {e}'
+            logger.exception(err_msg)
 
     logger.info('stopped')
 

--- a/grizzly_extras/async_message/utils.py
+++ b/grizzly_extras/async_message/utils.py
@@ -30,7 +30,7 @@ def tohex(value: Union[int, str, bytes, bytearray, Any]) -> str:
 
 def async_message_request(client: zmq.Socket, request: AsyncMessageRequest) -> AsyncMessageResponse:
     try:
-        request['request_id'] = uuid.uuid4().hex
+        request['request_id'] = str(uuid.uuid4())
         client.send_json(request)
 
         response: Optional[AsyncMessageResponse] = None

--- a/grizzly_extras/async_message/utils.py
+++ b/grizzly_extras/async_message/utils.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import uuid
 from time import perf_counter, sleep
 from typing import Any, Optional, Union, cast
 
@@ -29,6 +30,7 @@ def tohex(value: Union[int, str, bytes, bytearray, Any]) -> str:
 
 def async_message_request(client: zmq.Socket, request: AsyncMessageRequest) -> AsyncMessageResponse:
     try:
+        request['request_id'] = uuid.uuid4().hex
         client.send_json(request)
 
         response: Optional[AsyncMessageResponse] = None
@@ -43,7 +45,7 @@ def async_message_request(client: zmq.Socket, request: AsyncMessageRequest) -> A
 
             delta = perf_counter() - start
             if delta > 1.0:
-                logger.debug('async_message_request::recv_json took %f seconds', delta)
+                logger.debug('async_message_request::recv_json took %f seconds for request_id %s', delta, request['request_id'])
 
         if response is None:
             msg = 'no response'

--- a/tests/unit/test_grizzly/tasks/clients/test_messagequeue.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_messagequeue.py
@@ -266,7 +266,7 @@ class TestMessageQueueClientTask:
             if zmq_context is not None:
                 zmq_context.destroy()
 
-    def test_create_client(self, grizzly_fixture: GrizzlyFixture, noop_zmq: NoopZmqFixture, mocker: MockerFixture) -> None:
+    def test_create_client(self, grizzly_fixture: GrizzlyFixture, noop_zmq: NoopZmqFixture) -> None:
         noop_zmq('grizzly.tasks.clients.messagequeue')
         connect_mock = noop_zmq.get_mock('zmq.Socket.connect')
         setsockopt_mock = noop_zmq.get_mock('zmq.Socket.setsockopt')
@@ -302,13 +302,7 @@ class TestMessageQueueClientTask:
 
     def test_connect(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture, noop_zmq: NoopZmqFixture) -> None:  # noqa: PLR0915
         noop_zmq('grizzly.tasks.clients.messagequeue')
-
-        uuid4_mock = mocker.MagicMock()
-        uuid4_mock.hex = 'deadbeefdeadbeefdeadbeefdeadbeef'
-        mocker.patch(
-            'grizzly_extras.async_message.utils.uuid.uuid4',
-            return_value=uuid4_mock,
-        )
+        mocker.patch('grizzly_extras.async_message.utils.uuid.uuid4', return_value='foobar')
 
         zmq_context: Optional[zmq.Context] = None
         try:
@@ -348,7 +342,7 @@ class TestMessageQueueClientTask:
                         'heartbeat_interval': None,
                         'header_type': None,
                     },
-                    'request_id': 'deadbeefdeadbeefdeadbeefdeadbeef',
+                    'request_id': 'foobar',
                 })
                 assert recv_json_mock.call_count == 2
                 _, kwargs = recv_json_mock.call_args_list[-1]
@@ -413,7 +407,7 @@ class TestMessageQueueClientTask:
                         'heartbeat_interval': None,
                         'header_type': 'rfh2',
                     },
-                    'request_id': 'deadbeefdeadbeefdeadbeefdeadbeef',
+                    'request_id': 'foobar',
                 })
         finally:
             if zmq_context is not None:
@@ -421,13 +415,7 @@ class TestMessageQueueClientTask:
 
     def test_request_from(self, mocker: MockerFixture, noop_zmq: NoopZmqFixture, grizzly_fixture: GrizzlyFixture, caplog: LogCaptureFixture) -> None:  # noqa: PLR0915
         noop_zmq('grizzly.tasks.clients.messagequeue')
-
-        uuid4_mock = mocker.MagicMock()
-        uuid4_mock.hex = 'deadbeefdeadbeefdeadbeefdeadbeef'
-        mocker.patch(
-            'grizzly_extras.async_message.utils.uuid.uuid4',
-            return_value=uuid4_mock,
-        )
+        mocker.patch('grizzly_extras.async_message.utils.uuid.uuid4', return_value='foobar')
 
         parent = grizzly_fixture(scenario_type=IteratorScenario)
 
@@ -485,7 +473,7 @@ class TestMessageQueueClientTask:
                     'endpoint': 'topic:INCOMING.MSG',
                 },
                 'payload': None,
-                'request_id': 'deadbeefdeadbeefdeadbeefdeadbeef',
+                'request_id': 'foobar',
             },)
             assert kwargs == {}
             send_json_mock.reset_mock()
@@ -533,7 +521,7 @@ class TestMessageQueueClientTask:
                     'endpoint': 'topic:INCOMING.MSG, max_message_size:13337',
                 },
                 'payload': None,
-                'request_id': 'deadbeefdeadbeefdeadbeefdeadbeef',
+                'request_id': 'foobar',
             })
             send_json_mock.reset_mock()
             assert recv_json_mock.call_count == 4
@@ -619,13 +607,7 @@ class TestMessageQueueClientTask:
 
     def test_request_to(self, mocker: MockerFixture, noop_zmq: NoopZmqFixture, grizzly_fixture: GrizzlyFixture) -> None:
         noop_zmq('grizzly.tasks.clients.messagequeue')
-
-        uuid4_mock = mocker.MagicMock()
-        uuid4_mock.hex = 'deadbeefdeadbeefdeadbeefdeadbeef'
-        mocker.patch(
-            'grizzly_extras.async_message.utils.uuid.uuid4',
-            return_value=uuid4_mock,
-        )
+        mocker.patch('grizzly_extras.async_message.utils.uuid.uuid4', return_value='foobar')
 
         parent = grizzly_fixture()
 
@@ -694,7 +676,7 @@ class TestMessageQueueClientTask:
                     'endpoint': 'queue:INCOMING.MSG',
                 },
                 'payload': source,
-                'request_id': 'deadbeefdeadbeefdeadbeefdeadbeef',
+                'request_id': 'foobar',
             },)
             assert kwargs == {}
             send_json_mock.reset_mock()
@@ -741,7 +723,7 @@ class TestMessageQueueClientTask:
                     'endpoint': 'queue:INCOMING.MSG',
                 },
                 'payload': source_file.read_text(),
-                'request_id': 'deadbeefdeadbeefdeadbeefdeadbeef',
+                'request_id': 'foobar',
             })
             send_json_mock.reset_mock()
 

--- a/tests/unit/test_grizzly/tasks/clients/test_messagequeue.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_messagequeue.py
@@ -266,7 +266,7 @@ class TestMessageQueueClientTask:
             if zmq_context is not None:
                 zmq_context.destroy()
 
-    def test_create_client(self, grizzly_fixture: GrizzlyFixture, noop_zmq: NoopZmqFixture) -> None:
+    def test_create_client(self, grizzly_fixture: GrizzlyFixture, noop_zmq: NoopZmqFixture, mocker: MockerFixture) -> None:
         noop_zmq('grizzly.tasks.clients.messagequeue')
         connect_mock = noop_zmq.get_mock('zmq.Socket.connect')
         setsockopt_mock = noop_zmq.get_mock('zmq.Socket.setsockopt')
@@ -302,6 +302,13 @@ class TestMessageQueueClientTask:
 
     def test_connect(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture, noop_zmq: NoopZmqFixture) -> None:  # noqa: PLR0915
         noop_zmq('grizzly.tasks.clients.messagequeue')
+
+        uuid4_mock = mocker.MagicMock()
+        uuid4_mock.hex = 'deadbeefdeadbeefdeadbeefdeadbeef'
+        mocker.patch(
+            'grizzly_extras.async_message.utils.uuid.uuid4',
+            return_value=uuid4_mock,
+        )
 
         zmq_context: Optional[zmq.Context] = None
         try:
@@ -341,6 +348,7 @@ class TestMessageQueueClientTask:
                         'heartbeat_interval': None,
                         'header_type': None,
                     },
+                    'request_id': 'deadbeefdeadbeefdeadbeefdeadbeef',
                 })
                 assert recv_json_mock.call_count == 2
                 _, kwargs = recv_json_mock.call_args_list[-1]
@@ -405,6 +413,7 @@ class TestMessageQueueClientTask:
                         'heartbeat_interval': None,
                         'header_type': 'rfh2',
                     },
+                    'request_id': 'deadbeefdeadbeefdeadbeefdeadbeef',
                 })
         finally:
             if zmq_context is not None:
@@ -412,6 +421,13 @@ class TestMessageQueueClientTask:
 
     def test_request_from(self, mocker: MockerFixture, noop_zmq: NoopZmqFixture, grizzly_fixture: GrizzlyFixture, caplog: LogCaptureFixture) -> None:  # noqa: PLR0915
         noop_zmq('grizzly.tasks.clients.messagequeue')
+
+        uuid4_mock = mocker.MagicMock()
+        uuid4_mock.hex = 'deadbeefdeadbeefdeadbeefdeadbeef'
+        mocker.patch(
+            'grizzly_extras.async_message.utils.uuid.uuid4',
+            return_value=uuid4_mock,
+        )
 
         parent = grizzly_fixture(scenario_type=IteratorScenario)
 
@@ -469,6 +485,7 @@ class TestMessageQueueClientTask:
                     'endpoint': 'topic:INCOMING.MSG',
                 },
                 'payload': None,
+                'request_id': 'deadbeefdeadbeefdeadbeefdeadbeef',
             },)
             assert kwargs == {}
             send_json_mock.reset_mock()
@@ -516,6 +533,7 @@ class TestMessageQueueClientTask:
                     'endpoint': 'topic:INCOMING.MSG, max_message_size:13337',
                 },
                 'payload': None,
+                'request_id': 'deadbeefdeadbeefdeadbeefdeadbeef',
             })
             send_json_mock.reset_mock()
             assert recv_json_mock.call_count == 4
@@ -602,6 +620,13 @@ class TestMessageQueueClientTask:
     def test_request_to(self, mocker: MockerFixture, noop_zmq: NoopZmqFixture, grizzly_fixture: GrizzlyFixture) -> None:
         noop_zmq('grizzly.tasks.clients.messagequeue')
 
+        uuid4_mock = mocker.MagicMock()
+        uuid4_mock.hex = 'deadbeefdeadbeefdeadbeefdeadbeef'
+        mocker.patch(
+            'grizzly_extras.async_message.utils.uuid.uuid4',
+            return_value=uuid4_mock,
+        )
+
         parent = grizzly_fixture()
 
         fire_spy = mocker.spy(parent.user.environment.events.request, 'fire')
@@ -669,6 +694,7 @@ class TestMessageQueueClientTask:
                     'endpoint': 'queue:INCOMING.MSG',
                 },
                 'payload': source,
+                'request_id': 'deadbeefdeadbeefdeadbeefdeadbeef',
             },)
             assert kwargs == {}
             send_json_mock.reset_mock()
@@ -715,6 +741,7 @@ class TestMessageQueueClientTask:
                     'endpoint': 'queue:INCOMING.MSG',
                 },
                 'payload': source_file.read_text(),
+                'request_id': 'deadbeefdeadbeefdeadbeefdeadbeef',
             })
             send_json_mock.reset_mock()
 

--- a/tests/unit/test_grizzly/users/test_servicebus.py
+++ b/tests/unit/test_grizzly/users/test_servicebus.py
@@ -339,13 +339,7 @@ class TestServiceBusUser:
 
     def test_request(self, grizzly_fixture: GrizzlyFixture, noop_zmq: NoopZmqFixture, mocker: MockerFixture) -> None:  # noqa: PLR0915
         noop_zmq('grizzly.users.servicebus')
-
-        uuid4_mock = mocker.MagicMock()
-        uuid4_mock.hex = 'deadbeefdeadbeefdeadbeefdeadbeef'
-        mocker.patch(
-            'grizzly_extras.async_message.utils.uuid.uuid4',
-            return_value=uuid4_mock,
-        )
+        mocker.patch('grizzly_extras.async_message.utils.uuid.uuid4', return_value='foobar')
 
         grizzly_fixture.grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test scenario'))
         grizzly = grizzly_fixture.grizzly
@@ -442,7 +436,7 @@ class TestServiceBusUser:
                 'password': None,
                 'tenant': None,
             },
-            'request_id': 'deadbeefdeadbeefdeadbeefdeadbeef',
+            'request_id': 'foobar',
         })
 
         send_json_spy.reset_mock()
@@ -513,7 +507,7 @@ class TestServiceBusUser:
                 'password': None,
                 'tenant': None,
             },
-            'request_id': 'deadbeefdeadbeefdeadbeefdeadbeef',
+            'request_id': 'foobar',
         })
         send_json_spy.reset_mock()
 
@@ -570,6 +564,6 @@ class TestServiceBusUser:
                 'password': None,
                 'tenant': None,
             },
-            'request_id': 'deadbeefdeadbeefdeadbeefdeadbeef',
+            'request_id': 'foobar',
         })
         send_json_spy.reset_mock()

--- a/tests/unit/test_grizzly/users/test_servicebus.py
+++ b/tests/unit/test_grizzly/users/test_servicebus.py
@@ -340,6 +340,13 @@ class TestServiceBusUser:
     def test_request(self, grizzly_fixture: GrizzlyFixture, noop_zmq: NoopZmqFixture, mocker: MockerFixture) -> None:  # noqa: PLR0915
         noop_zmq('grizzly.users.servicebus')
 
+        uuid4_mock = mocker.MagicMock()
+        uuid4_mock.hex = 'deadbeefdeadbeefdeadbeefdeadbeef'
+        mocker.patch(
+            'grizzly_extras.async_message.utils.uuid.uuid4',
+            return_value=uuid4_mock,
+        )
+
         grizzly_fixture.grizzly.scenarios.create(grizzly_fixture.behave.create_scenario('test scenario'))
         grizzly = grizzly_fixture.grizzly
 
@@ -435,6 +442,7 @@ class TestServiceBusUser:
                 'password': None,
                 'tenant': None,
             },
+            'request_id': 'deadbeefdeadbeefdeadbeefdeadbeef',
         })
 
         send_json_spy.reset_mock()
@@ -505,6 +513,7 @@ class TestServiceBusUser:
                 'password': None,
                 'tenant': None,
             },
+            'request_id': 'deadbeefdeadbeefdeadbeefdeadbeef',
         })
         send_json_spy.reset_mock()
 
@@ -561,5 +570,6 @@ class TestServiceBusUser:
                 'password': None,
                 'tenant': None,
             },
+            'request_id': 'deadbeefdeadbeefdeadbeefdeadbeef',
         })
         send_json_spy.reset_mock()

--- a/tests/unit/test_grizzly_extras/async_message/test_daemon.py
+++ b/tests/unit/test_grizzly_extras/async_message/test_daemon.py
@@ -7,7 +7,7 @@ from itertools import cycle
 from json import dumps as jsondumps
 from multiprocessing import Process
 from threading import Event
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, cast
 
 import pytest
 import zmq.green as zmq


### PR DESCRIPTION
* request_id (a GUID) is added to requests and responses
* 'action' is returned in all responses
* Worker connects in __init__ instead if in run()
* Worker detects disconnect actions and finishes
* router pauses polling from frontend when spawning a new worker, until LRU_READY is received
* max_workers in routers' ThreadPoolExecutor is set to 500 instead of default (caused starvation)
* try/except around both router and Workers' run loops to log any unhandled exceptions