### PR TITLE
Custom failure handling

### DIFF
--- a/example/features/environment.py
+++ b/example/features/environment.py
@@ -38,4 +38,4 @@ def before_scenario(
     grizzly_before_scenario(context, scenario, *args, **kwargs)
 
     grizzly = cast(GrizzlyContext, context.grizzly)
-    grizzly.scenario.failure_exception = StopUser
+    grizzly.scenario.failure_handling.update({None: StopUser})

--- a/grizzly/context.py
+++ b/grizzly/context.py
@@ -296,7 +296,7 @@ class GrizzlyContextScenario:
     variables: GrizzlyVariables = field(init=False, repr=False, hash=False, default_factory=GrizzlyVariables)
     _tasks: GrizzlyContextTasks = field(init=False, repr=False, hash=False, compare=False)
     validation: GrizzlyContextScenarioValidation = field(init=False, hash=False, compare=False, default_factory=GrizzlyContextScenarioValidation)
-    failure_exception: Optional[type[Exception]] = field(init=False, default=None)
+    failure_handling: dict[type[Exception] | str | None, type[Exception]] = field(init=False, repr=False, hash=False, default_factory=dict)
     orphan_templates: list[str] = field(init=False, repr=False, hash=False, compare=False, default_factory=list)
     _jinja2: Environment = field(init=False, repr=False, default_factory=jinja2_environment_factory)
 

--- a/grizzly/exceptions.py
+++ b/grizzly/exceptions.py
@@ -8,6 +8,7 @@ from locust.exception import StopUser
 from grizzly_extras.exceptions import StopScenario
 
 if TYPE_CHECKING:  # pragma: no cover
+    from grizzly.context import GrizzlyContextScenario
     from grizzly.types.behave import Scenario, Step
 
 
@@ -27,6 +28,7 @@ class ResponseHandlerError(Exception):
 class RestartScenario(Exception):  # noqa: N818
     pass
 
+
 class AssertionErrors(Exception):  # noqa: N818
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -44,6 +46,8 @@ class AssertionErrors(Exception):  # noqa: N818
             error = self.errors[self._index]
             self._index += 1
             return error
+
+        self._index = 0
 
         raise StopIteration
 
@@ -79,3 +83,21 @@ class FeatureError(Exception):
 
     def __str__(self) -> str:
         return f'{self.error!s}'
+
+
+def failure_handler(exception: Exception | None, scenario: GrizzlyContextScenario) -> None:
+    # no failure, just return
+    if exception is None:
+        return
+
+    # always raise StopUser when these unhandled exceptions has occured
+    if isinstance(exception, (NotImplementedError, KeyError, IndexError, AttributeError, TypeError, SyntaxError)):
+        raise StopUser from exception
+
+    # @TODO: loop through and check any error specific exceptions
+
+    # no match, raise the default if it has been set
+    default_exception = scenario.failure_handling.get(None, None)
+
+    if default_exception is not None:
+        raise default_exception from exception

--- a/grizzly/exceptions.py
+++ b/grizzly/exceptions.py
@@ -29,6 +29,10 @@ class RestartScenario(Exception):  # noqa: N818
     pass
 
 
+class RetryTask(Exception):  # noqa: N818
+    pass
+
+
 class AssertionErrors(Exception):  # noqa: N818
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -94,7 +98,13 @@ def failure_handler(exception: Exception | None, scenario: GrizzlyContextScenari
     if isinstance(exception, (NotImplementedError, KeyError, IndexError, AttributeError, TypeError, SyntaxError)):
         raise StopUser from exception
 
-    # @TODO: loop through and check any error specific exceptions
+    # custom actions based on failure
+    for failure_type, failure_action in scenario.failure_handling.items():
+        if failure_type is None:
+            continue
+
+        if (isinstance(failure_type, str) and failure_type in str(exception)) or exception.__class__ is failure_type:
+            raise failure_action from exception
 
     # no match, raise the default if it has been set
     default_exception = scenario.failure_handling.get(None, None)

--- a/grizzly/locust.py
+++ b/grizzly/locust.py
@@ -990,7 +990,7 @@ def run(context: Context) -> int:  # noqa: C901, PLR0915, PLR0912
                 for scenario in grizzly.scenarios:
                     logger.info('# %s:', scenario.name)
 
-                    for variable, value in scenario.variables.items():
+                    for variable, value in dict(sorted(scenario.variables.items())).items():
                         if value is None or (isinstance(value, str) and value.lower() == 'none'):
                             continue
                         logger.info('    %s = %s', variable, value)

--- a/grizzly/steps/scenario/results.py
+++ b/grizzly/steps/scenario/results.py
@@ -32,7 +32,9 @@ def step_results_fail_ratio(context: Context, fail_ratio: int) -> None:
 
     """
     grizzly = cast(GrizzlyContext, context.grizzly)
-    assert grizzly.scenario.failure_exception is None, f"cannot use step 'fail ratio is greater than \"{fail_ratio}\" fail scenario' togheter with 'on failure' steps"
+    assert grizzly.scenario.failure_handling.get(None, None) is None, (
+        f"cannot use step 'fail ratio is greater than \"{fail_ratio}\" fail scenario' togheter with 'on failure' steps"
+    )
     grizzly.scenario.validation.fail_ratio = fail_ratio / 100.0
 
 

--- a/grizzly/steps/scenario/results.py
+++ b/grizzly/steps/scenario/results.py
@@ -33,7 +33,7 @@ def step_results_fail_ratio(context: Context, fail_ratio: int) -> None:
     """
     grizzly = cast(GrizzlyContext, context.grizzly)
     assert grizzly.scenario.failure_handling.get(None, None) is None, (
-        f"cannot use step 'fail ratio is greater than \"{fail_ratio}\" fail scenario' togheter with 'on failure' steps"
+        f"cannot use step 'fail ratio is greater than \"{fail_ratio}\" fail scenario' together with 'on failure' steps"
     )
     grizzly.scenario.validation.fail_ratio = fail_ratio / 100.0
 

--- a/grizzly/steps/scenario/setup.py
+++ b/grizzly/steps/scenario/setup.py
@@ -51,8 +51,8 @@ def parse_failure_type(value: str) -> type[Exception] | str:
 
 register_type(
     IterationGramaticalNumber=parse_iteration_gramatical_number,
-    FailureActionStepExpression=FailureAction.from_step_expression,
     FailureType=parse_failure_type,
+    FailureActionStepExpression=FailureAction.from_string,
 )
 
 

--- a/grizzly/steps/scenario/setup.py
+++ b/grizzly/steps/scenario/setup.py
@@ -151,7 +151,7 @@ def step_setup_stop_user_on_failure(context: Context) -> None:
 
     """
     grizzly = cast(GrizzlyContext, context.grizzly)
-    grizzly.scenario.failure_exception = StopUser
+    grizzly.scenario.failure_handling.update({None: StopUser})
 
 
 @given('restart scenario on failure')
@@ -167,7 +167,7 @@ def step_setup_restart_scenario_on_failure(context: Context) -> None:
 
     """
     grizzly = cast(GrizzlyContext, context.grizzly)
-    grizzly.scenario.failure_exception = RestartScenario
+    grizzly.scenario.failure_handling.update({None: RestartScenario})
 
 
 @then('metadata "{key}" is "{value}"')

--- a/grizzly/tasks/async_group.py
+++ b/grizzly/tasks/async_group.py
@@ -33,6 +33,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 import gevent
 
+from grizzly.exceptions import failure_handler
 from grizzly.types import RequestType
 from grizzly.users import AsyncRequests
 
@@ -66,7 +67,7 @@ class AsyncRequestGroupTask(GrizzlyTaskWrapper):
 
     def __call__(self) -> grizzlytask:  # noqa: C901
         @grizzlytask
-        def task(parent: GrizzlyScenario) -> Any:  # noqa: C901
+        def task(parent: GrizzlyScenario) -> Any:
             if not isinstance(parent.user, AsyncRequests):
                 message = f'{parent.user.__class__.__name__} does not inherit AsyncRequests'
                 raise NotImplementedError(message)  # pragma: no cover
@@ -136,7 +137,6 @@ class AsyncRequestGroupTask(GrizzlyTaskWrapper):
                     exception=exception,
                 )
 
-                if exception is not None and parent.user._scenario.failure_exception is not None:
-                    raise parent.user._scenario.failure_exception from exception
+                failure_handler(exception, parent.user._scenario)
 
         return task

--- a/grizzly/tasks/clients/__init__.py
+++ b/grizzly/tasks/clients/__init__.py
@@ -306,7 +306,8 @@ class ClientTask(GrizzlyMetaRequestTask):
 
             failure_handler(exception, parent.user._scenario)
 
-            parent.logger.warning('%s ignoring %s', self.__class__.__name__, exception)
+            if exception is not None:
+                parent.logger.warning('%s ignoring %s', self.__class__.__name__, exception)
 
 
 class client:

--- a/grizzly/tasks/clients/__init__.py
+++ b/grizzly/tasks/clients/__init__.py
@@ -29,7 +29,7 @@ from time import perf_counter as time
 from typing import TYPE_CHECKING, Any, ClassVar, Optional, cast, final
 from urllib.parse import unquote, urlparse
 
-from grizzly.exceptions import StopScenario
+from grizzly.exceptions import StopScenario, failure_handler
 from grizzly.tasks import GrizzlyMetaRequestTask, grizzlytask, template
 from grizzly.testdata.utils import resolve_variable
 from grizzly.types import GrizzlyResponse, RequestDirection, RequestMethod, RequestType
@@ -304,10 +304,9 @@ class ClientTask(GrizzlyMetaRequestTask):
 
                 log_file.write_text(jsondumps(request_log, indent=2))
 
-            if exception is not None and parent.user._scenario.failure_exception is not None:
-                raise parent.user._scenario.failure_exception
-            elif exception is not None:
-                parent.logger.warning('%s ignoring %s', self.__class__.__name__, exception)
+            failure_handler(exception, parent.user._scenario)
+
+            parent.logger.warning('%s ignoring %s', self.__class__.__name__, exception)
 
 
 class client:

--- a/grizzly/tasks/conditional.py
+++ b/grizzly/tasks/conditional.py
@@ -37,7 +37,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from gevent import sleep as gsleep
 
-from grizzly.exceptions import RestartScenario, StopUser
+from grizzly.exceptions import RestartScenario, StopUser, failure_handler
 
 from . import GrizzlyTask, GrizzlyTaskWrapper, grizzlytask, template
 
@@ -142,8 +142,7 @@ class ConditionalTask(GrizzlyTaskWrapper):
                     stats = parent.user.environment.stats.get(name, 'COND')
                     stats.log_error(None)
 
-                if exception is not None and parent.user._scenario.failure_exception is not None:
-                    raise parent.user._scenario.failure_exception from exception
+                failure_handler(exception, parent.user._scenario)
 
         @task.on_start
         def on_start(parent: GrizzlyScenario) -> None:

--- a/grizzly/tasks/keystore.py
+++ b/grizzly/tasks/keystore.py
@@ -35,6 +35,8 @@ from json import dumps as jsondumps
 from json import loads as jsonloads
 from typing import TYPE_CHECKING, Any, Literal, cast, get_args
 
+from grizzly.exceptions import failure_handler
+
 from . import GrizzlyTask, grizzlytask, template
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -72,7 +74,7 @@ class KeystoreTask(GrizzlyTask):
 
     def __call__(self) -> grizzlytask:
         @grizzlytask
-        def task(parent: GrizzlyScenario) -> Any:  # noqa: PLR0912
+        def task(parent: GrizzlyScenario) -> Any:
             key = parent.user.render(self.key)
 
             try:
@@ -120,7 +122,6 @@ class KeystoreTask(GrizzlyTask):
                     exception=e,
                 )
 
