### PR TITLE
IotHubUser: `allow_already_exist` argument for requests

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,6 +19,9 @@
                 "python.pythonPath": "/usr/local/bin/python",
                 "python.languageServer": "Pylance",
                 "pythonTestExplorer.testFramework": "pytest",
+                "github.copilot.enable": {
+                    "*": false
+                },
                 "files.associations": {
                     "*.j2.json": "jinja-json",
                     "*.j2.xml": "jinja-xml"

--- a/tests/unit/test_grizzly/users/test_iothub.py
+++ b/tests/unit/test_grizzly/users/test_iothub.py
@@ -187,9 +187,11 @@ class TestIotHubUser:
                 'messageID': 137,
             }),
         }
+        old_request = cast(RequestTask, user._scenario.tasks()[-1])
+        request = RequestTask(RequestMethod.SEND, "test-send", "not_relevant | allow_aready_exists=True", old_request.source)
+        user._scenario.tasks().clear()
+        user._scenario.tasks.add(request)
         user.add_context(remote_variables)
-        request = cast(RequestTask, user._scenario.tasks()[-1])
-        request.endpoint = 'not_relevant'
 
         expected_payload = {
             'result': {


### PR DESCRIPTION
which would allow the request task to continue and notify the file, which could be the case when the task is retried due to a earlier timeout, but the file upload actually finished.