### PR TITLE
register_message with concurrent=True made keystore more robust

### DIFF
--- a/grizzly/locust.py
+++ b/grizzly/locust.py
@@ -1051,7 +1051,7 @@ def run(context: Context) -> int:  # noqa: C901, PLR0915, PLR0912
 
         if not isinstance(runner, WorkerRunner):
             for message_type, callback in message_handlers.items():
-                grizzly.state.locust.register_message(message_type, callback)
+                grizzly.state.locust.register_message(message_type, callback, concurrent=True)
                 logger.info('registered callback for message type "%s"', message_type)
 
             runner.register_message('sig_trap', sig_trap)

--- a/tests/e2e/steps/test_utils.py
+++ b/tests/e2e/steps/test_utils.py
@@ -25,8 +25,8 @@ def test_e2e_step_utils_fail(e2e_fixture: End2EndFixture) -> None:
     assert rc == 1
     assert """Failure summary:
     Scenario: test_e2e_step_utils_fail
-        Then fail # features/test_e2e_step_utils_fail.lock.feature:8
+        Then fail # features/test_e2e_step_utils_fail.lock.feature:9
             ! manually failed""" in result
     assert """0 features passed, 1 failed, 0 skipped
 0 scenarios passed, 1 failed, 0 skipped
-4 steps passed, 1 failed, 0 skipped, 0 undefined""" in result
+5 steps passed, 1 failed, 0 skipped, 0 undefined""" in result

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -815,6 +815,7 @@ def step_start_webserver(context: Context, port: int) -> None:
         add_user_count_step = True
         add_user_type_step = True
         add_spawn_rate_step = True
+        add_iterations_step = True
 
         if background is None:
             background = []
@@ -833,6 +834,9 @@ def step_start_webserver(context: Context, port: int) -> None:
             if re.match(r'(And|Given) spawn rate is "[^"]*" user[s]? per second', step) is not None:
                 add_spawn_rate_step = False
 
+            if re.match(r'And repeat for "[^"]*" iteration[s]?', step) is not None:
+                add_iterations_step = False
+
         if add_user_count_step:
             background.insert(0, 'Given "1" user')
             if add_spawn_rate_step:
@@ -843,6 +847,9 @@ def step_start_webserver(context: Context, port: int) -> None:
 
         if add_spawn_rate_step and not add_user_count_step:
             background.append('Given spawn rate is "1" user per second')
+
+        if add_iterations_step:
+            scenario.insert(1, 'And repeat for "1" iteration')
 
         if self._distributed and not any(step.strip().startswith('Then start webserver on master port') for step in background):
             background.append(f'Then start webserver on master port "{self.webserver.port}"')


### PR DESCRIPTION
Mitigates "Didn't get heartbeat from master in over 180s" error