-                if parent.user._scenario.failure_exception is not None:
-                    raise parent.user._scenario.failure_exception from e
+                failure_handler(e, parent.user._scenario)
 
         return task

--- a/grizzly/tasks/transformer.py
+++ b/grizzly/tasks/transformer.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 from time import perf_counter
 from typing import TYPE_CHECKING, Any, Callable
 
+from grizzly.exceptions import failure_handler
 from grizzly_extras.transformer import Transformer, TransformerContentType, TransformerError, transformer
 
 from . import GrizzlyTask, grizzlytask, template
@@ -115,7 +116,6 @@ class TransformerTask(GrizzlyTask):
                     exception=exception,
                 )
 
-                if exception is not None and parent.user._scenario.failure_exception is not None:
-                    raise parent.user._scenario.failure_exception from exception
+                failure_handler(exception, parent.user._scenario)
 
         return task

--- a/grizzly/testdata/utils.py
+++ b/grizzly/testdata/utils.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Optional, cast
 
 from jinja2.meta import find_undeclared_variables
 
+from grizzly.exceptions import failure_handler
 from grizzly.testdata.ast import get_template_variables
 from grizzly.utils import has_template, is_file, merge_dicts, unflatten
 
@@ -78,8 +79,7 @@ def transform(scenario: GrizzlyContextScenario, data: dict[str, Any], *, objecti
                 except Exception as e:
                     logger.exception('failed to get value from variable instance')
 
-                    if scenario.failure_exception is not None:
-                        raise scenario.failure_exception from e
+                    failure_handler(e, scenario)
 
             paths: list[str] = key.split('.')
             variable = paths.pop(0)

--- a/grizzly/types/__init__.py
+++ b/grizzly/types/__init__.py
@@ -8,8 +8,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from locust.rpc.protocol import Message
 from typing_extensions import Concatenate, ParamSpec
 
-P = ParamSpec('P')
-
+from grizzly.exceptions import RestartScenario, RetryTask, StopUser
 from grizzly_extras.text import PermutationEnum
 
 from .locust import Environment
@@ -23,6 +22,9 @@ try:
     import pymqi
 except:
     from grizzly_extras import dummy_pymqi as pymqi
+
+
+P = ParamSpec('P')
 
 
 __all__ = [
@@ -68,6 +70,46 @@ class ResponseTarget(PermutationEnum):
         except KeyError as e:
             message = f'"{value.upper()}" is not a valid value of {cls.__name__}'
             raise AssertionError(message) from e
+
+
+class FailureAction(PermutationEnum):
+    __vector__ = (False, True)
+
+    STOP_USER = (StopUser, 'stop user', True)
+    RESTART_SCENARIO = (RestartScenario, 'restart scenario', True)
+    RETRY_TASK = (RetryTask, 'retry task', False)
+
+    step_expression: str
+    exception: type[Exception]
+    default_friendly: bool
+
+    def __new__(cls, exception: type[Exception], step_exression: str, default_friendly: bool) -> Self:  # noqa: FBT001
+        obj = object.__new__(cls)
+        obj._value_ = exception
+        obj.step_expression = step_exression
+        obj.exception = exception
+        obj.default_friendly = default_friendly
+
+        return obj
+
+    @classmethod
+    def from_step_expression(cls, value: str) -> FailureAction:
+        """Convert string value to enum value."""
+        for enum in FailureAction:
+            if enum.step_expression == value:
+                return enum
+
+        message = f'"{value}" is not a mapped step expression'
+        raise AssertionError(message)
+
+    @classmethod
+    def from_exception(cls, value: type[Exception]) -> FailureAction:
+        for enum in FailureAction:
+            if enum.exception is value:
+                return enum
+
+        message = f'"{value}" is not a mapped exception'
+        raise AssertionError(message)
 
 
 class ResponseAction(Enum):

--- a/grizzly/types/__init__.py
+++ b/grizzly/types/__init__.py
@@ -93,7 +93,7 @@ class FailureAction(PermutationEnum):
         return obj
 
     @classmethod
-    def from_step_expression(cls, value: str) -> FailureAction:
+    def from_string(cls, value: str) -> FailureAction:
         """Convert string value to enum value."""
         for enum in FailureAction:
             if enum.step_expression == value:
@@ -101,6 +101,10 @@ class FailureAction(PermutationEnum):
 
         message = f'"{value}" is not a mapped step expression'
         raise AssertionError(message)
+
+    @classmethod
+    def from_step_expression(cls, value: str) -> FailureAction:
+        return cls.from_string(value)
 
     @classmethod
     def from_exception(cls, value: type[Exception]) -> FailureAction:

--- a/grizzly/users/__init__.py
+++ b/grizzly/users/__init__.py
@@ -32,7 +32,7 @@ from locust.user.users import User, UserMeta
 
 from grizzly.context import GrizzlyContext
 from grizzly.events import GrizzlyEventHook, RequestLogger, ResponseHandler
-from grizzly.exceptions import RestartScenario, StopScenario
+from grizzly.exceptions import RestartScenario, StopScenario, failure_handler
 from grizzly.testdata import GrizzlyVariables
 from grizzly.types import GrizzlyResponse, RequestType, ScenarioState
 from grizzly.types.locust import Environment, StopUser
@@ -255,12 +255,7 @@ class GrizzlyUser(User, metaclass=GrizzlyUserMeta):
             )
 
         # ...request handled
-        if exception is not None:
-            if isinstance(exception, (NotImplementedError, KeyError, IndexError, AttributeError, TypeError, SyntaxError)):
-                raise StopUser
-
-            if self._scenario.failure_exception is not None:
-                raise self._scenario.failure_exception
+        failure_handler(exception, self._scenario)
 
         return (metadata, payload)
 

--- a/grizzly/users/servicebus.py
+++ b/grizzly/users/servicebus.py
@@ -279,7 +279,7 @@ class ServiceBusUser(GrizzlyUser):
             'context': request_context,
         }
 
