### PR TITLE
no http retries

### DIFF
--- a/docs/content/framework/usage/variables/environment-configuration.md
+++ b/docs/content/framework/usage/variables/environment-configuration.md
@@ -125,6 +125,7 @@ configuration:
 ```
 
 With the following secrets in `grizzly-dummy` keyvault:
+
 | key                                            | value  |
 | ---------------------------------------------- | ------ |
 | grizzly--global--authentication-admin-username | root   |

--- a/grizzly/scenarios/__init__.py
+++ b/grizzly/scenarios/__init__.py
@@ -99,6 +99,9 @@ class GrizzlyScenario(SequentialTaskSet):
         self.user.consumer = self.__class__._consumer
         self.user.scenario_state = ScenarioState.RUNNING
 
+        # only prefetch iterator testdata if everything was started OK
+        self.prefetch()
+
         for task in self.tasks:
             if isinstance(task, grizzlytask):
                 try:  # type: ignore[unreachable]
@@ -106,9 +109,6 @@ class GrizzlyScenario(SequentialTaskSet):
                 except:
                     self.logger.exception('on_start failed for task %r', task)
                     raise StopUser from None
-
-        # only prefetch iterator testdata if everything was started OK
-        self.prefetch()
 
     def on_iteration(self) -> None:
         self.user.on_iteration()

--- a/grizzly/tasks/clients/http.py
+++ b/grizzly/tasks/clients/http.py
@@ -222,7 +222,12 @@ class HttpClientTask(ClientTask, GrizzlyHttpAuthClient):
             }})
 
 
-            with Session(insecure=not self.verify, network_timeout=self.timeout, ssl_context_factory=self.ssl_context_factory) as client:
+            with Session(
+                insecure=not self.verify,
+                network_timeout=self.timeout,
+                ssl_context_factory=self.ssl_context_factory,
+                max_retries=0,
+            ) as client:
                 http_populate_cookiejar(client, self.cookies, url=url)
                 response = client.get(url, headers=self.metadata, **self.arguments)
 

--- a/grizzly/users/iothub.py
+++ b/grizzly/users/iothub.py
@@ -383,8 +383,6 @@ class IotHubUser(GrizzlyUser):
         filename = request.endpoint
         storage_info: dict[str, Any] | None = None
 
-        print(f'{request.arguments=}')
-
         try:
             with retry(retries=3, exceptions=(ClientError,), backoff=1.0) as context:
                 storage_info = cast(dict[str, Any], context.execute(self.iot_client.get_storage_info_for_blob, filename))

--- a/grizzly/users/iothub.py
+++ b/grizzly/users/iothub.py
@@ -272,12 +272,17 @@ class IotHubUser(GrizzlyUser):
     def on_start(self) -> None:
         super().on_start()
 
-        if self._scenario.user.fixed_count != 1:
-            self.logger.warning('do not run more than 1 user if you rely on cloud-to-device messages')
-
         self.iot_client = IoTHubDeviceClient.create_from_connection_string(self.host, websockets=True)
         self.iot_client.connect()
-        self.iot_client.on_message_received = self.message_handler
+
+        if self._scenario.user.fixed_count == 1:
+            self.iot_client.on_message_received = self.message_handler
+        else:
+            self.logger.warning(
+                'no handler for C2D messages registered, since there are %d users of type %s',
+                self._scenario.user.fixed_count,
+                self._scenario.user.class_name,
+            )
 
     def on_state(self, *, state: ScenarioState) -> None:
         super().on_state(state=state)

--- a/grizzly/users/iothub.py
+++ b/grizzly/users/iothub.py
@@ -279,7 +279,7 @@ class IotHubUser(GrizzlyUser):
             self.iot_client.on_message_received = self.message_handler
         else:
             self.logger.warning(
-                'no handler for C2D messages registered, since there are %d users of type %s',
+                'no handler for C2D messages registered, since there are %s users of type %s',
                 self._scenario.user.fixed_count,
                 self._scenario.user.class_name,
             )

--- a/grizzly/users/restapi.py
+++ b/grizzly/users/restapi.py
@@ -211,7 +211,7 @@ class RestApiUser(GrizzlyUser, AsyncRequests, GrizzlyHttpAuthClient, metaclass=R
             base_url=self.host,
             user=self,
             insecure=not self._context.get('verify_certificates', True),
-            max_retries=1,
+            max_retries=0,
             network_timeout=self._context.get('timeout', 60),
             ssl_context_factory=_ssl_context_factory,
         )

--- a/tests/e2e/steps/scenario/test_tasks.py
+++ b/tests/e2e/steps/scenario/test_tasks.py
@@ -389,7 +389,7 @@ def test_e2e_step_task_transform(e2e_fixture: End2EndFixture) -> None:
         assert task.content_type == TransformerContentType.JSON
         assert issubclass(task._transformer, JsonTransformer)
         assert task.get_templates() == ['{{ document }}']
-        assert callable(task._parser)
+        assert task.min_matches == 1
 
         task = tasks[1]
         assert isinstance(task, TransformerTask)
@@ -399,7 +399,7 @@ def test_e2e_step_task_transform(e2e_fixture: End2EndFixture) -> None:
         assert task.content_type == TransformerContentType.JSON
         assert issubclass(task._transformer, JsonTransformer)
         assert task.get_templates() == ['{{ document }}']
-        assert callable(task._parser)
+        assert task.min_matches == 0
 
     e2e_fixture.add_validator(validate_transform)
 
@@ -409,7 +409,7 @@ def test_e2e_step_task_transform(e2e_fixture: End2EndFixture) -> None:
             'And value for variable "document_title" is "None"',
             'And value for variable "document" is "{"document": {"id": "DOCUMENT_8843-1", "title": "TPM Report 2021"}}"',
             'Then parse "{{ document }}" as "json" and save value of "$.document.id" in variable "document_id"',
-            'Then parse "{{ document }}" as "json" and save value of "$.document.title" in variable "document_title"',
+            'Then parse "{{ document }}" as "json" and save value of "$.document.title | min_matches=0" in variable "document_title"',
             'Then log message "document_id={{ document_id }}"',
             'Then log message "document_title={{ document_title }}"',
         ],


### PR DESCRIPTION
change so that `RestApiUser` and `HttpClientTask` does not retry requests.

`GrizzlyScenario` should prefetch testdata before running tasks `on_start` logic, since it might be needed there.

A new pipe argument (`|`) for transformer tasks, which makes it possible to allow 0 matches, which could be valid in some scenarios.