### PR TITLE
dump include variables in `--dry-run`

### DIFF
--- a/grizzly/locust.py
+++ b/grizzly/locust.py
@@ -987,6 +987,13 @@ def run(context: Context) -> int:  # noqa: C901, PLR0915, PLR0912
                 runner.send_message('grizzly_worker_quit', None)
 
             if not isinstance(runner, WorkerRunner):
+                for scenario in grizzly.scenarios:
+                    logger.info('? %s:', scenario.name)
+
+                    for variable, value in scenario.variables.items():
+                        if value is None or (isinstance(value, str) and value.lower() == 'none'):
+                            continue
+                        logger.info('  %s = %s', variable, value)
                 runner.quit()
                 return 0
 

--- a/grizzly/locust.py
+++ b/grizzly/locust.py
@@ -988,12 +988,12 @@ def run(context: Context) -> int:  # noqa: C901, PLR0915, PLR0912
 
             if not isinstance(runner, WorkerRunner):
                 for scenario in grizzly.scenarios:
-                    logger.info('? %s:', scenario.name)
+                    logger.info('# %s:', scenario.name)
 
                     for variable, value in scenario.variables.items():
                         if value is None or (isinstance(value, str) and value.lower() == 'none'):
                             continue
-                        logger.info('  %s = %s', variable, value)
+                        logger.info('    %s = %s', variable, value)
                 runner.quit()
                 return 0
 

--- a/grizzly/scenarios/iterator.py
+++ b/grizzly/scenarios/iterator.py
@@ -314,8 +314,8 @@ class IteratorScenario(GrizzlyScenario):
                     gsleep((value / 1000) - pace_correction)
                     response_length = 1
                 else:
-                    self.logger.error('pace falling behind, currently at %d milliseconds', abs(pace_correction * 1000))
-                    message = 'pace falling behind'
+                    self.logger.error('pace falling behind, currently at %d milliseconds expecting %f milliseconds', abs(pace_correction * 1000), value)
+                    message = f'pace falling behind, iteration takes longer than {value} milliseconds'
                     raise RuntimeError(message)
         except Exception as e:
             exception = e

--- a/grizzly/steps/utils.py
+++ b/grizzly/steps/utils.py
@@ -47,4 +47,9 @@ def step_utils_add_orphan_template(context: Context, template: str) -> None:
     """
     grizzly = cast(GrizzlyContext, context.grizzly)
 
-    grizzly.scenario.orphan_templates.append(template)
+    if not context.step.in_background:
+        grizzly.scenario.orphan_templates.append(template)
+    else:
+        for scenario in grizzly.scenarios:
+            scenario.orphan_templates.append(template)
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 license = {text = 'MIT'}
 requires-python = ">=3.9"
 dependencies = [
-    "locust @ git+https://github.com/mgor/locust.git@2.31.3_debug",
+    "locust ==2.31.3",
     "azure-core ==1.30.1",
     "azure-servicebus ==7.12.1",
     "azure-storage-blob ==12.19.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 license = {text = 'MIT'}
 requires-python = ">=3.9"
 dependencies = [
-    "locust ==2.31.3",
+    "locust @ git+https://github.com/mgor/locust.git@2.31.3_debug",
     "azure-core ==1.30.1",
     "azure-servicebus ==7.12.1",
     "azure-storage-blob ==12.19.1",

--- a/tests/e2e/test_iteration_pace.py
+++ b/tests/e2e/test_iteration_pace.py
@@ -78,4 +78,4 @@ def test_e2e_iteration_pace(e2e_fixture: End2EndFixture) -> None:
 
     assert rc == 1
     assert 'HOOK-ERROR in after_feature: RuntimeError: locust test failed' in result
-    assert "1                  PACE 001 RequestTask: RuntimeError('pace falling behind')" in result
+    assert "1                  PACE 001 RequestTask: RuntimeError('pace falling behind, iteration takes longer than 500.0 milliseconds')" in result

--- a/tests/unit/test_grizzly/scenarios/test_iterator.py
+++ b/tests/unit/test_grizzly/scenarios/test_iterator.py
@@ -323,7 +323,7 @@ class TestIterationScenario:
         assert kwargs.get('response_length', None) == 0
         exception = kwargs.get('exception', None)
         assert isinstance(exception, RuntimeError)
-        assert str(exception) == 'pace falling behind'
+        assert str(exception) == 'pace falling behind, iteration takes longer than 500.0 milliseconds'
 
         perf_counter_spy.reset_mock()
         request_spy.reset_mock()
@@ -397,7 +397,7 @@ class TestIterationScenario:
         assert kwargs.get('response_length', None) == 0
         exception = kwargs.get('exception', None)
         assert isinstance(exception, RuntimeError)
-        assert str(exception) == 'pace falling behind'
+        assert str(exception) == 'pace falling behind, iteration takes longer than 500.0 milliseconds'
 
         perf_counter_spy.reset_mock()
         request_spy.reset_mock()

--- a/tests/unit/test_grizzly/steps/test_utils.py
+++ b/tests/unit/test_grizzly/steps/test_utils.py
@@ -21,10 +21,31 @@ def test_step_utils_fail(behave_fixture: BehaveFixture) -> None:
 def test_step_utils_add_orphan_template(behave_fixture: BehaveFixture) -> None:
     behave = behave_fixture.context
     grizzly = behave_fixture.grizzly
-    grizzly.scenarios.create(behave_fixture.create_scenario('test'))
+
+    test_scenario = grizzly.scenarios.create(behave_fixture.create_scenario('test'))
+    grizzly.scenarios.create(behave_fixture.create_scenario('second'))
+    grizzly.scenarios.create(behave_fixture.create_scenario('third'))
+    grizzly.scenarios.select(test_scenario.behave)
+
+    behave_fixture.create_step('test step', in_background=False, context=behave)
 
     assert grizzly.scenario.orphan_templates == []
 
     step_utils_add_orphan_template(behave, '{{ hello world }}')
 
     assert grizzly.scenario.orphan_templates == ['{{ hello world }}']
+
+    for scenario in grizzly.scenarios:
+        if scenario is test_scenario:
+            continue
+
+        assert scenario.orphan_templates == []
+
+    test_scenario.orphan_templates.clear()
+
+    behave_fixture.create_step('test step background', in_background=True, context=behave)
+
+    step_utils_add_orphan_template(behave, '{{ foobar }}')
+
+    for scenario in grizzly.scenarios:
+        assert scenario.orphan_templates == ['{{ foobar }}']


### PR DESCRIPTION
useful to debug what certain pre-run variables will be set to when starting a test.
since some variable values can be templates.

also, if `step_utils_add_orphan_template` is present in the Background-section, the orphan template should be added in all scenarios.