-        with self.request_context(task, request) as context:
+        with self.request_context(task, request):
             if 'queue' not in arguments and 'topic' not in arguments:
                 message = 'endpoint needs to be prefixed with queue: or topic:'
                 raise RuntimeError(message)
@@ -308,8 +308,6 @@ class ServiceBusUser(GrizzlyUser):
             if task.method.direction == RequestDirection.TO and arguments.get('expression', None) is not None:
                 message = 'argument expression is only allowed when receiving messages'
                 raise RuntimeError(message)
-
-            context['failure_exception'] = self._scenario.failure_exception
 
         self.hellos.add(description)
 

--- a/grizzly_extras/async_message/sb.py
+++ b/grizzly_extras/async_message/sb.py
@@ -708,7 +708,12 @@ class AsyncServiceBusHandler(AsyncMessageHandler):
 
                     break
                 except (ServiceBusError, ValueError) as e:
-                    if any(msg in str(e) for msg in ['Connection to remote host was lost', 'socket is already closed', 'handler has already been shutdown']):
+                    if any(msg in str(e) for msg in [
+                        'Connection to remote host was lost',
+                        'socket is already closed',
+                        'handler has already been shutdown',
+                        'Authentication attempt timed-out',
+                    ]):
                         if retry < 3 and not self._event.is_set():
                             self.logger.warning('connection unexpectedly closed, reconnecting', exc_info=True)
                             self._hello(request, force=True)

--- a/tests/e2e/steps/scenario/test_response.py
+++ b/tests/e2e/steps/scenario/test_response.py
@@ -257,7 +257,7 @@ def test_e2e_step_response_validate(e2e_fixture: End2EndFixture) -> None:
 
             assert len(grizzly.scenario.orphan_templates) == 0, 'unexpected number of orphan templates'
 
-            assert grizzly.scenario.failure_exception is None
+            assert grizzly.scenario.failure_handling.get(None, None) is None
 
             request = grizzly.scenario.tasks()[index]
 

--- a/tests/e2e/steps/scenario/test_setup.py
+++ b/tests/e2e/steps/scenario/test_setup.py
@@ -221,8 +221,8 @@ def test_e2e_step_setup_stop_user_on_failure(e2e_fixture: End2EndFixture) -> Non
         from grizzly.types.locust import StopUser
         grizzly = cast(GrizzlyContext, context.grizzly)
 
-        assert grizzly.scenario.failure_exception is not None
-        assert isinstance(grizzly.scenario.failure_exception(), StopUser), 'failure exception is not StopUser'
+        assert grizzly.scenario.failure_handling.get(None, None) is not None
+        assert isinstance(grizzly.scenario.failure_handling.get(None, RuntimeError)(), StopUser), 'failure exception is not StopUser'
 
     e2e_fixture.add_validator(validate_stop_user_on_failure)
 
@@ -242,8 +242,8 @@ def test_e2e_step_setup_restart_scenario_on_failure(e2e_fixture: End2EndFixture)
         from grizzly.exceptions import RestartScenario
         grizzly = cast(GrizzlyContext, context.grizzly)
 
-        assert grizzly.scenario.failure_exception is not None
-        assert isinstance(grizzly.scenario.failure_exception(), RestartScenario), 'failure exception is not RestartScenario'
+        assert grizzly.scenario.failure_handling.get(None, None) is not None
+        assert isinstance(grizzly.scenario.failure_handling.get(None, RuntimeError)(), RestartScenario), 'failure exception is not RestartScenario'
 
     e2e_fixture.add_validator(validate_restart_scenario_on_failure)
 

--- a/tests/e2e/test_failure.py
+++ b/tests/e2e/test_failure.py
@@ -58,7 +58,7 @@ def test_e2e_scenario_failure_handling(e2e_fixture: End2EndFixture) -> None:
     Scenario: stop user
         Given a user of type "RestApi" load testing "http://{e2e_fixture.host}"
         And repeat for "2" iterations
-        And stop user on failure
+        When a task fails stop user
         Then get request with name "stop-get1" from endpoint "/api/echo"
         Then get request with name "stop-get2" from endpoint "/api/until/hello?nth=2&wrong=foobar&right=world | content_type=json"
         When response payload "$.hello" is not "world" fail request
@@ -67,7 +67,7 @@ def test_e2e_scenario_failure_handling(e2e_fixture: End2EndFixture) -> None:
     Scenario: restart scenario
         Given a user of type "RestApi" load testing "http://{e2e_fixture.host}"
         And repeat for "2" iterations
-        And restart scenario on failure
+        When a task fails restart scenario
         Then get request with name "restart-get1" from endpoint "/api/echo"
         Then get request with name "restart-get2" from endpoint "/api/until/hello?nth=2&wrong=foobar&right=world | content_type=json"
         When response payload "$.hello" is not "world" fail request
@@ -114,7 +114,7 @@ def test_e2e_behave_failure(e2e_fixture: End2EndFixture) -> None:
     Scenario: fails 1
         Given a user of type "RestApi" load testing "http://{e2e_fixture.host}"
         And repeat for "2" iterations
