### PR TITLE
rewrite of testdata communication, and other improvements

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -87,7 +87,8 @@ jobs:
 
     - name: coverage
       id: coverage
-      run: python -m coverage report --omit=**/*messagequeue*,**/mq/*,**/__version__.py --fail-under=89
+      run: |
+        python -m coverage report -i --omit=**/*messagequeue*,**/mq/*,**/__version__.py --fail-under=89 || python -m coverage debug data
 
   test-e2e:
     name: 'e2e tests ${{ matrix.run_mode }}'

--- a/grizzly/behave.py
+++ b/grizzly/behave.py
@@ -50,10 +50,11 @@ def before_feature(context: Context, feature: Feature, *_args: Any, **_kwargs: A
 
     destroy_variables()
 
-    with suppress(ValueError):
-        GrizzlyContext.destroy()
+    from grizzly import context as grizzly_context
 
-    grizzly = GrizzlyContext()
+    grizzly_context.grizzly = GrizzlyContext()
+
+    grizzly = grizzly_context.grizzly
     grizzly.state.verbose = context.config.verbose
 
     persistent_file = Path(context.config.base_dir) / 'persistent' / f'{Path(feature.filename).stem}.json'

--- a/grizzly/context.py
+++ b/grizzly/context.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
 import yaml
+from gevent.lock import Semaphore
 from jinja2 import DebugUndefined, Environment, FileSystemLoader
 from jinja2.filters import FILTERS
 from typing_extensions import Self
@@ -91,7 +92,7 @@ def jinja2_environment_factory() -> Environment:
 
 @dataclass
 class GrizzlyContextState:
-    spawning_complete: bool = field(default=False)
+    spawning_complete: Semaphore = field(default_factory=Semaphore)
     background_done: bool = field(default=False)
     configuration: dict[str, Any] = field(init=False, default_factory=load_configuration_file)
     verbose: bool = field(default=False)

--- a/grizzly/listeners/__init__.py
+++ b/grizzly/listeners/__init__.py
@@ -75,11 +75,11 @@ def init(grizzly: GrizzlyContext, testdata: Optional[TestdataType] = None) -> Ca
 
         if not isinstance(runner, MasterRunner):
             for message_type, callback in grizzly.setup.locust.messages.get(MessageDirection.SERVER_CLIENT, {}).items():
-                runner.register_message(message_type, callback)
+                runner.register_message(message_type, callback, concurrent=True)
 
         if not isinstance(runner, WorkerRunner):
             for message_type, callback in grizzly.setup.locust.messages.get(MessageDirection.CLIENT_SERVER, {}).items():
-                runner.register_message(message_type, callback)
+                runner.register_message(message_type, callback, concurrent=True)
 
     return cast(Callable[Concatenate[LocustRunner, P], None], ginit)
 

--- a/grizzly/listeners/influxdb.py
+++ b/grizzly/listeners/influxdb.py
@@ -15,7 +15,6 @@ import gevent
 from influxdb import InfluxDBClient
 from influxdb.exceptions import InfluxDBClientError
 
-from grizzly.context import GrizzlyContext
 from grizzly.types.locust import CatchResponseError, Environment
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -152,7 +151,6 @@ class InfluxDbListener:
         self.run_events_greenlet = gevent.spawn(self.run_events)
         self.run_user_count_greenlet = gevent.spawn(self.run_user_count)
         self.connection = self.create_client().connect()
-        self.grizzly = GrizzlyContext()
         self.logger = logging.getLogger(__name__)
         self.environment.events.request.add_listener(self.request)
         self.environment.events.heartbeat_sent.add_listener(self.heartbeat_sent)
@@ -160,6 +158,8 @@ class InfluxDbListener:
         self.environment.events.usage_monitor.add_listener(self.usage_monitor)
         self.environment.events.quit.add_listener(self.on_quit)
 
+        from grizzly.context import grizzly
+        self.grizzly = grizzly
         self.grizzly.events.keystore_request.add_listener(self.on_grizzly_event)
         self.grizzly.events.testdata_request.add_listener(self.on_grizzly_event)
         self.grizzly.events.user_event.add_listener(self.on_grizzly_event)

--- a/grizzly/locust.py
+++ b/grizzly/locust.py
@@ -27,7 +27,7 @@ from roundrobin import smooth
 
 from . import __locust_version__, __version__
 from .context import GrizzlyContext
-from .listeners import init, init_statistics_listener, locust_test_start, locust_test_stop, quitting, spawning_complete, validate_result, worker_report
+from .listeners import init, init_statistics_listener, locust_test_start, locust_test_stop, spawning_complete, validate_result, worker_report
 from .testdata.utils import initialize_testdata
 from .testdata.variables.csv_writer import open_files
 from .types import RequestType, TestdataType
@@ -771,12 +771,11 @@ def setup_environment_listeners(context: Context, *, testdata: Optional[Testdata
         if validate_results:
             environment.events.quitting.add_listener(validate_result(grizzly))
 
-        environment.events.quitting.add_listener(quitting)
         environment.events.worker_report.add_listener(worker_report)
 
     environment.events.init.add_listener(init(grizzly, testdata))
     environment.events.test_start.add_listener(locust_test_start(grizzly))
-    environment.events.test_stop.add_listener(locust_test_stop)
+    environment.events.test_stop.add_listener(locust_test_stop(grizzly))
 
     if not on_master(context):
         environment.events.spawning_complete.add_listener(spawning_complete(grizzly))

--- a/grizzly/scenarios/iterator.py
+++ b/grizzly/scenarios/iterator.py
@@ -286,7 +286,8 @@ class IteratorScenario(GrizzlyScenario):
             self._prefetch = False
             return
 
-        self.on_iteration()
+        if not prefetch:
+            self.on_iteration()
 
         if self.start is not None:
             response_time = int((perf_counter() - self.start) * 1000)

--- a/grizzly/tasks/__init__.py
+++ b/grizzly/tasks/__init__.py
@@ -60,10 +60,10 @@ from os import environ
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, Optional, Union, cast, overload
 
-from grizzly.context import GrizzlyContext
 from grizzly.utils import has_template
 
 if TYPE_CHECKING:  # pragma: no cover
+    from grizzly.context import GrizzlyContext
     from grizzly.scenarios import GrizzlyScenario
     from grizzly.types import GrizzlyResponse
     from grizzly_extras.transformer import TransformerContentType
@@ -172,13 +172,14 @@ class GrizzlyTask(ABC):
     _context_root: str
 
     timeout: float | None
-
     grizzly: GrizzlyContext
 
     def __init__(self, *, timeout: float | None = None) -> None:
         self._context_root = environ.get('GRIZZLY_CONTEXT_ROOT', '.')
-        self.grizzly = GrizzlyContext()
         self.timeout = timeout
+
+        from grizzly.context import grizzly
+        self.grizzly =  grizzly
 
     @abstractmethod
     def __call__(self) -> grizzlytask:

--- a/grizzly/tasks/clients/__init__.py
+++ b/grizzly/tasks/clients/__init__.py
@@ -16,7 +16,6 @@ performed.
 """
 from __future__ import annotations
 
-import logging
 import traceback
 from abc import abstractmethod
 from contextlib import contextmanager
@@ -312,7 +311,7 @@ class ClientTask(GrizzlyMetaRequestTask):
             failure_handler(exception, parent.user._scenario)
 
             if exception is not None:
-                parent.logger.warning('%s ignoring %s', self.__class__.__name__, exception)
+                parent.user.logger.warning('%s ignoring %s', self.__class__.__name__, exception)
 
 
 class client:
@@ -333,8 +332,6 @@ class client:
         return impl
 
 
-logger = logging.getLogger(__name__)
-
 from .blobstorage import BlobStorageClientTask
 from .http import HttpClientTask
 from .messagequeue import MessageQueueClientTask
@@ -345,5 +342,4 @@ __all__ = [
     'BlobStorageClientTask',
     'MessageQueueClientTask',
     'ServiceBusClientTask',
-    'logger',
 ]

--- a/grizzly/tasks/clients/servicebus.py
+++ b/grizzly/tasks/clients/servicebus.py
@@ -110,7 +110,7 @@ from grizzly.utils.protocols import async_message_request_wrapper, zmq_disconnec
 from grizzly_extras.arguments import parse_arguments
 from grizzly_extras.transformer import TransformerContentType
 
-from . import ClientTask, client, logger
+from . import ClientTask, client
 
 if TYPE_CHECKING:  # pragma: no cover
     from grizzly.scenarios import GrizzlyScenario
@@ -318,7 +318,7 @@ class ServiceBusClientTask(ClientTask):
     def connect(self, parent: GrizzlyScenario) -> None:
         state = self.get_state(parent)
 
-        logger.debug(f'{state.parent_id}::sb connecting, {state.worker=}')
+        parent.user.logger.debug('%d::sb connecting, state.worker=%r', state.parent_id, state.worker)
 
         request: AsyncMessageRequest = {
             'worker': state.worker,
@@ -331,7 +331,7 @@ class ServiceBusClientTask(ClientTask):
         if state.first_response is None:
             state.first_response = response
 
-        logger.debug(f'{state.parent_id}::sb connected to worker {state.worker} at {hostname()}')
+        parent.user.logger.debug('%d::sb connected to worker %r at %s', state.parent_id, state.worker, hostname())
 
     def disconnect(self, parent: GrizzlyScenario) -> None:
         state = self.get_state(parent)
@@ -365,7 +365,7 @@ class ServiceBusClientTask(ClientTask):
         }
 
         response = async_message_request_wrapper(parent, state.client, request)
-        logger.info(response['message'])
+        parent.user.logger.info(response['message'])
 
         state.first_response = response
 
@@ -382,7 +382,7 @@ class ServiceBusClientTask(ClientTask):
         }
 
         response = async_message_request_wrapper(parent, state.client, request)
-        logger.info(response['message'])
+        parent.user.logger.info(response['message'])
 
     def empty(self, parent: GrizzlyScenario) -> None:
         state = self.get_state(parent)
@@ -401,7 +401,7 @@ class ServiceBusClientTask(ClientTask):
         message = response['message']
 
         if message is not None and len(message) > 0:
-            logger.info(response['message'])
+            parent.user.logger.info(response['message'])
 
     def on_start(self, parent: GrizzlyScenario) -> None:
         # create subscription before connecting to it

--- a/grizzly/testdata/communication.py
+++ b/grizzly/testdata/communication.py
@@ -7,26 +7,26 @@ from json import dumps as jsondumps
 from os import environ
 from pathlib import Path
 from time import perf_counter
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
-import zmq.green as zmq
 from gevent import sleep as gsleep
+from gevent.event import AsyncResult
 from gevent.lock import Semaphore
-from zmq.error import Again as ZMQAgain
-from zmq.error import ZMQError
 
-from grizzly.events import GrizzlyEventDecoder, event, events
-from grizzly.types.locust import Environment, StopUser
-from grizzly.utils.protocols import zmq_disconnect
+from grizzly.events import GrizzlyEventDecoder, GrizzlyEvents, event, events
+from grizzly.types.locust import LocalRunner, MasterRunner, StopUser, WorkerRunner
 
 from . import GrizzlyVariables
 from .utils import transform
 from .variables import AtomicVariablePersist
 
 if TYPE_CHECKING:  # pragma: no cover
+    from locust.rpc.protocol import Message
+
     from grizzly.context import GrizzlyContext
     from grizzly.scenarios import GrizzlyScenario
     from grizzly.types import TestdataType
+    from grizzly.types.locust import Environment
 
 
 class KeystoreDecoder(GrizzlyEventDecoder):
@@ -84,41 +84,39 @@ class TestdataConsumer:
     # need so pytest doesn't raise PytestCollectionWarning
     __test__: bool = False
 
+    _responses: ClassVar[dict[int, AsyncResult]] = {}
+
     scenario: GrizzlyScenario
+    runner: LocalRunner | WorkerRunner
     identifier: str
     stopped: bool
     poll_interval: float
+    response: dict[str, Any]
+    events: GrizzlyEvents
 
     semaphore = Semaphore()
 
-    def __init__(self, scenario: GrizzlyScenario, address: str = 'tcp://127.0.0.1:5555', poll_interval: float = 1.0) -> None:
+    def __init__(self, runner: LocalRunner | WorkerRunner, scenario: GrizzlyScenario, poll_interval: float = 1.0) -> None:
+        self.runner = runner
         self.scenario = scenario
         self.identifier = scenario.__class__.__name__
 
-        self.context = zmq.Context()
-        self.socket = self.context.socket(zmq.REQ)
-        self.socket.setsockopt(zmq.LINGER, 0)
-        self.socket.connect(address)
         self.stopped = False
         self.poll_interval = poll_interval
 
-        self.logger.debug('connected to producer at %s', address)
+        self.response = {}
+        self.logger.debug('started consumer')
+
+    @classmethod
+    def handle_response(cls, environment: Environment, msg: Message, **_kwargs: Any) -> None:  # noqa: ARG003
+        uid = msg.data['uid']
+        response = msg.data['response']
+
+        cls._responses[uid].set(response)
 
     @property
     def logger(self) -> logging.Logger:
         return self.scenario.logger
-
-    def stop(self) -> None:
-        if self.stopped:
-            return
-
-        self.logger.debug('consumer stopping')
-        try:
-            zmq_disconnect(self.socket, destroy_context=True)
-        except:
-            self.logger.exception('failed to stop')
-        finally:
-            self.stopped = True
 
     @event(events.testdata_request, tags={'type': 'consumer'}, decoder=TestdataDecoder(arg='request'))
     def _testdata_request(self, *, request: dict[str, Any]) -> dict[str, Any] | None:
@@ -243,26 +241,22 @@ class TestdataConsumer:
         return self._request({'message': 'keystore', **request})
 
     def _request(self, request: dict[str, str]) -> dict[str, Any] | None:
-        with self.semaphore:  # one at a time
-            self.socket.send_json(request)
+        with self.semaphore:
+            uid = id(self.scenario.user)
 
-            self.logger.debug('waiting for response from producer')
-            message: dict[str, Any]
+            if uid in self._responses:
+                self.logger.warning('greenlet %d is already waiting for testdata', uid)
 
-            # loop and NOBLOCK needed when running in local mode, to let other gevent threads get time
-            while True:
-                try:
-                    message = cast(dict[str, Any], self.socket.recv_json(flags=zmq.NOBLOCK))
-                    break
-                except ZMQAgain:
-                    gsleep(0.1)  # let other greenlets execute
+            self._responses.update({uid: AsyncResult()})
+            self.runner.send_message('produce_testdata', {'uid': uid, 'cid': self.runner.client_id, 'request': request})
 
-            error = message.get('error', None)
+            # waits for async result
+            response = cast(dict[str, Any] | None, self._responses[uid].get())
 
-            if error is not None:
-                raise RuntimeError(error)
+            # remove request as pending
+            del self._responses[uid]
 
-            return message
+            return response
 
 
 class TestdataProducer:
@@ -274,29 +268,21 @@ class TestdataProducer:
 
     logger: logging.Logger
     semaphore = Semaphore()
-    grizzly: GrizzlyContext
     scenarios_iteration: dict[str, int]
     testdata: TestdataType
-    environment: Environment
     has_persisted: bool
     keystore: dict[str, Any]
+    runner: MasterRunner | LocalRunner
+    grizzly: GrizzlyContext
 
-    def __init__(self, grizzly: GrizzlyContext, testdata: TestdataType, address: str = 'tcp://127.0.0.1:5555') -> None:
-        self.grizzly = grizzly
+    def __init__(self, runner: MasterRunner | LocalRunner, testdata: TestdataType) -> None:
         self.testdata = testdata
-        self.environment = self.grizzly.state.locust.environment
+        self.runner = runner
 
         self.logger = logging.getLogger(f'{__name__}/producer')
 
-        self.logger.debug('starting on %s', address)
-
-        self.context = zmq.Context()
-        self.socket = self.context.socket(zmq.REP)
-        self.socket.setsockopt(zmq.LINGER, 0)
-        self.socket.bind(address)
         self.scenarios_iteration = {}
 
-        self._stopping = False
         self.has_persisted = False
 
         self.logger.debug('serving:\n%r', self.testdata)
@@ -310,6 +296,9 @@ class TestdataProducer:
         self._persist_file = persist_root / f'{Path(feature_file).stem}.json'
 
         self.keystore = {}
+
+        from grizzly.context import grizzly
+        self.grizzly = grizzly
 
     def on_test_stop(self) -> None:
         self.logger.debug('test stopping')
@@ -352,20 +341,7 @@ class TestdataProducer:
             self.logger.exception('failed to persist feature file data')
 
     def stop(self) -> None:
-        self._stopping = True
-        self.logger.debug('stopping producer')
-        try:
-            zmq_disconnect(self.socket, destroy_context=True)
-        except:
-            self.logger.exception('failed to stop')
-        finally:
-            # make sure that socket is properly released
-            try:
-                gsleep(0.1)
-            except:  # noqa: S110
-                pass
-            finally:
-                self.persist_data()
+        self.persist_data()
 
     @event(events.keystore_request, tags={'type': 'producer'}, decoder=KeystoreDecoder(arg='request'))
     def _handle_request_keystore(self, *, request: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915, PLR0912
@@ -522,32 +498,19 @@ class TestdataProducer:
 
         return response
 
-    def run(self) -> None:
-        self.logger.debug('start producing...')
-        try:
-            while True:
-                try:
-                    recv = cast(dict[str, Any], self.socket.recv_json(flags=zmq.NOBLOCK))
-                    consumer_identifier = recv.get('identifier', '')
-                    self.logger.debug('got request from consumer %s', consumer_identifier)
-                    response: dict[str, Any]
+    def handle_request(self, environment: Environment, msg: Message, **_kwargs: Any) -> None:  # noqa: ARG002
+        with self.semaphore:
+            self.logger.debug('handling message')
+            uid = msg.data['uid']
+            cid = msg.data['cid']
+            request = msg.data['request']
 
-                    with self.semaphore:
-                        if recv['message'] == 'keystore':
-                            response = self._handle_request_keystore(request=recv)
-                        elif recv['message'] == 'testdata':
-                            response = self._handle_request_testdata(request=recv)
-                        else:
-                            self.logger.error('received unknown message "%s"', recv['message'])
-                            response = {}
+            if request['message'] == 'keystore':
+                response = self._handle_request_keystore(request=request)
+            elif request['message'] == 'testdata':
+                response = self._handle_request_testdata(request=request)
+            else:
+                self.logger.error('received unknown message "%s"', request['message'])
+                response = {}
 
-                        self.logger.debug('producing %r for consumer %s', response, consumer_identifier)
-                        self.socket.send_json(response)
-
-                    gsleep(0)
-                except ZMQAgain:  # noqa: PERF203
-                    gsleep(0.1)
-        except ZMQError:
-            if not self._stopping:
-                self.logger.exception('failed when waiting for consumers')
-            self.environment.events.test_stop.fire(environment=self.environment)
+            self.runner.send_message('consume_testdata', {'uid': uid, 'response': response}, client_id=cid)

--- a/grizzly/testdata/communication.py
+++ b/grizzly/testdata/communication.py
@@ -7,7 +7,7 @@ from json import dumps as jsondumps
 from os import environ
 from pathlib import Path
 from time import perf_counter
-from typing import TYPE_CHECKING, Any, ClassVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, cast
 
 from gevent import sleep as gsleep
 from gevent.event import AsyncResult
@@ -251,7 +251,7 @@ class TestdataConsumer:
             self.runner.send_message('produce_testdata', {'uid': uid, 'cid': self.runner.client_id, 'request': request})
 
             # waits for async result
-            response = cast(dict[str, Any] | None, self._responses[uid].get())
+            response = cast(Optional[dict[str, Any]], self._responses[uid].get())
 
             # remove request as pending
             del self._responses[uid]

--- a/grizzly/testdata/variables/__init__.py
+++ b/grizzly/testdata/variables/__init__.py
@@ -16,13 +16,13 @@ from typing import TYPE_CHECKING, Any, Callable, ClassVar, Generic, Optional, Ty
 
 from gevent.lock import DummySemaphore, Semaphore
 
-from grizzly.context import GrizzlyContext, GrizzlyContextScenario
 from grizzly.types import bool_type
 
 T = TypeVar('T')
 
 
 if TYPE_CHECKING:  # pragma: no cover
+    from grizzly.context import GrizzlyContext, GrizzlyContextScenario
     from grizzly.types.locust import MessageHandler
 
 
@@ -73,8 +73,10 @@ class AtomicVariable(Generic[T], AbstractAtomicClass):
         if cls._instances.get(cls, {}).get(scenario, None) is None:
             instance = super().__new__(cls)
             instance._initialized = False
-            instance.grizzly = GrizzlyContext()
             instance._scenario = scenario
+
+            from grizzly.context import grizzly
+            instance.grizzly = grizzly
 
             cls._instances[cls].update({scenario: instance})
 

--- a/grizzly_extras/async_message/sb.py
+++ b/grizzly_extras/async_message/sb.py
@@ -659,7 +659,7 @@ class AsyncServiceBusHandler(AsyncMessageHandler):
                                     empty_message_count += 1
 
                         empty_message_time = perf_counter() - empty_message_start
-                        msg = f'{client}::{cache_endpoint}: consumed {empty_message_count} messages which took {empty_message_time:.2f} seconds'
+                        msg = f'consumed {empty_message_count} messages from {cache_endpoint} which took {empty_message_time:.2f} seconds'
 
                         self.logger.info(msg)
 
@@ -681,7 +681,7 @@ class AsyncServiceBusHandler(AsyncMessageHandler):
                         self.logger.debug('%d::%s: got message id %s', client, cache_endpoint, message.message_id)
 
                         if expression is None:
-                            self.logger.debug('%d::%s: completing message id %s', client, cache_endpoint, message.message_id)
+                            self.logger.debug('completing message id %s on %s', message.message_id, cache_endpoint)
                             receiver.complete_message(message)
                             break
 
@@ -707,10 +707,9 @@ class AsyncServiceBusHandler(AsyncMessageHandler):
                             if len(values) > 0:
                                 wait_time = perf_counter() - wait_start
                                 self.logger.info(
-                                    '! %d::%s: completing message id %s, with expression "%s" after consuming %d messages (%.2fs)',
-                                    client,
-                                    cache_endpoint,
+                                    'completing message id %s on %s, with expression "%s" after consuming %d messages (%.2fs)',
                                     message.message_id,
+                                    cache_endpoint,
                                     expression,
                                     consume_message_ignore_count,
                                     wait_time,
@@ -728,7 +727,7 @@ class AsyncServiceBusHandler(AsyncMessageHandler):
                                         receiver.abandon_message(message)
                                         message = None
                                     else:
-                                        self.logger.debug('%d::%s: consuming and ignoring message id %s', client, cache_endpoint, message.message_id)
+                                        self.logger.debug('consuming and ignoring message id %s on %s', message.message_id, cache_endpoint)
                                         receiver.complete_message(message)  # remove message from endpoint, but ignore contents
                                         message = payload = metadata = None
                                         consume_message_ignore_count += 1
@@ -746,7 +745,7 @@ class AsyncServiceBusHandler(AsyncMessageHandler):
                     break
                 except MessageLockLostError as e:
                     if message is not None:
-                        self.logger.warning('message lock expired for message id %s', message.message_id)
+                        self.logger.warning('message lock expired for message id %s on %s', message.message_id, cache_endpoint)
 
                     if self._event.is_set():
                         break

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,9 +102,9 @@ def _cwd_fixture() -> Generator[CwdFixture, None, None]:
 
 
 cleanup = pytest.fixture()(_atomicvariable_cleanup)
-locust_fixture = pytest.fixture()(_locust_fixture)
-behave_fixture = pytest.fixture()(_behave_fixture)
-request_task = pytest.fixture()(_request_task)
+locust_fixture = pytest.fixture(scope='function')(_locust_fixture)
+behave_fixture = pytest.fixture(scope='function')(_behave_fixture)
+request_task = pytest.fixture(scope='function')(_request_task)
 grizzly_fixture = pytest.fixture(scope='function')(_grizzly_fixture)
 noop_zmq = pytest.fixture()(_noop_zmq)
 response_context_manager_fixture = pytest.fixture()(_response_context_manager)

--- a/tests/e2e/test_keystore.py
+++ b/tests/e2e/test_keystore.py
@@ -67,15 +67,3 @@ def test_e2e_keystore(e2e_fixture: End2EndFixture) -> None:
     assert "key_holder_1={'hello': 'world'}" in result
     assert "key_holder_2=hello, key_holder_3={'hello': 'world'}" in result
     assert "foobar_push: 10, 20, 30" in result
-    assert (
-        result.index("producing {'message': 'keystore', 'action': 'push', 'key': 'foobar::push', 'data': 10, 'identifier': 'IteratorScenario_001'}")
-        < result.index("producing {'message': 'keystore', 'action': 'push', 'key': 'foobar::push', 'data': 20, 'identifier': 'IteratorScenario_001'}")
-    )
-    assert (
-        result.index("producing {'message': 'keystore', 'action': 'push', 'key': 'foobar::push', 'data': 20, 'identifier': 'IteratorScenario_001'}")
-        < result.index("producing {'message': 'keystore', 'action': 'push', 'key': 'foobar::push', 'data': 30, 'identifier': 'IteratorScenario_001'}")
-    )
-    assert (
-        result.index("producing {'message': 'keystore', 'action': 'push', 'key': 'foobar::push', 'data': 30, 'identifier': 'IteratorScenario_001'}")
-        < result.index("producing {'message': 'keystore', 'action': 'pop', 'key': 'foobar::push', 'identifier': 'IteratorScenario_002', 'data': 10}")
-    )

--- a/tests/unit/test_grizzly/listeners/test___init__.py
+++ b/tests/unit/test_grizzly/listeners/test___init__.py
@@ -124,7 +124,7 @@ def test_init_master(caplog: LogCaptureFixture, grizzly_fixture: GrizzlyFixture)
         init_function(runner)
 
         assert grizzly.state.locust.custom_messages == cast(dict[str, tuple[Callable, bool]], {
-            'test_message': (callback, False),
+            'test_message': (callback, True),
         })
     finally:
         if runner is not None:
@@ -168,7 +168,7 @@ def test_init_worker(grizzly_fixture: GrizzlyFixture) -> None:
 
         assert grizzly.state.locust.custom_messages == cast(dict[str, tuple[Callable, bool]], {
             'grizzly_worker_quit': (grizzly_worker_quit, False),
-            'test_message_ack': (callback_ack, False),
+            'test_message_ack': (callback_ack, True),
         })
     finally:
         if runner is not None:
@@ -213,8 +213,8 @@ def test_init_local(grizzly_fixture: GrizzlyFixture) -> None:
         init_function(runner)
 
         assert grizzly.state.locust.custom_messages == cast(dict[str, tuple[Callable, bool]], {
-            'test_message': (callback, False),
-            'test_message_ack': (callback_ack, False),
+            'test_message': (callback, True),
+            'test_message_ack': (callback_ack, True),
         })
     finally:
         if runner is not None:

--- a/tests/unit/test_grizzly/scenarios/test_iterator.py
+++ b/tests/unit/test_grizzly/scenarios/test_iterator.py
@@ -5,7 +5,7 @@ import logging
 from contextlib import suppress
 from os import environ
 from types import FunctionType
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, cast
 from unittest.mock import ANY
 
 import pytest
@@ -19,6 +19,7 @@ from grizzly.tasks import ExplicitWaitTask, LogMessageTask, grizzlytask
 from grizzly.testdata.communication import TestdataConsumer
 from grizzly.testdata.utils import transform
 from grizzly.types import ScenarioState
+from grizzly.types.locust import LocalRunner
 from tests.helpers import RequestCalled, TestTask, regex
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -113,39 +114,6 @@ class TestIterationScenario:
         assert isinstance(last_task, FunctionType)
         assert last_task.__name__ == 'pace'
 
-    def test_on_event_handlers(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture, caplog: LogCaptureFixture) -> None:
-        try:
-            parent = grizzly_fixture(scenario_type=IteratorScenario)
-
-            mocker.patch(
-                'grizzly.testdata.communication.TestdataConsumer.__init__',
-                return_value=None,
-            )
-
-            consumer_stop_mock = mocker.patch(
-                'grizzly.testdata.communication.TestdataConsumer.stop',
-                return_value=None,
-            )
-
-            assert parent is not None
-
-            mocker.patch.object(parent, 'prefetch', return_value=None)
-
-            with pytest.raises(StopUser), caplog.at_level(logging.ERROR):
-                parent.on_start()
-
-            assert caplog.messages == ['no address to testdata producer specified']
-
-            environ['TESTDATA_PRODUCER_ADDRESS'] = 'localhost:5555'
-
-            parent.on_start()
-
-            parent.on_stop()
-            consumer_stop_mock.assert_called_once_with()
-        finally:
-            with suppress(KeyError):
-                del environ['TESTDATA_PRODUCER_ADDRESS']
-
     def test_prefetch(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture) -> None:
         parent = grizzly_fixture(scenario_type=IteratorScenario)
 
@@ -165,7 +133,7 @@ class TestIterationScenario:
         assert isinstance(parent, IteratorScenario)
         assert not parent._prefetch
 
-        parent.consumer = TestdataConsumer(parent)
+        parent.consumer = TestdataConsumer(cast(LocalRunner, grizzly.state.locust), parent)
 
         on_iteration_mock = mocker.patch.object(parent, 'on_iteration', return_value=None)
 
@@ -724,105 +692,98 @@ class TestIterationScenario:
         parent.user._scenario.failure_handling.update({TaskTimeoutError: RetryTask})
 
         # add tasks to IteratorScenario.tasks
-        try:
-            for i in range(1, 6):
-                name = f'test-task-{i}'
-                parent.user._scenario.tasks.behave_steps.update({i + 1: name})
-                parent.__class__.populate(TestTask(name=name))
+        for i in range(1, 6):
+            name = f'test-task-{i}'
+            parent.user._scenario.tasks.behave_steps.update({i + 1: name})
+            parent.__class__.populate(TestTask(name=name))
 
-            parent.__class__.populate(TestErrorTask(name='test-error-task-1'))
-            parent.user._scenario.tasks.behave_steps.update({7: 'test-error-task-1'})
+        parent.__class__.populate(TestErrorTask(name='test-error-task-1'))
+        parent.user._scenario.tasks.behave_steps.update({7: 'test-error-task-1'})
 
-            for i in range(6, 11):
-                name = f'test-task-{i}'
-                parent.user._scenario.tasks.behave_steps.update({i + 2: name})
-                parent.__class__.populate(TestTask(name=name))
+        for i in range(6, 11):
+            name = f'test-task-{i}'
+            parent.user._scenario.tasks.behave_steps.update({i + 2: name})
+            parent.__class__.populate(TestTask(name=name))
 
-            scenario = parent.__class__(parent.user)
-            scenario.__class__.pace_time = '10000'
-            mocker.patch.object(scenario, 'prefetch', return_value=None)
+        scenario = parent.__class__(parent.user)
+        scenario.__class__.pace_time = '10000'
+        mocker.patch.object(scenario, 'prefetch', return_value=None)
 
-            assert parent.task_count == 13
-            assert len(parent.tasks) == 13
+        assert parent.task_count == 13
+        assert len(parent.tasks) == 13
 
-            mocker.patch('grizzly.scenarios.TestdataConsumer.__init__', return_value=None)
-            mocker.patch('grizzly.scenarios.TestdataConsumer.stop', return_value=None)
+        mocker.patch('grizzly.scenarios.TestdataConsumer.__init__', return_value=None)
 
-            environ['TESTDATA_PRODUCER_ADDRESS'] = 'tcp://localhost:5555'
+        scenario.on_start()  # create scenario.consumer, so we can patch request below
 
-            scenario.on_start()  # create scenario.consumer, so we can patch request below
+        # same as 1 iteration
+        mocker.patch.object(scenario.consumer, 'testdata', side_effect=[
+            {'variables': {'hello': 'world'}},
+            {'variables': {'hello': 'world'}},
+            {'variables': {'foo': 'bar'}},
+            None,
+        ])
+        mocker.patch.object(scenario, 'on_start', return_value=None)
 
-            # same as 1 iteration
-            mocker.patch.object(scenario.consumer, 'testdata', side_effect=[
-                {'variables': {'hello': 'world'}},
-                {'variables': {'hello': 'world'}},
-                {'variables': {'foo': 'bar'}},
-                None,
-            ])
-            mocker.patch.object(scenario, 'on_start', return_value=None)
+        with caplog.at_level(logging.DEBUG), pytest.raises(StopUser):
+            scenario.run()
 
-            with caplog.at_level(logging.DEBUG), pytest.raises(StopUser):
-                scenario.run()
+        expected_messages = [
+            'task 1 of 13 executed: iterator',  # IteratorScenario.iterator()
+            'task 2 of 13 executed: test-task-1',
+            'task 3 of 13 executed: test-task-2',
+            'task 4 of 13 executed: test-task-3',
+            'task 5 of 13 executed: test-task-4',
+            'task 6 of 13 executed: test-task-5',
+            'task 7 of 13 failed: test-error-task-1',
+            'task 7 of 13 will execute a 2nd time in 1.00 seconds: test-error-task-1',
+            'task 7 of 13 failed: test-error-task-1',
+            'restarting scenario at task 7 of 13',
+            '0 tasks in queue',
+            'task 1 of 13 executed: iterator',  # IteratorScenario.iterator()
+            'task 2 of 13 executed: test-task-1',
+            'task 3 of 13 executed: test-task-2',
+            'task 4 of 13 executed: test-task-3',
+            'task 5 of 13 executed: test-task-4',
+            'task 6 of 13 executed: test-task-5',
+            'task 7 of 13 failed: test-error-task-1',
+            'restarting scenario at task 7 of 13',
+            '0 tasks in queue',
+            'task 1 of 13 executed: iterator',  # IteratorScenario.iterator()
+            'task 2 of 13 executed: test-task-1',
+            'task 3 of 13 executed: test-task-2',
+            'task 4 of 13 executed: test-task-3',
+            'task 5 of 13 executed: test-task-4',
+            'task 6 of 13 executed: test-task-5',
+            'stop scenarios before stopping user',
+            'scenario state=ScenarioState.RUNNING -> ScenarioState.STOPPING',
+            'task 7 of 13 executed: test-error-task-1',
+            'not finished with scenario, currently at task 7 of 13, let me be!',
+            'task 8 of 13 executed: test-task-6',
+            'not finished with scenario, currently at task 8 of 13, let me be!',
+            'task 9 of 13 executed: test-task-7',
+            'not finished with scenario, currently at task 9 of 13, let me be!',
+            'task 10 of 13 executed: test-task-8',
+            'not finished with scenario, currently at task 10 of 13, let me be!',
+            'task 11 of 13 executed: test-task-9',
+            'not finished with scenario, currently at task 11 of 13, let me be!',
+            'task 12 of 13 executed: test-task-10',
+            'not finished with scenario, currently at task 12 of 13, let me be!',
+            r'^keeping pace by sleeping [0-9\.]+ milliseconds$',
+            'task 13 of 13 executed: pace',
+            "okay, I'm done with my running tasks now",
+            'scenario state=ScenarioState.STOPPING -> ScenarioState.STOPPED',
+            "scenario_state=STOPPED, user_state=stopping, exception=StopUser()",
+            "stopping scenario with <class 'locust.exception.StopUser'>",
+        ]
 
-            expected_messages = [
-                'task 1 of 13 executed: iterator',  # IteratorScenario.iterator()
-                'task 2 of 13 executed: test-task-1',
-                'task 3 of 13 executed: test-task-2',
-                'task 4 of 13 executed: test-task-3',
-                'task 5 of 13 executed: test-task-4',
-                'task 6 of 13 executed: test-task-5',
-                'task 7 of 13 failed: test-error-task-1',
-                'task 7 of 13 will execute a 2nd time in 1.00 seconds: test-error-task-1',
-                'task 7 of 13 failed: test-error-task-1',
-                'restarting scenario at task 7 of 13',
-                '0 tasks in queue',
-                'task 1 of 13 executed: iterator',  # IteratorScenario.iterator()
-                'task 2 of 13 executed: test-task-1',
-                'task 3 of 13 executed: test-task-2',
-                'task 4 of 13 executed: test-task-3',
-                'task 5 of 13 executed: test-task-4',
-                'task 6 of 13 executed: test-task-5',
-                'task 7 of 13 failed: test-error-task-1',
-                'restarting scenario at task 7 of 13',
-                '0 tasks in queue',
-                'task 1 of 13 executed: iterator',  # IteratorScenario.iterator()
-                'task 2 of 13 executed: test-task-1',
-                'task 3 of 13 executed: test-task-2',
-                'task 4 of 13 executed: test-task-3',
-                'task 5 of 13 executed: test-task-4',
-                'task 6 of 13 executed: test-task-5',
-                'stop scenarios before stopping user',
-                'scenario state=ScenarioState.RUNNING -> ScenarioState.STOPPING',
-                'task 7 of 13 executed: test-error-task-1',
-                'not finished with scenario, currently at task 7 of 13, let me be!',
-                'task 8 of 13 executed: test-task-6',
-                'not finished with scenario, currently at task 8 of 13, let me be!',
-                'task 9 of 13 executed: test-task-7',
-                'not finished with scenario, currently at task 9 of 13, let me be!',
-                'task 10 of 13 executed: test-task-8',
-                'not finished with scenario, currently at task 10 of 13, let me be!',
-                'task 11 of 13 executed: test-task-9',
-                'not finished with scenario, currently at task 11 of 13, let me be!',
-                'task 12 of 13 executed: test-task-10',
-                'not finished with scenario, currently at task 12 of 13, let me be!',
-                r'^keeping pace by sleeping [0-9\.]+ milliseconds$',
-                'task 13 of 13 executed: pace',
-                "okay, I'm done with my running tasks now",
-                'scenario state=ScenarioState.STOPPING -> ScenarioState.STOPPED',
-                "scenario_state=STOPPED, user_state=stopping, exception=StopUser()",
-                "stopping scenario with <class 'locust.exception.StopUser'>",
-            ]
+        actual_messages = [message for message in caplog.messages if not any(ignore in message for ignore in ['instance variable=', 'CPU usage above'])]
 
-            actual_messages = [message for message in caplog.messages if 'instance variable=' not in message]
+        assert len(actual_messages) == len(expected_messages)
 
-            assert len(actual_messages) == len(expected_messages)
-
-            for actual, _expected in zip(actual_messages, expected_messages):
-                expected = regex.possible(_expected)
-                assert actual == expected
-        finally:
-            with suppress(KeyError):
-                del environ['TESTDATA_PRODUCER_ADDRESS']
+        for actual, _expected in zip(actual_messages, expected_messages):
+            expected = regex.possible(_expected)
+            assert actual == expected
 
     def test_run_retry_task(self, grizzly_fixture: GrizzlyFixture, caplog: LogCaptureFixture, mocker: MockerFixture) -> None:
         class TestErrorTask(TestTask):
@@ -872,9 +833,6 @@ class TestIterationScenario:
             assert len(parent.tasks) == 13
 
             mocker.patch('grizzly.scenarios.TestdataConsumer.__init__', return_value=None)
-            mocker.patch('grizzly.scenarios.TestdataConsumer.stop', return_value=None)
-
-            environ['TESTDATA_PRODUCER_ADDRESS'] = 'tcp://localhost:5555'
 
             scenario.on_start()  # create scenario.consumer, so we can patch request below
 
@@ -981,17 +939,6 @@ class TestIterationScenario:
             task_1_on_start_spy = mocker.spy(task_1, '_on_start')
             task_2_on_start_spy = mocker.spy(task_2, '_on_start')
 
-            with pytest.raises(StopUser):
-                scenario.on_start()
-
-            testdata_consumer_mock.assert_not_called()
-            task_1_on_start_spy.assert_not_called()
-            task_2_on_start_spy.assert_not_called()
-            prefetch_mock.assert_not_called()
-            assert getattr(scenario.user, '_scenario_state', None) == ScenarioState.STOPPED
-
-            environ['TESTDATA_PRODUCER_ADDRESS'] = 'tcp://localhost:5555'
-
             scenario.on_start()
 
             assert scenario.user._scenario_state == ScenarioState.RUNNING
@@ -1025,9 +972,6 @@ class TestIterationScenario:
 
         scenario = parent.__class__(parent.user)
 
-        testdata_consumer_mock = mocker.MagicMock()
-        scenario.consumer = testdata_consumer_mock
-
         task_1 = scenario.tasks[-3]
         task_2 = scenario.tasks[-2]
 
@@ -1042,6 +986,5 @@ class TestIterationScenario:
         scenario.on_stop()
 
         assert scenario.user._scenario_state == ScenarioState.STOPPED
-        assert testdata_consumer_mock.stop.call_count == 1
         task_1_on_stop_spy.assert_called_once_with(scenario)
         task_2_on_stop_spy.assert_called_once_with(scenario)

--- a/tests/unit/test_grizzly/steps/scenario/tasks/test_keystore.py
+++ b/tests/unit/test_grizzly/steps/scenario/tasks/test_keystore.py
@@ -148,6 +148,7 @@ def test_step_task_keystore_pop(behave_fixture: BehaveFixture) -> None:
     behave.scenario = grizzly.scenario.behave
 
     grizzly.scenario.tasks.clear()
+    grizzly.scenario.variables.clear()
 
     step_task_keystore_pop(behave, 'foobar', 1)
     assert behave.exceptions == {behave.scenario.name: [ANY(AssertionError, message='action context for "pop" must be a string')]}

--- a/tests/unit/test_grizzly/steps/test_setup.py
+++ b/tests/unit/test_grizzly/steps/test_setup.py
@@ -50,6 +50,9 @@ def test_step_setup_variable_value_ask(behave_fixture: BehaveFixture, section: s
         behave.scenario = grizzly.scenario.behave
         behave_fixture.create_step('test step', in_background=in_background, context=behave)
 
+        for scenario in grizzly.scenarios:
+            scenario.variables.clear()
+
         name = 'AtomicIntegerIncrementer.messageID'
         assert f'TESTDATA_VARIABLE_{name}' not in environ
         behave.assert_variable_value(name, None)

--- a/tests/unit/test_grizzly/tasks/clients/test_messagequeue.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_messagequeue.py
@@ -270,8 +270,9 @@ class TestMessageQueueClientTask:
         connect_mock = noop_zmq.get_mock('zmq.Socket.connect')
         setsockopt_mock = noop_zmq.get_mock('zmq.Socket.setsockopt')
         close_mock = noop_zmq.get_mock('zmq.Socket.close')
-
         zmq_context: ztypes.Context | None = None
+
+        parent = grizzly_fixture()
         try:
             MessageQueueClientTask.__scenario__ = grizzly_fixture.grizzly.scenario
             task_factory = MessageQueueClientTask(
@@ -280,7 +281,7 @@ class TestMessageQueueClientTask:
             )
             zmq_context = task_factory._zmq_context
 
-            with task_factory.create_client() as client:
+            with task_factory.create_client(parent) as client:
                 assert connect_mock.call_count == 1
                 args, kwargs = connect_mock.call_args_list[-1]
                 assert args == (task_factory._zmq_url,)
@@ -302,8 +303,10 @@ class TestMessageQueueClientTask:
     def test_connect(self, grizzly_fixture: GrizzlyFixture, mocker: MockerFixture, noop_zmq: NoopZmqFixture) -> None:  # noqa: PLR0915
         noop_zmq('grizzly.tasks.clients.messagequeue')
         mocker.patch('grizzly_extras.async_message.utils.uuid4', return_value='foobar')
-
         zmq_context: ztypes.Context | None = None
+
+        parent = grizzly_fixture()
+
         try:
             MessageQueueClientTask.__scenario__ = grizzly_fixture.grizzly.scenario
             task_factory = MessageQueueClientTask(
@@ -312,7 +315,7 @@ class TestMessageQueueClientTask:
             )
             zmq_context = task_factory._zmq_context
 
-            with task_factory.create_client() as client:
+            with task_factory.create_client(parent) as client:
                 recv_json_mock = mocker.patch.object(client, 'recv_json')
                 send_json_mock = mocker.patch.object(client, 'send_json')
                 recv_json_mock.side_effect = [ZMQAgain, None]
@@ -382,7 +385,7 @@ class TestMessageQueueClientTask:
             )
             zmq_context = task_factory._zmq_context
 
-            with task_factory.create_client() as client:
+            with task_factory.create_client(parent) as client:
                 recv_json_mock = mocker.patch.object(client, 'recv_json')
                 send_json_mock = mocker.patch.object(client, 'send_json')
 

--- a/tests/unit/test_grizzly/test_behave.py
+++ b/tests/unit/test_grizzly/test_behave.py
@@ -107,8 +107,6 @@ def test_before_feature(behave_fixture: BehaveFixture, tmp_path_factory: TempPat
             'hello': 'world',
         }
 
-        GrizzlyContext.destroy()
-
         before_feature(context, feature)
 
         assert hasattr(context, 'started')
@@ -265,6 +263,7 @@ def test_before_scenario(behave_fixture: BehaveFixture, mocker: MockerFixture) -
     assert len(behave.scenario.background.steps) == 5
 
     grizzly = cast(GrizzlyContext, behave.grizzly)
+    grizzly.scenarios.clear()
 
     assert len(grizzly.scenarios()) == 0
 

--- a/tests/unit/test_grizzly/test_context.py
+++ b/tests/unit/test_grizzly/test_context.py
@@ -274,7 +274,7 @@ class TestGrizzlyContext:
         grizzly = cast(GrizzlyContext, behave.grizzly)
         assert isinstance(grizzly, GrizzlyContext)
 
-        second_grizzly = GrizzlyContext()
+        from grizzly.context import grizzly as second_grizzly
 
         assert grizzly is second_grizzly
 
@@ -289,7 +289,7 @@ class TestGrizzlyContext:
         ]
         expected_attributes.sort()
 
-        actual_attributes = list(get_property_decorated_attributes(grizzly.__class__))
+        actual_attributes = list(get_property_decorated_attributes(grizzly.__class__)) + list(filter(lambda d: not d.startswith('_'), grizzly.__dict__))
         actual_attributes.sort()
 
         for test_attribute in expected_attributes:
@@ -298,20 +298,6 @@ class TestGrizzlyContext:
         assert isinstance(grizzly.setup, GrizzlyContextSetup)
         assert callable(getattr(grizzly, 'scenarios', None))
         assert expected_attributes == actual_attributes
-
-    def test_destroy(self, behave_fixture: BehaveFixture) -> None:
-        behave = behave_fixture.context
-        grizzly = cast(GrizzlyContext, behave.grizzly)
-        assert grizzly is GrizzlyContext()
-
-        GrizzlyContext.destroy()
-
-        with pytest.raises(ValueError, match="'GrizzlyContext' is not instantiated"):
-            GrizzlyContext.destroy()
-
-        grizzly = GrizzlyContext()
-
-        assert grizzly is GrizzlyContext()
 
 
 class TestGrizzlyContextScenarios:
@@ -583,7 +569,7 @@ class TestGrizzlyContextTasks:
     def test___init__(self) -> None:
         tasks = GrizzlyContextTasks()
 
-        assert isinstance(tasks._tmp, GrizzlyContextTasksTmp)
+        assert isinstance(tasks.tmp, GrizzlyContextTasksTmp)
         assert tasks.tmp is tasks._tmp
 
     def test___call__(self, grizzly_fixture: GrizzlyFixture) -> None:

--- a/tests/unit/test_grizzly/test_context.py
+++ b/tests/unit/test_grizzly/test_context.py
@@ -6,6 +6,7 @@ from os import environ
 from typing import TYPE_CHECKING, Any, Optional, cast
 
 import pytest
+from gevent.lock import Semaphore
 
 from grizzly.context import (
     GrizzlyContext,
@@ -24,7 +25,7 @@ from grizzly.locust import FixedUsersDispatcher
 from grizzly.tasks import AsyncRequestGroupTask, ConditionalTask, ExplicitWaitTask, LogMessageTask, LoopTask, RequestTask
 from grizzly.types import MessageDirection, RequestMethod
 from grizzly.types.behave import Scenario
-from tests.helpers import TestTask, get_property_decorated_attributes, rm_rf
+from tests.helpers import ANY, TestTask, get_property_decorated_attributes, rm_rf
 
 if TYPE_CHECKING:  # pragma: no cover
     from _pytest.tmpdir import TempPathFactory
@@ -206,7 +207,7 @@ class TestGrizzlyContextState:
         state = GrizzlyContextState()
 
         expected_properties = {
-            'spawning_complete': (False, True),
+            'spawning_complete': (ANY(Semaphore), None),
             'background_done': (False, True),
             'configuration': ({}, {'sut.host': 'http://example.com'}),
             'verbose': (False, True),
@@ -220,8 +221,10 @@ class TestGrizzlyContextState:
             assert test_attribute_name in actual_attributes
             assert hasattr(state, test_attribute_name)
             assert getattr(state, test_attribute_name) == default_value
-            setattr(state, test_attribute_name, test_value)
-            assert getattr(state, test_attribute_name) == test_value
+
+            if test_value is not None:
+                setattr(state, test_attribute_name, test_value)
+                assert getattr(state, test_attribute_name) == test_value
 
     def test_configuration(self, grizzly_fixture: GrizzlyFixture, tmp_path_factory: TempPathFactory) -> None:
         grizzly = grizzly_fixture.grizzly

--- a/tests/unit/test_grizzly/test_locust.py
+++ b/tests/unit/test_grizzly/test_locust.py
@@ -426,7 +426,7 @@ def test_setup_environment_listeners(behave_fixture: BehaveFixture, mocker: Mock
         assert len(environment.events.test_start._handlers) == 1
         assert len(environment.events.test_stop._handlers) == 1
         assert len(environment.events.spawning_complete._handlers) == 1
-        assert len(environment.events.quitting._handlers) == 1
+        assert len(environment.events.quitting._handlers) == 0
 
         AtomicIntegerIncrementer.destroy()
         grizzly.setup.statistics_url = 'influxdb://influx.example.com:1231/testdb'
@@ -437,7 +437,7 @@ def test_setup_environment_listeners(behave_fixture: BehaveFixture, mocker: Mock
         assert len(environment.events.test_start._handlers) == 1
         assert len(environment.events.test_stop._handlers) == 1
         assert len(environment.events.spawning_complete._handlers) == 1
-        assert len(environment.events.quitting._handlers) == 1
+        assert len(environment.events.quitting._handlers) == 0
 
         grizzly.scenario.validation.fail_ratio = 0.1
         environment.events.spawning_complete._handlers = []
@@ -447,7 +447,7 @@ def test_setup_environment_listeners(behave_fixture: BehaveFixture, mocker: Mock
         assert len(environment.events.test_start._handlers) == 1
         assert len(environment.events.test_stop._handlers) == 1
         assert len(environment.events.spawning_complete._handlers) == 1
-        assert len(environment.events.quitting._handlers) == 2
+        assert len(environment.events.quitting._handlers) == 1
 
         grizzly.setup.statistics_url = None
         environment.events.spawning_complete._handlers = []
@@ -556,7 +556,6 @@ def test_run_worker(behave_fixture: BehaveFixture, capsys: CaptureFixture, mocke
     for method in [
         'locust.runners.WorkerRunner.start_worker',
         'gevent.sleep',
-        'grizzly.listeners._init_testdata_producer',
     ]:
         mocker.patch(
             method,
@@ -619,7 +618,6 @@ def test_run_master(behave_fixture: BehaveFixture, capsys: CaptureFixture, mocke
         'locust.runners.MasterRunner.client_listener',
         'gevent.sleep',
         'locust.rpc.zmqrpc.Server.__init__',
-        'grizzly.listeners._init_testdata_producer',
     ]:
         mocker.patch(
             method,

--- a/tests/unit/test_grizzly/test_locust.py
+++ b/tests/unit/test_grizzly/test_locust.py
@@ -599,7 +599,7 @@ def test_run_worker(behave_fixture: BehaveFixture, capsys: CaptureFixture, mocke
     # @TODO: test coverage further down in run is needed!
 
 
-def test_run_master(behave_fixture: BehaveFixture, capsys: CaptureFixture, mocker: MockerFixture) -> None:
+def test_run_master(behave_fixture: BehaveFixture, capsys: CaptureFixture, mocker: MockerFixture) -> None:  # noqa: PLR0915
     behave = behave_fixture.context
 
     def mock_on_node(*, master: bool, worker: bool) -> None:
@@ -630,6 +630,9 @@ def test_run_master(behave_fixture: BehaveFixture, capsys: CaptureFixture, mocke
             return_value=None,
         )
 
+    behave.grizzly.state.spawning_complete = mocker.MagicMock(spec=gevent.lock.Semaphore)
+    environ['GRIZZLY_FEATURE_FILE'] = 'test.feature'
+
     def mocked_popen___init__(*args: Any, **_kwargs: Any) -> None:
         setattr(args[0], 'returncode', -15)  # noqa: B010
 
@@ -647,56 +650,62 @@ def test_run_master(behave_fixture: BehaveFixture, capsys: CaptureFixture, mocke
         'worker': 'true',
     }
 
-    assert run(behave) == 254
+    try:
+        assert run(behave) == 254
 
-    capture = capsys.readouterr()
-    assert 'cannot be both master and worker' in capture.err
+        capture = capsys.readouterr()
+        assert 'cannot be both master and worker' in capture.err
 
-    behave.config.userdata = {'master': 'true'}
+        behave.config.userdata = {'master': 'true'}
 
-    grizzly = cast(GrizzlyContext, behave.grizzly)
+        grizzly = cast(GrizzlyContext, behave.grizzly)
 
-    grizzly.setup.spawn_rate = None
-    assert run(behave) == 254
+        grizzly.setup.spawn_rate = None
+        assert run(behave) == 254
 
-    capture = capsys.readouterr()
-    assert 'spawn rate is not set' in capture.err
+        capture = capsys.readouterr()
+        assert 'spawn rate is not set' in capture.err
 
-    grizzly.setup.spawn_rate = 1
+        grizzly.setup.spawn_rate = 1
 
-    assert run(behave) == 254
+        assert run(behave) == 254
 
-    capture = capsys.readouterr()
-    assert 'step \'Given "user_count" users\' is not in the feature file' in capture.err
+        capture = capsys.readouterr()
+        assert 'step \'Given "user_count" users\' is not in the feature file' in capture.err
 
-    grizzly.setup.user_count = 2
-    grizzly.scenarios.create(behave_fixture.create_scenario('test'))
-    grizzly.scenario.user.class_name = 'RestApiUser'
-    grizzly.scenario.context['host'] = 'https://test.example.org'
-    grizzly.scenario.tasks.add(ExplicitWaitTask(time_expression='1.5'))
-    task = RequestTask(RequestMethod.GET, 'test-1', '/api/v1/test/1')
-    grizzly.scenario.tasks.add(task)
-    grizzly.setup.spawn_rate = 1
+        grizzly.setup.user_count = 2
+        grizzly.scenarios.create(behave_fixture.create_scenario('test'))
+        grizzly.scenario.user.class_name = 'RestApiUser'
+        grizzly.scenario.context['host'] = 'https://test.example.org'
+        grizzly.scenario.tasks.add(ExplicitWaitTask(time_expression='1.5'))
+        task = RequestTask(RequestMethod.GET, 'test-1', '/api/v1/test/1')
+        grizzly.scenario.tasks.add(task)
+        grizzly.setup.spawn_rate = 1
 
-    grizzly.setup.timespan = 'adsf'
-    assert run(behave) == 1
-    assert 'invalid timespan' in capsys.readouterr().err
-    assert grizzly.setup.dispatcher_class == WeightedUsersDispatcher
+        grizzly.setup.timespan = 'adsf'
+        assert run(behave) == 1
+        assert 'invalid timespan' in capsys.readouterr().err
+        assert grizzly.setup.dispatcher_class == WeightedUsersDispatcher
 
-    grizzly.setup.timespan = None
+        grizzly.setup.timespan = None
 
-    behave.config.userdata = {
-        'expected-workers': 3,
-    }
+        behave.config.userdata = {
+            'expected-workers': 3,
+        }
 
-    mock_on_node(master=True, worker=False)
+        mock_on_node(master=True, worker=False)
 
-    with pytest.raises(AssertionError, match=r'there are more workers \(3\) than users \(2\), which is not supported'):
-        run(behave)
+        with pytest.raises(AssertionError, match=r'there are more workers \(3\) than users \(2\), which is not supported'):
+            run(behave)
 
-    assert messagequeue_process_spy.call_count == 0
+        assert messagequeue_process_spy.call_count == 0
+    finally:
+        with suppress(KeyError):
+            del environ['GRIZZLY_FEATURE_FILE']
 
-    del behave.config.userdata['expected-workers']
+
+        with suppress(KeyError):
+            del behave.config.userdata['expected-workers']
 
     # @TODO: this is where it gets hard(er)...
 

--- a/tests/unit/test_grizzly/testdata/test_communication.py
+++ b/tests/unit/test_grizzly/testdata/test_communication.py
@@ -6,7 +6,7 @@ import logging
 from contextlib import suppress
 from os import environ, sep
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, cast
+from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
 import pytest
 from gevent.event import AsyncResult
@@ -155,7 +155,7 @@ value3,value4
                     {'uid': uid, 'cid': cast(LocalRunner, grizzly.state.locust).client_id, 'request': {'message': 'testdata', 'identifier': grizzly.scenario.class_name}},
                 )
 
-                response = cast(dict[str, Any] | None, responses[uid].get())
+                response = cast(Optional[dict[str, Any]], responses[uid].get())
 
                 del responses[uid]
 
@@ -177,7 +177,7 @@ value3,value4
                 responses[uid] = AsyncResult()
                 grizzly.state.locust.send_message('produce_testdata', {'uid': uid, 'cid': cast(LocalRunner, grizzly.state.locust).client_id, 'request': request})
 
-                response = cast(dict[str, Any] | None, responses[uid].get())
+                response = cast(Optional[dict[str, Any]], responses[uid].get())
 
                 del responses[uid]
 
@@ -437,7 +437,7 @@ value3,value4
                     {'uid': uid, 'cid': cast(LocalRunner, grizzly.state.locust).client_id, 'request': {'message': 'testdata', 'identifier': grizzly.scenario.class_name}},
                 )
 
-                response = cast(dict[str, Any] | None, responses[uid].get())
+                response = cast(Optional[dict[str, Any]], responses[uid].get())
 
                 del responses[uid]
 
@@ -596,7 +596,7 @@ value3,value4
                 responses[uid] = AsyncResult()
                 grizzly.state.locust.send_message('produce_testdata', {'uid': uid, 'cid': cast(LocalRunner, grizzly.state.locust).client_id, 'request': request})
 
-                response = cast(dict[str, Any] | None, responses[uid].get())
+                response = cast(Optional[dict[str, Any]], responses[uid].get())
 
                 del responses[uid]
 

--- a/tests/unit/test_grizzly/testdata/test_utils.py
+++ b/tests/unit/test_grizzly/testdata/test_utils.py
@@ -28,7 +28,7 @@ from grizzly_extras.transformer import TransformerContentType
 if TYPE_CHECKING:  # pragma: no cover
     from _pytest.logging import LogCaptureFixture
 
-    from tests.fixtures import AtomicVariableCleanupFixture, GrizzlyFixture, NoopZmqFixture, RequestTaskFixture
+    from tests.fixtures import AtomicVariableCleanupFixture, GrizzlyFixture, RequestTaskFixture
 
 
 def test_initialize_testdata_no_tasks(grizzly_fixture: GrizzlyFixture) -> None:
@@ -137,9 +137,7 @@ def test_initialize_testdata_with_tasks(
         cleanup()
 
 
-def test_initialize_testdata_with_payload_context(grizzly_fixture: GrizzlyFixture, cleanup: AtomicVariableCleanupFixture, noop_zmq: NoopZmqFixture) -> None:  # noqa: PLR0915
-    noop_zmq('grizzly.testdata.communication')
-
+def test_initialize_testdata_with_payload_context(grizzly_fixture: GrizzlyFixture, cleanup: AtomicVariableCleanupFixture) -> None:  # noqa: PLR0915
     try:
         grizzly = grizzly_fixture.grizzly
         parent = grizzly_fixture()


### PR DESCRIPTION
simplified `GrizzlyContext` by removing singleton logic from instance creation, and instead creates a global instance which should be imported where needed.

rewrite of `Testdata*` communication, to use locust custom messages instead of their own ZMQ socket and connection.

better handling for being able to determine if spawning has completed.
`grizzly.state.spawning_complete`, replace bool with a Semaphore, which is acquired on locust init, and released on "spawning complete" event.

master/local uses the semaphore before starting the check that there are users running.

workers/local uses the semaphore to not stop any users before all users has been spawned. this is to prevent locust to spawn additional users that has stopped before complete spawning has finished.
stopping a users after all users has spawned will not result in additional users spawning after being stopped.