-        And stop user on failure
+        When a task fails stop user
         Then get request with name "{{{{ get1 }}}}" from endpoint "/api/echo"
         Then get request with name "get2" from endpoint "/api/until/hello?nth=2&wrong=foobar&right=world | content_type=json"
         Then save response payload "$.hello.world" in variable "var1"
@@ -125,7 +125,7 @@ def test_e2e_behave_failure(e2e_fixture: End2EndFixture) -> None:
     Scenario: fails 2
         Given a user of type "RestApi" load testing "http://{e2e_fixture.host}"
         And repeat for "2" iterations
-        And restart scenario on failure
+        When a task fails restart scenario
         Then get request with name "get1" from endpoint "/api/echo"
         Then save response metadata "$.Content-Type" in variable "var2"
         Then get request with name "{{{{ get2 }}}}" from endpoint "/api/until/hello?nth=2&wrong=foobar&right=world | content_type=json"
@@ -160,3 +160,89 @@ def test_e2e_behave_failure(e2e_fixture: End2EndFixture) -> None:
             ! variable "var2" has not been declared
 
 Started : """ in result
+
+
+def test_e2e_scenario_failure_handling_retry_task(e2e_fixture: End2EndFixture) -> None:
+    def after_feature(context: Context, *_args: Any, **_kwargs: Any) -> None:
+        from grizzly.locust import on_master
+        if on_master(context):
+            return
+
+        grizzly = cast(GrizzlyContext, context.grizzly)
+
+        stats = grizzly.state.locust.environment.stats
+
+        expectations = [
+            # failure exception is StopUser, abort user/scenario when there's a failure
+            ('001 stop user', 'SCEN', 1, 1),
+            ('001 stop user', 'TSTD', 0, 1),
+            ('001 stop-get1', 'GET', 0, 1),
+            ('001 stop-get2', 'GET', 1, 1),
+            # failure exception is RestartScenario, do not run steps after the failing step, restart from task 0
+            ('002 restart scenario', 'SCEN', 0, 2),
+            ('002 restart scenario', 'TSTD', 0, 2),
+            ('002 restart-get1', 'GET', 0, 2),
+            ('002 restart-get2', 'GET', 2, 4),
+            ('002 restart-get3', 'GET', 0, 2),
+            # failure exception is None, just continue
+            ('003 default', 'SCEN', 1, 2),
+            ('003 default', 'TSTD', 0, 2),
+            ('003 default-get1', 'GET', 0, 2),
+            ('003 default-get2', 'GET', 1, 2),
+            ('003 default-get3', 'GET', 0, 1),
+        ]
+
+        for name, method, expected_num_failures, expected_num_requests in expectations:
+            stat = stats.get(name, method)
+            assert stat.num_failures == expected_num_failures, f'{stat.method}:{stat.name}.num_failures: {stat.num_failures} != {expected_num_failures}'
+            assert stat.num_requests == expected_num_requests, f'{stat.method}:{stat.name}.num_requests: {stat.num_requests} != {expected_num_requests}'
+
+    e2e_fixture.add_after_feature(after_feature)
+
+    start_webserver_step = f'Then start webserver on master port "{e2e_fixture.webserver.port}"\n' if e2e_fixture._distributed else ''
+
+    feature_file = e2e_fixture.create_feature(dedent(f"""Feature: test scenario failure handling
+    Background: common configuration
+        Given "3" users
+        And spawn rate is "3" user per second
+        {start_webserver_step}
+    Scenario: stop user
+        Given a user of type "RestApi" load testing "http://{e2e_fixture.host}"
+        And repeat for "2" iterations
+        When a task fails stop user
+        When a task fails with "504 not in [200]" stop user
+        Then get request with name "stop-get1" from endpoint "/api/echo"
+        Then get request with name "stop-get2" from endpoint "/api/until/hello?nth=2&wrong=504&right=200 | content_type=json"
+        Then get request with name "stop-get3" from endpoint "/api/echo"
+
+    Scenario: restart scenario
+        Given a user of type "RestApi" load testing "http://{e2e_fixture.host}"
+        And repeat for "2" iterations
+        When a task fails restart scenario
+        When a task fails with "504 not in [200]" retry task
+        Then get request with name "restart-get1" from endpoint "/api/echo"
+        Then get request with name "restart-get2" from endpoint "/api/until/hello?nth=2&wrong=504&right=200 | content_type=json"
+        Then get request with name "restart-get3" from endpoint "/api/echo"
+
+    Scenario: default
+        Given a user of type "RestApi" load testing "http://{e2e_fixture.host}"
+        And repeat for "2" iterations
+        When a task fails with "504 not in [200]" restart scenario
+        Then get request with name "default-get1" from endpoint "/api/echo"
+        Then get request with name "default-get2" from endpoint "/api/until/hello?nth=2&wrong=504&right=200 | content_type=json"
+        Then get request with name "default-get3" from endpoint "/api/echo"
+    """))
+
+    log_files = list((e2e_fixture.root / 'features' / 'logs').glob('*.log'))
+
+    for log_file in log_files:
+        log_file.unlink()
+
+    rc, output = e2e_fixture.execute(feature_file)
+
+    assert rc == 1
+    assert "HOOK-ERROR in after_feature: RuntimeError: locust test failed" in ''.join(output)
+
+    log_files = list((e2e_fixture.root / 'features' / 'logs').glob('*.log'))
+
+    assert len(log_files) == 4

--- a/tests/unit/test_grizzly/scenarios/test_iterator.py
+++ b/tests/unit/test_grizzly/scenarios/test_iterator.py
@@ -13,7 +13,7 @@ from locust.exception import InterruptTaskSet, RescheduleTask, RescheduleTaskImm
 from locust.user.sequential_taskset import SequentialTaskSet
 from locust.user.task import LOCUST_STATE_RUNNING, LOCUST_STATE_STOPPING
 
-from grizzly.exceptions import RestartScenario, StopScenario
+from grizzly.exceptions import RestartScenario, RetryTask, StopScenario
 from grizzly.scenarios import IteratorScenario
 from grizzly.tasks import ExplicitWaitTask, LogMessageTask, grizzlytask
 from grizzly.testdata.communication import TestdataConsumer
@@ -781,6 +781,125 @@ class TestIterationScenario:
             ]
 
             actual_messages = [message for message in caplog.messages if 'instance variable=' not in message]
+
+            assert len(actual_messages) == len(expected_messages)
+
+            for actual, _expected in zip(actual_messages, expected_messages):
+                expected = regex.possible(_expected)
+                assert actual == expected
+
+        finally:
+            with suppress(KeyError):
+                del environ['TESTDATA_PRODUCER_ADDRESS']
+
+    def test_run_retry_task(self, grizzly_fixture: GrizzlyFixture, caplog: LogCaptureFixture, mocker: MockerFixture) -> None:
+        class TestErrorTask(TestTask):
+            def __call__(self) -> grizzlytask:
+                self.call_count += 1
+                self.task_call_count = 0
+
+                @grizzlytask
+                def task(parent: GrizzlyScenario) -> Any:  # noqa: ARG001
+                    self.task_call_count += 1
+
+                    # second time, always raise RetryTask
+                    if self.task_call_count < 3 or self.task_call_count > 3:
+                        raise RetryTask
+
+                return task
+
+        parent = grizzly_fixture(scenario_type=IteratorScenario)
+
+        assert isinstance(parent, IteratorScenario)
+
+        mocker.patch('grizzly.scenarios.iterator.gsleep', return_value=None)
+        mocker.patch('grizzly.scenarios.iterator.uniform', return_value=1.0)
+        parent.grizzly.state.spawning_complete = True
+
+        # add tasks to IteratorScenario.tasks
+        try:
+            for i in range(1, 6):
+                name = f'test-task-{i}'
+                parent.user._scenario.tasks.behave_steps.update({i + 1: name})
+                parent.__class__.populate(TestTask(name=name))
+
+            parent.__class__.populate(TestErrorTask(name='test-error-task-1'))
+            parent.user._scenario.tasks.behave_steps.update({7: 'test-error-task-1'})
+
+            for i in range(6, 11):
+                name = f'test-task-{i}'
+                parent.user._scenario.tasks.behave_steps.update({i + 2: name})
+                parent.__class__.populate(TestTask(name=name))
+
+            scenario = parent.__class__(parent.user)
+            scenario.__class__.pace_time = '10000'
+            mocker.patch.object(scenario, 'prefetch', return_value=None)
+            parent.user._scenario.failure_handling.update({None: StopUser})
+
+            assert parent.task_count == 13
+            assert len(parent.tasks) == 13
+
+            mocker.patch('grizzly.scenarios.TestdataConsumer.__init__', return_value=None)
+            mocker.patch('grizzly.scenarios.TestdataConsumer.stop', return_value=None)
+
+            environ['TESTDATA_PRODUCER_ADDRESS'] = 'tcp://localhost:5555'
+
+            scenario.on_start()  # create scenario.consumer, so we can patch request below
+
+            # same as 1 iteration
+            mocker.patch.object(scenario.consumer, 'testdata', side_effect=[
+                {'variables': {'hello': 'world'}},
+                {'variables': {'foo': 'bar'}},
+                None,
+            ])
+            mocker.patch.object(scenario, 'on_start', return_value=None)
+
+            with caplog.at_level(logging.DEBUG), pytest.raises(StopUser):
+                scenario.run()
+
+            expected_messages = [
+                'task 1 of 13 executed: iterator',  # IteratorScenario.iterator()
+                'task 2 of 13 executed: test-task-1',
+                'task 3 of 13 executed: test-task-2',
+                'task 4 of 13 executed: test-task-3',
+                'task 5 of 13 executed: test-task-4',
+                'task 6 of 13 executed: test-task-5',
+                'task 7 of 13 failed: test-error-task-1',
+                'task 7 of 13 will execute a 2nd time in 1.00 seconds: test-error-task-1',
+                'task 7 of 13 failed: test-error-task-1',
+                'task 7 of 13 will execute a 3rd time in 2.00 seconds: test-error-task-1',
+                'task 7 of 13 executed: test-error-task-1',
+                'task 8 of 13 executed: test-task-6',
+                'task 9 of 13 executed: test-task-7',
+                'task 10 of 13 executed: test-task-8',
+                'task 11 of 13 executed: test-task-9',
+                'task 12 of 13 executed: test-task-10',
+                r'^keeping pace by sleeping [0-9\.]+ milliseconds$',
+                'task 13 of 13 executed: pace',
+                'task 1 of 13 executed: iterator',  # IteratorScenario.iterator()
+                'task 2 of 13 executed: test-task-1',
+                'task 3 of 13 executed: test-task-2',
+                'task 4 of 13 executed: test-task-3',
+                'task 5 of 13 executed: test-task-4',
+                'task 6 of 13 executed: test-task-5',
+                'task 7 of 13 failed: test-error-task-1',
+                'task 7 of 13 will execute a 2nd time in 1.00 seconds: test-error-task-1',
+                'task 7 of 13 failed: test-error-task-1',
+                'task 7 of 13 will execute a 3rd time in 2.00 seconds: test-error-task-1',
+                'task 7 of 13 failed: test-error-task-1',
+                'task 7 of 13 failed after 3 retries: test-error-task-1',
+                'scenario_state=RUNNING, user_state=running, exception=StopUser()',
+                'scenario state=ScenarioState.RUNNING -> ScenarioState.STOPPED',
+                "stopping scenario with <class 'locust.exception.StopUser'>",
+            ]
+
+            actual_messages = [
+                message for message in caplog.messages
+                    if 'instance variable=' not in message
+            ]
+
+            for m in actual_messages:
+                print(f'{m=}')
 
             assert len(actual_messages) == len(expected_messages)
 

--- a/tests/unit/test_grizzly/scenarios/test_iterator.py
+++ b/tests/unit/test_grizzly/scenarios/test_iterator.py
@@ -49,7 +49,7 @@ class TestIterationScenario:
         assert len(parent.tasks) == 3
 
         task_method = parent.tasks[-2]
-        parent.user._scenario.failure_exception = StopUser
+        parent.user._scenario.failure_handling.update({None: StopUser})
 
         assert callable(task_method)
         with pytest.raises(StopUser):

--- a/tests/unit/test_grizzly/steps/background/test_setup.py
+++ b/tests/unit/test_grizzly/steps/background/test_setup.py
@@ -120,11 +120,11 @@ def test_step_setup_stop_user_on_failure(behave_fixture: BehaveFixture) -> None:
     grizzly = cast(GrizzlyContext, behave.grizzly)
     grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
-    assert grizzly.scenario.failure_exception is None
+    assert grizzly.scenario.failure_handling.get(None, None) is None
 
     step_setup_stop_user_on_failure(behave)
 
-    assert grizzly.scenario.failure_exception == StopUser
+    assert isinstance(grizzly.scenario.failure_handling.get(None, RuntimeError)(), StopUser)
 
 
 def test_step_setup_restart_scenario_on_failure(behave_fixture: BehaveFixture) -> None:
@@ -133,12 +133,12 @@ def test_step_setup_restart_scenario_on_failure(behave_fixture: BehaveFixture) -
     grizzly.scenarios.create(behave_fixture.create_scenario('test scenario'))
 
     assert not behave.config.stop
-    assert grizzly.scenario.failure_exception is None
+    assert grizzly.scenario.failure_handling.get(None, None) is None
 
     step_setup_restart_scenario_on_failure(behave)
 
     assert not behave.config.stop
-    assert grizzly.scenario.failure_exception == RestartScenario
+    assert isinstance(grizzly.scenario.failure_handling.get(None, RuntimeError)(), RestartScenario)
 
 
 def test_step_setup_log_level(behave_fixture: BehaveFixture) -> None:

--- a/tests/unit/test_grizzly/tasks/clients/test___init__.py
+++ b/tests/unit/test_grizzly/tasks/clients/test___init__.py
@@ -56,14 +56,14 @@ def test_task_failing(grizzly_fixture: GrizzlyFixture, mocker: MockerFixture, ca
         task = task_factory()
 
         assert task_factory._context.get('test', None) is None
-        parent.user._scenario.failure_exception = StopUser
+        parent.user._scenario.failure_handling.update({None: StopUser})
 
         with pytest.raises(StopUser):
             task(parent)
 
         assert task_factory._context.get('test', None) == 'was here'
 
-        parent.user._scenario.failure_exception = RestartScenario
+        parent.user._scenario.failure_handling.update({None: RestartScenario})
         parent.user._context.update({'test': 'is here', 'foo': 'bar'})
 
         assert task_factory._context.get('foo', None) is None
@@ -74,7 +74,7 @@ def test_task_failing(grizzly_fixture: GrizzlyFixture, mocker: MockerFixture, ca
         assert parent.user._context.get('test', None) == 'is here'
         assert parent.user._context.get('foo', None) == 'bar'
 
-        parent.user._scenario.failure_exception = None
+        del parent.user._scenario.failure_handling[None]
 
         task(parent)
 
@@ -82,7 +82,7 @@ def test_task_failing(grizzly_fixture: GrizzlyFixture, mocker: MockerFixture, ca
         mocker.patch.object(parent, 'on_start', return_value=None)
         mocker.patch.object(parent, 'wait', side_effect=[NotImplementedError, NotImplementedError])
         parent.user.environment.catch_exceptions = True
-        parent.user._scenario.failure_exception = RestartScenario
+        parent.user._scenario.failure_handling.update({None: RestartScenario})
 
         parent.tasks.clear()
         parent._task_queue.clear()

--- a/tests/unit/test_grizzly/tasks/clients/test_http.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_http.py
@@ -181,13 +181,13 @@ class TestHttpClientTask:
 
             assert len(list(task_factory.log_dir.rglob('**/*'))) == 2
 
-            parent.user._scenario.failure_exception = StopUser
+            parent.user._scenario.failure_handling.update({None: StopUser})
             task_factory.name = 'test-3'
 
             with pytest.raises(StopUser):
                 task(parent)
 
-            parent.user._scenario.failure_exception = RestartScenario
+            parent.user._scenario.failure_handling.update({None: RestartScenario})
             task_factory.name = 'test-4'
 
             requests_get_spy.reset_mock()
@@ -214,7 +214,8 @@ class TestHttpClientTask:
             request_fire_spy.reset_mock()
             assert len(list(task_factory.log_dir.rglob('**/*'))) == 4
 
-            parent.user._scenario.failure_exception = None
+            with suppress(KeyError):
+                del parent.user._scenario.failure_handling[None]
 
             task_factory = test_cls(RequestDirection.FROM, 'http://example.org', 'http-get', payload_variable='test')
             task = task_factory()
@@ -406,7 +407,9 @@ class TestHttpClientTask:
         )
         request_fire_spy.reset_mock()
 
-        grizzly.scenario.failure_exception = None
+        with suppress(KeyError):
+            del grizzly.scenario.failure_handling[None]
+
         response.status_code = 500
         response.headers = CaseInsensitiveDict({'x-foo-bar': 'test'})
         requests_request_spy.return_value = response

--- a/tests/unit/test_grizzly/tasks/clients/test_messagequeue.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_messagequeue.py
@@ -583,7 +583,7 @@ class TestMessageQueueClientTask:
             fire_spy.reset_mock()
 
             async_message_request_mock = mocker.patch('grizzly.tasks.clients.messagequeue.async_message_request', side_effect=[AsyncMessageError('oooh nooo')])
-            parent.user._scenario.failure_exception = RestartScenario
+            parent.user._scenario.failure_handling.update({None: RestartScenario})
 
             log_error_mock = mocker.patch.object(parent.stats, 'log_error')
             mocker.patch.object(parent, 'on_start', return_value=None)

--- a/tests/unit/test_grizzly/tasks/clients/test_messagequeue.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_messagequeue.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 class TestMessageQueueClientTaskNoPymqi:
-    @pytest.mark.timeout(20)
+    @pytest.mark.timeout(40)
     def test_no_pymqi_dependencies(self) -> None:
         env = environ.copy()
         with suppress(KeyError):
@@ -37,24 +37,21 @@ class TestMessageQueueClientTaskNoPymqi:
 
         env['PYTHONPATH'] = '.'
 
-        process = subprocess.Popen(
-            [
-                sys.executable,
-                '-c',
-                (
-                    'from grizzly.types import RequestDirection; import grizzly.tasks.clients.messagequeue as mq; '
-                    'print(f"{mq.pymqi.__name__=}"); mq.MessageQueueClientTask(RequestDirection.FROM, "mqs://localhost:1");'
-                ),
-            ],
-            env=env,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-        )
-
-        out, _ = process.communicate()
-        output = out.decode()
-
-        assert process.returncode == 1
+        with pytest.raises(subprocess.CalledProcessError) as e:
+            subprocess.check_output(
+                [
+                    sys.executable,
+                    '-c',
+                    (
+                        'from grizzly.types import RequestDirection; import grizzly.tasks.clients.messagequeue as mq; '
+                        'print(f"{mq.pymqi.__name__=}"); mq.MessageQueueClientTask(RequestDirection.FROM, "mqs://localhost:1");'
+                    ),
+                ],
+                env=env,
+                stderr=subprocess.STDOUT,
+            )
+        assert e.value.returncode == 1
+        output = e.value.output.decode()
         assert "mq.pymqi.__name__='grizzly_extras.dummy_pymqi'" in output
         assert 'NotImplementedError: MessageQueueClientTask could not import pymqi, have you installed IBM MQ dependencies and set environment variable LD_LIBRARY_PATH?' in output
 

--- a/tests/unit/test_grizzly/tasks/test_async_group.py
+++ b/tests/unit/test_grizzly/tasks/test_async_group.py
@@ -157,7 +157,7 @@ class TestAsyncRequestGroup:
 
         # exception before spawning greenlets, with a scenario failure exception
         joinall_mock.side_effect = [RuntimeError]
-        parent.user._scenario.failure_exception = RestartScenario
+        parent.user._scenario.failure_handling.update({None: RestartScenario})
 
         with pytest.raises(RestartScenario):
             task(parent)
@@ -167,7 +167,7 @@ class TestAsyncRequestGroup:
         spawn_mock.reset_mock()
         try:
             environ['GEVENT_MONITOR_THREAD_ENABLE'] = 'true'
-            parent.user._scenario.failure_exception = StopUser
+            parent.user._scenario.failure_handling.update({None: StopUser})
 
             with caplog.at_level(logging.DEBUG), pytest.raises(StopUser):
                     task(parent)

--- a/tests/unit/test_grizzly/tasks/test_conditional.py
+++ b/tests/unit/test_grizzly/tasks/test_conditional.py
@@ -1,6 +1,7 @@
 """Unit tests of grizzly.tasks.conditional."""
 from __future__ import annotations
 
+from contextlib import suppress
 from typing import TYPE_CHECKING, Any, cast
 
 import pytest
@@ -167,7 +168,7 @@ class TestConditionalTask:
 
         # invalid condition, RestartScenario scenario.failure_exception
         parent.user.set_variable('value', 'foobar')
-        scenario_context.failure_exception = RestartScenario
+        scenario_context.failure_handling.update({None: RestartScenario})
 
         with pytest.raises(RestartScenario):
             task(parent)
@@ -182,7 +183,8 @@ class TestConditionalTask:
         )
         request_spy.reset_mock()
 
-        scenario_context.failure_exception = None  # reset
+        with suppress(KeyError):
+            del scenario_context.failure_handling[None]  # reset
 
         # true condition
         task_factory.condition = '{{ value | int > 0 }}'

--- a/tests/unit/test_grizzly/tasks/test_keystore.py
+++ b/tests/unit/test_grizzly/tasks/test_keystore.py
@@ -72,7 +72,7 @@ class TestKeystoreTask:
         task_factory = KeystoreTask('foobar', 'get', 'foobar')
         task = task_factory()
 
-        parent.user._scenario.failure_exception = RestartScenario
+        parent.user._scenario.failure_handling.update({None: RestartScenario})
 
         with pytest.raises(RestartScenario):
             task(parent)

--- a/tests/unit/test_grizzly/tasks/test_loop.py
+++ b/tests/unit/test_grizzly/tasks/test_loop.py
@@ -206,7 +206,7 @@ class TestLoopTask:
 
         # not a valid json input
         task_factory.values = '"hello'
-        scenario_context.failure_exception = RestartScenario
+        scenario_context.failure_handling.update({None: RestartScenario})
 
         task = task_factory()
 
@@ -228,7 +228,7 @@ class TestLoopTask:
 
         task = task_factory()
 
-        with pytest.raises(RestartScenario):
+        with pytest.raises(StopUser):
             task(parent)
 
         request_spy.assert_called_once_with(
@@ -271,7 +271,7 @@ class TestLoopTask:
 
         # wrapped task throws scenario.failure_exception
         for failure_exception in [RestartScenario, StopUser]:
-            scenario_context.failure_exception = failure_exception
+            scenario_context.failure_handling.update({None: failure_exception})
             task_factory.tasks = []
             task_factory.add(TestExceptionTask(failure_exception))
 

--- a/tests/unit/test_grizzly/tasks/test_transformer.py
+++ b/tests/unit/test_grizzly/tasks/test_transformer.py
@@ -1,6 +1,7 @@
 """Unit tests for grizzly.tasks.transformer."""
 from __future__ import annotations
 
+from contextlib import suppress
 from json import dumps as jsondumps
 from typing import TYPE_CHECKING
 
@@ -152,7 +153,7 @@ class TestTransformerTask:
             }),
         )
         task = task_factory()
-        parent.user._scenario.failure_exception = RestartScenario
+        parent.user._scenario.failure_handling.update({None: RestartScenario})
         with pytest.raises(RestartScenario):
             task(parent)
 
@@ -166,7 +167,8 @@ class TestTransformerTask:
         )
         fire_spy.reset_mock()
 
-        parent.user._scenario.failure_exception = None
+        with suppress(KeyError):
+            del parent.user._scenario.failure_handling[None]
 
         task_factory = TransformerTask(
             variable='test_variable',

--- a/tests/unit/test_grizzly/tasks/test_until.py
+++ b/tests/unit/test_grizzly/tasks/test_until.py
@@ -1,6 +1,7 @@
 """Unit tests for grizzly.tasks.until."""
 from __future__ import annotations
 
+from contextlib import suppress
 from json import dumps as jsondumps
 from logging import ERROR
 from typing import TYPE_CHECKING, Any
@@ -200,7 +201,7 @@ class TestUntilRequestTask:
             ],
         )
 
-        parent.user._scenario.failure_exception = StopUser
+        parent.user._scenario.failure_handling.update({None: StopUser})
         task_factory = UntilRequestTask(meta_request_task, '$.`this`[?status="ready"] | wait=10, retries=2')
         task = task_factory()
 
@@ -235,7 +236,7 @@ class TestUntilRequestTask:
             ],
         )
 
-        parent.user._scenario.failure_exception = RestartScenario
+        parent.user._scenario.failure_handling.update({None: RestartScenario})
         with pytest.raises(RestartScenario), caplog.at_level(ERROR):
             task(parent)
 
@@ -388,7 +389,9 @@ class TestUntilRequestTask:
         task_factory = UntilRequestTask(meta_request_task, '$.list[?(@.count == 18)] | wait=4, expected_matches=1, retries=1')
         task = task_factory()
         request_spy.return_value = ({}, None)
-        parent.user._scenario.failure_exception = None
+
+        with suppress(KeyError):
+            del parent.user._scenario.failure_handling[None]
 
         task(parent)
 

--- a/tests/unit/test_grizzly/test_behave.py
+++ b/tests/unit/test_grizzly/test_behave.py
@@ -33,7 +33,8 @@ if TYPE_CHECKING:  # pragma: no cover
     from tests.fixtures import BehaveFixture, GrizzlyFixture
 
 
-@pytest.mark.timeout(20)
+@pytest.mark.skipif((sys.platform != 'win32' and 'GITHUB_RUN_ID' in environ), reason='this test hangs on linux when executed on a github runner!?')
+@pytest.mark.timeout(40)
 def test_behave_no_pymqi_dependencies() -> None:
     env = environ.copy()
     with suppress(KeyError):
@@ -41,7 +42,7 @@ def test_behave_no_pymqi_dependencies() -> None:
 
     env['PYTHONPATH'] = '.'
 
-    process = subprocess.Popen(
+    out = subprocess.check_output(
         [
             sys.executable,
             '-c',
@@ -51,14 +52,10 @@ def test_behave_no_pymqi_dependencies() -> None:
             ),
         ],
         env=env,
-        stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
     )
 
-    out, _ = process.communicate()
     output = out.decode()
-
-    assert process.returncode == 0
     assert "gbehave.pymqi.__name__='grizzly_extras.dummy_pymqi'" in output
 
 

--- a/tests/unit/test_grizzly/test_context.py
+++ b/tests/unit/test_grizzly/test_context.py
@@ -369,7 +369,7 @@ class TestGrizzlyContextScenario:
         assert scenario.tasks() == []
         assert getattr(scenario, 'pace', '') is None
         assert isinstance(scenario.validation, GrizzlyContextScenarioValidation)
-        assert not scenario.failure_exception
+        assert scenario.failure_handling.get(None, None) is None
         assert scenario.class_type == 'IteratorScenario'
 
         assert scenario.class_name == f'IteratorScenario_{identifier}'

--- a/tests/unit/test_grizzly/test_exceptions.py
+++ b/tests/unit/test_grizzly/test_exceptions.py
@@ -1,0 +1,49 @@
+"""Unit tests of grizzly.exceptions."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from grizzly.exceptions import RestartScenario, RetryTask, StopUser, failure_handler
+
+if TYPE_CHECKING:
+    from tests.fixtures import GrizzlyFixture
+
+
+def test_failure_handler(grizzly_fixture: GrizzlyFixture) -> None:
+    grizzly = grizzly_fixture.grizzly
+
+    scenario = grizzly.scenario
+
+    assert scenario.failure_handling == {}
+
+    scenario.failure_handling.update({
+        None: StopUser,
+        '504 gateway timeout': RetryTask,
+    })
+
+    failure_handler(None, scenario)
+
+    with pytest.raises(StopUser):
+        failure_handler(RuntimeError('foobar'), scenario)
+
+    with pytest.raises(RetryTask):
+        failure_handler(RuntimeError('504 gateway timeout'), scenario)
+
+    del scenario.failure_handling[None]
+
+    failure_handler(RuntimeError('foobar'), scenario)
+
+    with pytest.raises(RetryTask):
+        failure_handler(RuntimeError('504 gateway timeout'), scenario)
+
+    scenario.failure_handling.update({AttributeError: RestartScenario})
+
+    with pytest.raises(StopUser):
+        failure_handler(AttributeError('foobaz'), scenario)
+
+    scenario.failure_handling.update({MemoryError: RestartScenario})
+
+    with pytest.raises(RestartScenario):
+        failure_handler(MemoryError('0% free'), scenario)

--- a/tests/unit/test_grizzly/users/test_iothub.py
+++ b/tests/unit/test_grizzly/users/test_iothub.py
@@ -201,7 +201,7 @@ class TestIotHubUser:
 
         user.request(request)
 
-        user._scenario.failure_exception = RestartScenario
+        user._scenario.failure_handling.update({None: RestartScenario})
         parent_fixture.blob_client_mock.upload_blob.side_effect=[RuntimeError('failed to upload blob')]
         parent_fixture.iot_device_mock.notify_blob_upload_status.reset_mock()
 
@@ -284,7 +284,7 @@ class TestIotHubUser:
         request.metadata['content_type'] = 'application/octet-stream; charset=utf-8'
         request.metadata['content_encoding'] = 'vulcan'
 
-        user._scenario.failure_exception = RestartScenario
+        user._scenario.failure_handling.update({None: RestartScenario})
         with pytest.raises(RestartScenario):
             user.request(request)
 
@@ -316,7 +316,7 @@ class TestIotHubUser:
         gzip_compress = mocker.patch('gzip.compress', autospec=True, return_value='this_is_compressed')
         request.source = None
 
-        parent_fixture.user._scenario.failure_exception = RestartScenario
+        parent_fixture.user._scenario.failure_handling.update({None: RestartScenario})
         with pytest.raises(RestartScenario):
             parent_fixture.user.request(request)
 

--- a/tests/unit/test_grizzly/users/test_messagequeue.py
+++ b/tests/unit/test_grizzly/users/test_messagequeue.py
@@ -271,7 +271,7 @@ class TestMessageQueueUser:
 
         request = RequestTask(RequestMethod.PUT, name='test-put', endpoint='EXAMPLE.QUEUE')
         scenario.name = 'test'
-        scenario.failure_exception = StopUser
+        scenario.failure_handling.update({None: StopUser})
         scenario.tasks.add(request)
         user._scenario = scenario
 
@@ -311,7 +311,7 @@ class TestMessageQueueUser:
 
             request = RequestTask(RequestMethod.GET, name='test-get', endpoint=self.real_stuff['endpoint'])
             scenario = GrizzlyContextScenario(1, behave=grizzly_fixture.behave.create_scenario('get tls real'), grizzly=grizzly_fixture.grizzly)
-            scenario.failure_exception = StopUser
+            scenario.failure_handling.update({None: StopUser})
             scenario.tasks.add(request)
 
             MessageQueueUser.host = f'mq://{self.real_stuff["host"]}/?QueueManager={self.real_stuff["queue_manager"]}&Channel={self.real_stuff["channel"]}'
@@ -596,7 +596,8 @@ class TestMessageQueueUser:
             } for _ in range(3)
         ]
 
-        mq_parent.user._scenario.failure_exception = None
+        with suppress(KeyError):
+            del mq_parent.user._scenario.failure_handling[None]
         mq_parent.user.request(request)
 
         assert request_event_spy.call_count == 1
@@ -604,7 +605,7 @@ class TestMessageQueueUser:
         assert kwargs['exception'] is not None
         request_event_spy.reset_mock()
 
-        mq_parent.user._scenario.failure_exception = StopUser
+        mq_parent.user._scenario.failure_handling.update({None: StopUser})
         with pytest.raises(StopUser):
             mq_parent.user.request(request)
 
@@ -613,7 +614,7 @@ class TestMessageQueueUser:
         assert kwargs['exception'] is not None
         request_event_spy.reset_mock()
 
-        mq_parent.user._scenario.failure_exception = RestartScenario
+        mq_parent.user._scenario.failure_handling.update({None: RestartScenario})
         with pytest.raises(RestartScenario):
             mq_parent.user.request(request)
 
@@ -706,14 +707,14 @@ class TestMessageQueueUser:
 
         # Test error when missing expression: prefix
         request.endpoint = 'queue:IFKTEST3, /class/student[marks<55]'
-        mq_parent.user._scenario.failure_exception = StopUser
+        mq_parent.user._scenario.failure_handling.update({None: StopUser})
         with pytest.raises(StopUser):
             mq_parent.user.request(request)
 
         # Test with expression argument but wrong method
         request.endpoint = 'queue:IFKTEST3, expression:/class/student[marks<55]'
         request.method = RequestMethod.PUT
-        mq_parent.user._scenario.failure_exception = RestartScenario
+        mq_parent.user._scenario.failure_handling.update({None: RestartScenario})
 
         with pytest.raises(RestartScenario):
             mq_parent.user.request(request)
@@ -728,7 +729,7 @@ class TestMessageQueueUser:
         # Test with empty queue name
         request.endpoint = 'queue:, expression:/class/student[marks<55]'
         request.method = RequestMethod.GET
-        mq_parent.user._scenario.failure_exception = StopUser
+        mq_parent.user._scenario.failure_handling.update({None: StopUser})
 
         with pytest.raises(StopUser):
             mq_parent.user.request(request)
@@ -868,7 +869,8 @@ class TestMessageQueueUser:
         )
         request_event_spy.reset_mock()
 
-        mq_parent.user._scenario.failure_exception = None
+        with suppress(KeyError):
+            del mq_parent.user._scenario.failure_handling[None]
         mq_parent.user.request(template)
 
         request_event_spy.assert_called_once_with(
@@ -881,7 +883,7 @@ class TestMessageQueueUser:
         )
         request_event_spy.reset_mock()
 
-        mq_parent.user._scenario.failure_exception = StopUser
+        mq_parent.user._scenario.failure_handling.update({None: StopUser})
         with pytest.raises(StopUser):
             mq_parent.user.request(template)
 
@@ -895,7 +897,7 @@ class TestMessageQueueUser:
         )
         request_event_spy.reset_mock()
 
-        mq_parent.user._scenario.failure_exception = RestartScenario
+        mq_parent.user._scenario.failure_handling.update({None: RestartScenario})
         with pytest.raises(RestartScenario):
             mq_parent.user.request(template)
 
@@ -904,7 +906,7 @@ class TestMessageQueueUser:
         assert kwargs['exception'] is not None
         request_event_spy.reset_mock()
 
-        mq_parent.user._scenario.failure_exception = StopUser
+        mq_parent.user._scenario.failure_handling.update({None: StopUser})
         template.endpoint = 'sub:TEST.QUEUE'
 
         with pytest.raises(StopUser):

--- a/tests/unit/test_grizzly/users/test_servicebus.py
+++ b/tests/unit/test_grizzly/users/test_servicebus.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from contextlib import suppress
 from typing import TYPE_CHECKING, cast
 
 import pytest
@@ -384,7 +385,7 @@ class TestServiceBusUser:
         task = RequestTask(RequestMethod.PUT, name='test-send', endpoint='queue:test-queue')
         task.source = 'hello'
         parent.user._scenario.tasks.add(task)
-        parent.user._scenario.failure_exception = StopUser
+        parent.user._scenario.failure_handling.update({None: StopUser})
         mocker.patch.object(parent.user.zmq_client, 'disconnect', side_effect=[TypeError])
 
         with pytest.raises(StopUser):
@@ -414,7 +415,8 @@ class TestServiceBusUser:
         task.method = RequestMethod.SEND
 
         # unsuccessful response from async-messaged
-        parent.user._scenario.failure_exception = None
+        with suppress(KeyError):
+            del parent.user._scenario.failure_handling[None]
 
         parent.user.request(task)
 

--- a/tests/webserver.py
+++ b/tests/webserver.py
@@ -187,14 +187,20 @@ def app_until_attribute(attribute: str) -> FlaskResponse:
     right = args.get('right')
     as_array = args.get('as_array', None)
 
+    if wrong is None or right is None:
+        response = jsonify({'message': 'missing wrong and/or right in query string'})
+        response.status_code = 400
+
+        return response
+
     if app_request_count[x_grizzly_user] < nth - 1:
-        status = wrong
+        status = wrong if not wrong.isnumeric() else 'foobar'
         app_request_count[x_grizzly_user] += 1
-        status_code = 400
+        status_code = 400 if not wrong.isnumeric() else int(wrong)
     else:
-        status = right
+        status = right if not right.isnumeric() else 'foobar'
         app_request_count[x_grizzly_user] = 0
-        status_code = 200
+        status_code = 200 if not right.isnumeric() else int(right)
 
     json_result: Any = {attribute: status}
 


### PR DESCRIPTION
Implementation of #328 .

Adds the possibility to treat specific failures different from the default failure.

New failure action `RetryStep`, which will retry the failed tasks up to 3 times, with an expnential random back-off.

New `When` steps for setting up the failure handling. The two old `Given` steps are (soft) deprecated, and will be removed in a future release.