### PR TITLE
bump locust version

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         runs-on: ['ubuntu-latest']
         include:
           - python-version: '3.12'

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12']
         runs-on: ['ubuntu-latest']
         include:
           - python-version: '3.12'

--- a/example/features/steps/custom.py
+++ b/example/features/steps/custom.py
@@ -32,11 +32,11 @@ class Task(GrizzlyTask):
     def __call__(self) -> grizzlytask:
         @grizzlytask
         def implementation(parent: GrizzlyScenario) -> Any:
-            if isinstance(parent.grizzly.state.locust, (LocalRunner,)) and self.data.get('server', None) is not None:
+            if isinstance(parent.grizzly.state.locust, LocalRunner) and self.data.get('server', None) is not None:
                 self.logger.info('sending "server_client" from SERVER')
                 parent.grizzly.state.locust.send_message('server_client', self.data)
 
-            if isinstance(parent.grizzly.state.locust, (WorkerRunner, LocalRunner)) and self.data.get('client', None) is not None:
+            if isinstance(parent.grizzly.state.locust, WorkerRunner | LocalRunner) and self.data.get('client', None) is not None:
                 self.logger.info('sending "client_server" from CLIENT')
                 parent.grizzly.state.locust.send_message('client_server', self.data)
 

--- a/grizzly/auth/__init__.py
+++ b/grizzly/auth/__init__.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 
 import logging
 from abc import ABCMeta
+from collections.abc import Callable
 from datetime import datetime, timezone
 from functools import wraps
 from importlib import import_module
 from time import perf_counter
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Generic, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar, Union, cast
 from urllib.parse import urlparse
 
 from azure.core.credentials import AccessToken

--- a/grizzly/context.py
+++ b/grizzly/context.py
@@ -2,11 +2,12 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from os import environ
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 import yaml
 from gevent.lock import Semaphore

--- a/grizzly/events/__init__.py
+++ b/grizzly/events/__init__.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 
 import logging
 from abc import ABCMeta, abstractmethod
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from functools import wraps
 from time import perf_counter
-from typing import TYPE_CHECKING, Any, Callable, Optional, Protocol, Union
+from typing import TYPE_CHECKING, Any, Optional, Protocol, Union
 
 from locust.event import EventHook
 

--- a/grizzly/exceptions.py
+++ b/grizzly/exceptions.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from random import uniform
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from gevent import sleep as gsleep
 from locust.exception import StopUser
@@ -11,6 +11,7 @@ from typing_extensions import Self
 from grizzly_extras.exceptions import StopScenario
 
 if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Callable
     from types import TracebackType
 
     from grizzly.context import GrizzlyContextScenario
@@ -117,7 +118,7 @@ def failure_handler(exception: Exception | None, scenario: GrizzlyContextScenari
         raise exception
 
     # always raise StopUser when these unhandled exceptions has occured
-    if isinstance(exception, (NotImplementedError, KeyError, IndexError, AttributeError, TypeError, SyntaxError)):
+    if isinstance(exception, NotImplementedError | KeyError | IndexError | AttributeError | TypeError | SyntaxError):
         raise StopUser from exception
 
     # custom actions based on failure

--- a/grizzly/gevent.py
+++ b/grizzly/gevent.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 from gevent import Greenlet, Timeout, getcurrent
 
@@ -12,7 +12,7 @@ from grizzly.types import FailureAction
 
 if TYPE_CHECKING:  # pragma: no cover
     import logging
-    from collections.abc import Generator
+    from collections.abc import Callable, Generator
 
     from grizzly.scenarios import GrizzlyScenario
 

--- a/grizzly/listeners/__init__.py
+++ b/grizzly/listeners/__init__.py
@@ -2,7 +2,8 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Callable, Optional, cast
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Concatenate, Optional, cast
 from urllib.parse import urlparse
 
 from locust.stats import (
@@ -12,7 +13,7 @@ from locust.stats import (
     print_percentile_stats,
     print_stats,
 )
-from typing_extensions import Concatenate, ParamSpec
+from typing_extensions import ParamSpec
 
 from grizzly.testdata.communication import GrizzlyDependencies, TestdataConsumer, TestdataProducer
 from grizzly.types import MessageDirection, RequestType, TestdataType

--- a/grizzly/locust.py
+++ b/grizzly/locust.py
@@ -15,7 +15,7 @@ from os import environ
 from platform import node as gethostname
 from signal import SIGINT, SIGTERM, Signals
 from time import perf_counter
-from typing import TYPE_CHECKING, Any, Callable, NoReturn, Optional, SupportsIndex, TypeVar, cast
+from typing import TYPE_CHECKING, Any, NoReturn, Optional, SupportsIndex, TypeVar, cast
 
 import gevent
 import gevent.event
@@ -45,7 +45,7 @@ __all__ = [
 
 
 if TYPE_CHECKING:  # pragma: no cover
-    from collections.abc import Generator, Iterator
+    from collections.abc import Callable, Generator, Iterator
 
     from gevent.fileobject import FileObjectThread
     from locust.runners import WorkerNode
@@ -188,7 +188,7 @@ class FixedUsersDispatcher(UsersDispatcher):
         and the one below is the most efficient.
         """
         # type is ignored due to: https://github.com/python/mypy/issues/1507
-        return dict(zip(users_on_workers.keys(), map(dict.copy, users_on_workers.values())))  # type: ignore[arg-type]
+        return dict(zip(users_on_workers.keys(), map(dict.copy, users_on_workers.values()), strict=False))  # type: ignore[arg-type]
 
     def __next__(self) -> dict[str, dict[str, int]]:
         users_on_workers = next(self._dispatcher_generator)
@@ -496,7 +496,7 @@ class FixedUsersDispatcher(UsersDispatcher):
 
         # map worker to sticky tag
         self._workers_to_sticky_tag.clear()
-        for worker, worker_sticky_tag in zip(self._worker_nodes, sticky_tags_gen):
+        for worker, worker_sticky_tag in zip(self._worker_nodes, sticky_tags_gen, strict=False):
             if worker_sticky_tag is None:
                 continue
             self._workers_to_sticky_tag.update({worker: worker_sticky_tag})

--- a/grizzly/scenarios/__init__.py
+++ b/grizzly/scenarios/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from math import floor
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, Union, cast
 
 from gevent.event import Event
 from locust.exception import LocustError
@@ -17,6 +17,7 @@ from grizzly.types.locust import LocalRunner, StopUser, WorkerRunner
 
 if TYPE_CHECKING:  # pragma: no cover
     import logging
+    from collections.abc import Callable
 
     from gevent import Greenlet
     from locust.user.task import TaskSet

--- a/grizzly/steps/scenario/response.py
+++ b/grizzly/steps/scenario/response.py
@@ -236,7 +236,7 @@ def step_response_allow_status_codes(context: Context, status_list: str) -> None
 
     request = grizzly.scenario.tasks()[-1]
 
-    assert isinstance(request, (RequestTask, HttpClientTask)), 'previous task is not a request'
+    assert isinstance(request, RequestTask | HttpClientTask), 'previous task is not a request'
 
     add_request_response_status_codes(request, status_list)
 
@@ -286,7 +286,7 @@ def step_response_allow_status_codes_table(context: Context) -> None:
     try:
         for row in rows:
             task = tasks[index]
-            assert isinstance(task, (RequestTask, HttpClientTask)), f'task at index {index} is not a request'
+            assert isinstance(task, RequestTask | HttpClientTask), f'task at index {index} is not a request'
             index -= 1
             add_request_response_status_codes(task, row['status'])
     except KeyError as e:

--- a/grizzly/steps/scenario/setup.py
+++ b/grizzly/steps/scenario/setup.py
@@ -278,7 +278,7 @@ def step_setup_metadata(context: Context, key: str, value: str) -> None:
     if len(tasks) > 0:
         previous_task = tasks[-1]
 
-    if isinstance(previous_task, (RequestTask, GrizzlyHttpAuthClient)):
+    if isinstance(previous_task, RequestTask | GrizzlyHttpAuthClient):
         previous_task.add_metadata(key, value)
     else:
         if grizzly.scenario.context.get('metadata', None) is None:

--- a/grizzly/tasks/__init__.py
+++ b/grizzly/tasks/__init__.py
@@ -55,10 +55,11 @@ There are examples of this in the {@link framework.example}.
 from __future__ import annotations
 
 from abc import ABC, ABCMeta, abstractmethod
+from collections.abc import Callable
 from inspect import getmro
 from os import environ
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Optional, Union, cast, overload
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, Union, cast, overload
 
 from grizzly.utils import has_template
 

--- a/grizzly/tasks/clients/http.py
+++ b/grizzly/tasks/clients/http.py
@@ -49,7 +49,7 @@ import logging
 from json import dumps as jsondumps
 from pathlib import Path
 from time import time
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Optional, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, cast
 
 from geventhttpclient import Session
 from locust.exception import CatchResponseError
@@ -65,6 +65,8 @@ from grizzly_extras.transformer import TransformerContentType
 from . import ClientTask, client
 
 if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Callable
+
     from geventhttpclient.useragent import CompatResponse
 
     from grizzly.scenarios import GrizzlyScenario
@@ -180,7 +182,7 @@ class HttpClientTask(ClientTask, GrizzlyHttpAuthClient):
 
     def _handle_response(self, parent: GrizzlyScenario, meta: dict[str, Any], url: str, response: CompatResponse) -> GrizzlyResponse:
         text = response.text
-        payload = text.decode() if isinstance(text, (bytearray, bytes)) else text
+        payload = text.decode() if isinstance(text, bytearray | bytes) else text
 
         metadata = {key: value for key, value in response.headers.items()}  # noqa: C416
 

--- a/grizzly/tasks/conditional.py
+++ b/grizzly/tasks/conditional.py
@@ -130,7 +130,7 @@ class ConditionalTask(GrizzlyTaskWrapper):
                 name = f'{parent.user._scenario.identifier} {self.name}: {condition_rendered} ({task_count})'
 
                 # do not log these exceptions if thrown from wrapped task, just log the error for this task
-                if not isinstance(exception, (StopUser, RestartScenario)):
+                if not isinstance(exception, StopUser | RestartScenario):
                     parent.user.environment.events.request.fire(
                         request_type='COND',
                         name=name,

--- a/grizzly/tasks/until.py
+++ b/grizzly/tasks/until.py
@@ -44,7 +44,7 @@ import json
 import logging
 from contextlib import suppress
 from time import perf_counter
-from typing import TYPE_CHECKING, Any, Callable, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 from gevent import sleep as gsleep
 
@@ -60,6 +60,8 @@ from grizzly_extras.transformer import Transformer, TransformerContentType, Tran
 from . import GrizzlyMetaRequestTask, GrizzlyTask, grizzlytask, template
 
 if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Callable
+
     from grizzly.scenarios import GrizzlyScenario
 
 
@@ -170,7 +172,7 @@ class UntilRequestTask(GrizzlyTask):
 
                         # only way to get these exceptions here is if we've beem abprted
                         # by injecting an exception in the task greenlet
-                        if isinstance(e, (StopUser, StopScenario)):
+                        if isinstance(e, StopUser | StopScenario):
                             break
                     finally:
                         retry += 1

--- a/grizzly/testdata/__init__.py
+++ b/grizzly/testdata/__init__.py
@@ -2,9 +2,11 @@
 from __future__ import annotations
 
 from importlib import import_module
-from typing import TYPE_CHECKING, Any, Callable, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Callable
+
     from grizzly.context import GrizzlyContextScenario
     from grizzly.testdata.communication import GrizzlyDependencies
     from grizzly.types import GrizzlyVariableType
@@ -111,7 +113,7 @@ class GrizzlyVariables(dict):
 
     @classmethod
     def guess_datatype(cls, value: Any) -> GrizzlyVariableType:
-        if isinstance(value, (int, bool, float)) or (isinstance(value, str) and len(value) == 0):
+        if isinstance(value, int | bool | float) or (isinstance(value, str) and len(value) == 0):
             return value
 
         check_value = value.replace('.', '', 1)

--- a/grizzly/testdata/ast.py
+++ b/grizzly/testdata/ast.py
@@ -221,7 +221,7 @@ def _parse_templates(templates: dict[GrizzlyContextScenario, set[str]]) -> AstVa
         if isinstance(node, j2.Getattr):
             child_node = getattr(node, 'node', None)
             if child_node is not None:
-                if isinstance(child_node, (j2.Getattr, j2.Name)):
+                if isinstance(child_node, j2.Getattr | j2.Name):
                     attributes = walk_attr(node)
                 else:
                     yield from _getattr(child_node)
@@ -257,7 +257,7 @@ def _parse_templates(templates: dict[GrizzlyContextScenario, set[str]]) -> AstVa
             name = getattr(node, 'name', None)
             if name is not None:
                 attributes = [name]
-        elif isinstance(node, (j2.Filter, j2.UnaryExpr)):
+        elif isinstance(node, j2.Filter | j2.UnaryExpr):
             child_node = getattr(node, 'node', None)
             if child_node is not None:
                 yield from _getattr(child_node)
@@ -338,7 +338,7 @@ def _parse_templates(templates: dict[GrizzlyContextScenario, set[str]]) -> AstVa
         elif isinstance(node, j2.Output):
             for child_node in getattr(node, 'nodes', []):
                 yield from _getattr(child_node)
-        elif not isinstance(node, (j2.Const, j2.TemplateData, j2.For)):  # all unhandled AST nodes
+        elif not isinstance(node, j2.Const | j2.TemplateData | j2.For):  # all unhandled AST nodes
             logger.warning('unhandled AST node: %r', node)
 
         if attributes is not None:

--- a/grizzly/testdata/communication.py
+++ b/grizzly/testdata/communication.py
@@ -661,7 +661,7 @@ class TestdataProducer:
                 pop_value = self.keystore[key].pop(0)
 
                 # remove key if it was the last value
-                if len(self.keystore) < 1:
+                if len(self.keystore[key]) < 1:
                     response.update({'data': pop_value})
                     self._remove_key(key, response)
             except AttributeError:

--- a/grizzly/testdata/filters.py
+++ b/grizzly/testdata/filters.py
@@ -5,9 +5,12 @@ import json
 from ast import literal_eval as ast_literal_eval
 from base64 import b64decode as base64_b64decode
 from base64 import b64encode as base64_b64encode
-from typing import Any, Callable, NamedTuple, Optional, Union
+from typing import TYPE_CHECKING, Any, NamedTuple, Optional, Union
 
 from jinja2.filters import FILTERS
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class templatingfilter:

--- a/grizzly/testdata/variables/__init__.py
+++ b/grizzly/testdata/variables/__init__.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Generic, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, Optional, TypeVar
 
 from gevent.lock import DummySemaphore, Semaphore
 
@@ -22,6 +22,8 @@ T = TypeVar('T')
 
 
 if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Callable
+
     from grizzly.context import GrizzlyContext, GrizzlyContextScenario
     from grizzly.testdata.communication import GrizzlyDependencies
 

--- a/grizzly/testdata/variables/csv_writer.py
+++ b/grizzly/testdata/variables/csv_writer.py
@@ -219,7 +219,7 @@ class AtomicCsvWriter(AtomicVariable[str], AtomicVariableSettable):
             message = f'{self.__class__.__name__}.{variable}: {diff_text} values ({values_count}) than headers ({header_count})'
             raise ValueError(message)
 
-        buffer = dict(zip(headers, values))
+        buffer = dict(zip(headers, values, strict=False))
 
         # values for all headers set, flush to file
         data = {

--- a/grizzly/testdata/variables/random_string.py
+++ b/grizzly/testdata/variables/random_string.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 from contextlib import suppress
 from secrets import choice, randbelow
 from string import ascii_letters
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Optional, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, cast
 from uuid import uuid4
 
 from grizzly.types import bool_type, int_rounded_float_type
@@ -49,6 +49,8 @@ from grizzly_extras.text import has_separator
 from . import AtomicVariable
 
 if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Callable
+
     from grizzly.context import GrizzlyContextScenario
 
 

--- a/grizzly/types/__init__.py
+++ b/grizzly/types/__init__.py
@@ -1,12 +1,13 @@
 """Grizzly types."""
 from __future__ import annotations
 
+from collections.abc import Callable
 from enum import Enum, auto
-from typing import Any, Callable, Optional, TypeVar, Union, cast
+from typing import Any, Concatenate, Optional, TypeVar, Union, cast
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from locust.rpc.protocol import Message
-from typing_extensions import Concatenate, ParamSpec
+from typing_extensions import ParamSpec
 
 from grizzly.exceptions import RestartIteration, RestartScenario, RetryTask, StopUser
 from grizzly_extras.text import PermutationEnum

--- a/grizzly/types/behave.py
+++ b/grizzly/types/behave.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from functools import wraps
-from typing import Any, Callable, TypeVar, cast
+from typing import Any, TypeVar, cast
 
 import behave
 from behave.model import Feature, Row, Scenario, Status, Step, Table

--- a/grizzly/types/locust.py
+++ b/grizzly/types/locust.py
@@ -1,5 +1,6 @@
 """Locust types frequently used in grizzly."""
-from typing import Callable, Union
+from collections.abc import Callable
+from typing import Union
 
 from locust.env import Environment
 from locust.exception import CatchResponseError, LocustError, StopUser

--- a/grizzly/users/__init__.py
+++ b/grizzly/users/__init__.py
@@ -238,7 +238,7 @@ class GrizzlyUser(User, metaclass=GrizzlyUserMeta):
                 raise exception
 
             # execute response listeners, but not on these exceptions
-            if not isinstance(exception, (RestartScenario, StopUser, AsyncMessageError)):
+            if not isinstance(exception, RestartScenario | StopUser | AsyncMessageError):
                 try:
                     self.events.request.fire(
                         name=request.name,

--- a/grizzly/users/iothub.py
+++ b/grizzly/users/iothub.py
@@ -139,7 +139,7 @@ class MessageJsonSerializer(json.JSONEncoder):
         serialized_value: Any
         if isinstance(value, UUID):
             serialized_value = str(value)
-        elif isinstance(value, (bytes, bytearray)):
+        elif isinstance(value, bytes | bytearray):
             serialized_value = value.decode()
         else:
             serialized_value = super().default(value)

--- a/grizzly/users/iothub.py
+++ b/grizzly/users/iothub.py
@@ -278,6 +278,9 @@ class IotHubUser(GrizzlyUser):
         if self._scenario.user.fixed_count == 1:
             self.iot_client.on_message_received = self.message_handler
         else:
+            with suppress(Exception):
+                self.iot_client.on_message_received = self.noop_message_handler
+
             self.logger.warning(
                 'no handler for C2D messages registered, since there are %s users of type %s',
                 self._scenario.user.fixed_count,
@@ -291,6 +294,9 @@ class IotHubUser(GrizzlyUser):
         with suppress(Exception):
             self.iot_client.shutdown()
         super().on_stop()
+
+    def noop_message_handler(self, message: IotMessage) -> None:  # noqa: ARG002
+        return
 
     @event(events.user_event, tags={'type': 'iot::cloud-to-device'}, decoder=IotMessageDecoder(arg=1))  # 0 = self...
     def message_handler(self, message: IotMessage) -> None:

--- a/grizzly/users/restapi.py
+++ b/grizzly/users/restapi.py
@@ -331,7 +331,7 @@ class RestApiUser(GrizzlyUser, AsyncRequests, GrizzlyHttpAuthClient, metaclass=R
 
             headers = dict(response.headers.items()) if response.headers not in [None, {}] else None
             text = response.text
-            payload = text.decode() if isinstance(text, (bytearray, bytes)) else text
+            payload = text.decode() if isinstance(text, bytearray | bytes) else text
 
         exception = response.request_meta.get('exception', None)
 

--- a/grizzly/utils/protocols.py
+++ b/grizzly/utils/protocols.py
@@ -8,7 +8,7 @@ import re
 from datetime import datetime, timezone
 from http.cookiejar import Cookie
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Optional, Protocol, cast
+from typing import TYPE_CHECKING, Any, Optional, Protocol, cast
 from urllib.parse import urlparse
 
 from dateutil.parser import ParserError
@@ -19,6 +19,7 @@ from grizzly.utils import _print_table
 from grizzly_extras.async_message.utils import async_message_request
 
 if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Callable
     from http.cookiejar import CookieJar
 
     from zmq import sugar as ztypes

--- a/grizzly_extras/async_message/__init__.py
+++ b/grizzly_extras/async_message/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 import sys
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from datetime import datetime
 from json import dumps as jsondumps
 from os import environ
@@ -11,7 +12,7 @@ from pathlib import Path
 from platform import node as hostname
 from threading import Event
 from time import monotonic as time
-from typing import Any, Callable, Optional, TypedDict, final
+from typing import Any, Optional, TypedDict, final
 
 from grizzly_extras.transformer import JsonBytesEncoder
 

--- a/grizzly_extras/async_message/daemon.py
+++ b/grizzly_extras/async_message/daemon.py
@@ -12,13 +12,12 @@ from multiprocessing import Process
 from signal import SIGINT, SIGTERM, Signals, signal
 from threading import Event
 from time import sleep
-from typing import TYPE_CHECKING, Optional, Union, cast
+from typing import TYPE_CHECKING, Literal, Optional, Union, cast
 from urllib.parse import urlparse
 from uuid import uuid4
 
 import setproctitle as proc
 import zmq.green as zmq
-from typing_extensions import Literal
 from zmq import sugar as ztypes
 
 from grizzly_extras.transformer import JsonBytesEncoder

--- a/grizzly_extras/async_message/sb.py
+++ b/grizzly_extras/async_message/sb.py
@@ -2,10 +2,10 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from contextlib import suppress
 from time import perf_counter, sleep, time
-from typing import TYPE_CHECKING, Any, Callable, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Optional, Union, cast
 from urllib.parse import urlparse
 
 from azure.core.exceptions import ResourceExistsError, ResourceNotFoundError

--- a/grizzly_extras/async_message/utils.py
+++ b/grizzly_extras/async_message/utils.py
@@ -23,7 +23,7 @@ def tohex(value: Union[int, str, bytes, bytearray, Any]) -> str:
     if isinstance(value, str):
         return ''.join(f'{ord(c):02x}' for c in value)
 
-    if isinstance(value, (bytes, bytearray)):
+    if isinstance(value, bytes | bytearray):
         return value.hex()
 
     if isinstance(value, int):

--- a/grizzly_extras/novella.py
+++ b/grizzly_extras/novella.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from re import Match
 from token import NAME, OP, STRING
 from tokenize import TokenError, TokenInfo, tokenize
-from typing import TYPE_CHECKING, Any, Callable, NamedTuple, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, NamedTuple, Optional, Union, cast
 
 import frontmatter
 import mistune
@@ -28,7 +28,7 @@ from pydoc_markdown.contrib.renderers.markdown import MarkdownRenderer as PydocM
 from pydoc_markdown.novella.preprocessor import PydocTagPreprocessor
 
 if TYPE_CHECKING:  # pragma: no cover
-    from collections.abc import Generator
+    from collections.abc import Callable, Generator
 
     from novella.markdown.tags.anchor import AnchorTagProcessor
     from novella.novella import NovellaContext

--- a/grizzly_extras/queue.py
+++ b/grizzly_extras/queue.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 from collections import deque
 from contextlib import suppress
 from time import perf_counter
-from typing import TYPE_CHECKING, Callable, TypeVar
+from typing import TYPE_CHECKING, TypeVar
 from unittest.mock import ANY
 
 if TYPE_CHECKING:  # pragma: no cover
-    from collections.abc import Iterable
+    from collections.abc import Callable, Iterable
 
 T = TypeVar('T')
 

--- a/grizzly_extras/text.py
+++ b/grizzly_extras/text.py
@@ -8,10 +8,13 @@ from contextlib import suppress
 from enum import Enum, EnumMeta
 from json import JSONDecodeError
 from json import loads as jsonloads
-from typing import Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from dateutil.parser import ParserError
 from dateutil.parser import parse as date_parse
+
+if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Callable
 
 
 class permutation:

--- a/grizzly_extras/transformer.py
+++ b/grizzly_extras/transformer.py
@@ -10,12 +10,15 @@ from functools import wraps
 from json import JSONEncoder
 from json import dumps as jsondumps
 from json import loads as jsonloads
-from typing import Any, Callable, ClassVar, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, Union, cast
 
 from jsonpath_ng.ext import parse as jsonpath_parse
 from lxml import etree as XML  # noqa: N812
 
 from .text import PermutationEnum, caster
+
+if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Callable
 
 
 class TransformerError(Exception):
@@ -247,7 +250,7 @@ class JsonTransformer(Transformer):
                     if m is None or m.value is None:
                         continue
 
-                    value = jsondumps(m.value) if isinstance(m.value, (dict, list)) else str(m.value)
+                    value = jsondumps(m.value) if isinstance(m.value, dict | list) else str(m.value)
 
                     if expected is None or (assertion is not None and assertion(value, expected)):
                         values.append(value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 license = {text = 'MIT'}
 requires-python = ">=3.9"
 dependencies = [
-    "locust ==2.33.2",
+    "locust ==2.37.3",
     "azure-core ==1.30.1",
     "azure-servicebus ==7.12.1",
     "azure-storage-blob ==12.19.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 readme = "README.md"
 license = {text = 'MIT'}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "locust ==2.37.3",
     "azure-core ==1.30.1",
@@ -40,7 +40,6 @@ classifiers = [
     "Natural Language :: English",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/tests/e2e/test_example.py
+++ b/tests/e2e/test_example.py
@@ -68,6 +68,7 @@ def test_e2e_example(e2e_fixture: End2EndFixture) -> None:  # noqa: PLR0915
     assert code == 0
 
     try:
+        assert 'Exception ignored in' not in result
         assert 'ERROR' not in result
         assert 'WARNING' not in result
         assert '1 feature passed, 0 failed, 0 skipped' in result

--- a/tests/e2e/test_keystore.py
+++ b/tests/e2e/test_keystore.py
@@ -64,6 +64,7 @@ def test_e2e_keystore(e2e_fixture: End2EndFixture) -> None:
 
     result = ''.join(output)
 
+    assert 'Exception ignored in' not in result
     assert "key_holder_1={'hello': 'world'}" in result
     assert "key_holder_2=hello, key_holder_3={'hello': 'world'}" in result
     assert "foobar_push: 10, 20, 30" in result

--- a/tests/e2e/test_persistence.py
+++ b/tests/e2e/test_persistence.py
@@ -79,6 +79,7 @@ def test_e2e_persistence(e2e_fixture: End2EndFixture) -> None:
     result = ''.join(output)
 
     assert rc == 0
+    assert 'Exception ignored in' not in result
     assert 'persistent=3' in result
     assert "foobar=['hello', '3']" in result
     assert 'persistent=4' in result

--- a/tests/e2e/test_variables.py
+++ b/tests/e2e/test_variables.py
@@ -84,6 +84,7 @@ def test_e2e_variables_atomic_json_reader(e2e_fixture: End2EndFixture) -> None:
 
     result = ''.join(output)
 
+    assert 'Exception ignored in' not in result
     assert 'object={"password": "some-password", "username": "bob1"}' in result
     assert 'object.username=bob1' in result
     assert 'object.password=some-password' in result

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -12,7 +12,7 @@ from os import chdir, environ
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from textwrap import dedent, indent
-from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, cast
+from typing import TYPE_CHECKING, Any, Literal, Optional, cast
 from urllib.parse import urlparse
 
 import yaml
@@ -40,6 +40,7 @@ from grizzly.utils import create_scenario_class_type, create_user_class_type
 from .helpers import TestScenario, TestUser, rm_rf, run_command
 
 if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Callable
     from types import TracebackType
     from unittest.mock import MagicMock
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from re import Pattern
 from shutil import rmtree
 from types import MethodType, TracebackType
-from typing import TYPE_CHECKING, Any, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 from unittest.mock import MagicMock
 from uuid import UUID
 
@@ -32,7 +32,7 @@ from grizzly.types.locust import Environment, Message
 from grizzly.users import GrizzlyUser
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Callable, Generator
 
 
 class AtomicCustomVariable(AtomicVariable[str]):
@@ -254,11 +254,9 @@ def get_property_decorated_attributes(target: Any) -> set[str]:
             for name, _ in inspect.getmembers(
                 target,
                 lambda p: isinstance(
-                    p,
-                    (property, MethodType),
+                    p, property | MethodType,
                 ) and not isinstance(
-                    p,
-                    (classmethod, MethodType),  # @classmethod anotated methods becomes @property
+                    p, classmethod | MethodType,  # @classmethod anotated methods becomes @property
                 )) if not name.startswith('_')
     }
 
@@ -355,7 +353,7 @@ def tree(dir_path: Path, prefix: str = '', ignore: Optional[list[str]] = None) -
     contents = sorted(dir_path.iterdir())
     # contents each get pointers that are ├── with a final └── :
     pointers = [tee] * (len(contents) - 1) + [last]
-    for pointer, sub_path in zip(pointers, contents):
+    for pointer, sub_path in zip(pointers, contents, strict=False):
         if ignore is None or sub_path.name not in ignore:
             yield prefix + pointer + sub_path.name
             if sub_path.is_dir():  # extend the prefix and recurse:

--- a/tests/unit/test_grizzly/events/test_request_logger.py
+++ b/tests/unit/test_grizzly/events/test_request_logger.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from contextlib import suppress
 from os import environ
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -15,6 +15,8 @@ from grizzly.users import GrizzlyUser
 from tests.helpers import rm_rf
 
 if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Callable
+
     from tests.fixtures import GrizzlyFixture
 
 

--- a/tests/unit/test_grizzly/events/test_response_handler.py
+++ b/tests/unit/test_grizzly/events/test_response_handler.py
@@ -7,7 +7,7 @@ from json import dumps as jsondumps
 from json import loads as jsonloads
 from os import environ
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 import pytest
 from jinja2.filters import FILTERS
@@ -25,6 +25,8 @@ from grizzly_extras.transformer import TransformerContentType
 from tests.helpers import ANY, JSON_EXAMPLE, TestUser
 
 if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Callable
+
     from pytest_mock import MockerFixture
 
     from tests.fixtures import GrizzlyFixture

--- a/tests/unit/test_grizzly/listeners/test___init__.py
+++ b/tests/unit/test_grizzly/listeners/test___init__.py
@@ -2,9 +2,10 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from os import environ
 from secrets import choice
-from typing import TYPE_CHECKING, Any, Callable, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 import pytest
 from locust.runners import STATE_RUNNING, WorkerNode

--- a/tests/unit/test_grizzly/listeners/test_appinsights.py
+++ b/tests/unit/test_grizzly/listeners/test_appinsights.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import pytest
 
@@ -10,6 +10,8 @@ from grizzly.listeners.appinsights import ApplicationInsightsListener
 from grizzly.types.locust import CatchResponseError
 
 if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Callable
+
     from _pytest.logging import LogCaptureFixture
     from pytest_mock import MockerFixture
 

--- a/tests/unit/test_grizzly/listeners/test_influxdb.py
+++ b/tests/unit/test_grizzly/listeners/test_influxdb.py
@@ -7,7 +7,7 @@ import socket
 from datetime import datetime, timezone
 from json import dumps as jsondumps
 from platform import node as get_hostname
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Optional
 from unittest.mock import patch
 
 import pytest
@@ -21,6 +21,8 @@ from grizzly.types.locust import CatchResponseError
 from tests.helpers import ANY, SOME
 
 if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Callable
+
     from _pytest.logging import LogCaptureFixture
     from influxdb_client import InfluxDBClient  # type: ignore[attr-defined]
     from pytest_mock import MockerFixture

--- a/tests/unit/test_grizzly/scenarios/test_iterator.py
+++ b/tests/unit/test_grizzly/scenarios/test_iterator.py
@@ -841,7 +841,7 @@ class TestIterationScenario:
 
         assert len(actual_messages) == len(expected_messages)
 
-        for actual, _expected in zip(actual_messages, expected_messages):
+        for actual, _expected in zip(actual_messages, expected_messages, strict=False):
             expected = regex.possible(_expected)
             assert actual == expected
 
@@ -953,7 +953,7 @@ class TestIterationScenario:
 
             assert len(actual_messages) == len(expected_messages)
 
-            for actual, _expected in zip(actual_messages, expected_messages):
+            for actual, _expected in zip(actual_messages, expected_messages, strict=False):
                 expected = regex.possible(_expected)
                 assert actual == expected
 
@@ -1066,7 +1066,7 @@ class TestIterationScenario:
 
             assert len(actual_messages) == len(expected_messages)
 
-            for actual, _expected in zip(actual_messages, expected_messages):
+            for actual, _expected in zip(actual_messages, expected_messages, strict=False):
                 expected = regex.possible(_expected)
                 assert actual == expected
 

--- a/tests/unit/test_grizzly/steps/scenario/test_response.py
+++ b/tests/unit/test_grizzly/steps/scenario/test_response.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from itertools import product
-from typing import TYPE_CHECKING, Callable, Union, cast
+from typing import TYPE_CHECKING, Union, cast
 
 import pytest
 from parse import compile
@@ -17,6 +17,8 @@ from grizzly_extras.transformer import TransformerContentType
 from tests.helpers import ANY
 
 if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Callable
+
     from tests.fixtures import BehaveFixture, GrizzlyFixture
 
 

--- a/tests/unit/test_grizzly/test_locust_dispatch.py
+++ b/tests/unit/test_grizzly/test_locust_dispatch.py
@@ -3774,10 +3774,10 @@ class TestRampUpUsersFromZeroWithFixed(UsersDispatcherTestCase):
             fixed_users = user_classes[: len(case.fixed_counts)]
             weighted_users_list = user_classes[len(case.fixed_counts) :]
 
-            for user, fixed_count in zip(fixed_users, case.fixed_counts):
+            for user, fixed_count in zip(fixed_users, case.fixed_counts, strict=False):
                 user.fixed_count = fixed_count
 
-            for user, weight in zip(weighted_users_list, case.weights):
+            for user, weight in zip(weighted_users_list, case.weights, strict=False):
                 user.weight = weight
 
             worker_node1 = WorkerNode("1")

--- a/tests/unit/test_grizzly/testdata/test_communication.py
+++ b/tests/unit/test_grizzly/testdata/test_communication.py
@@ -1165,7 +1165,8 @@ value3,value4
             response = request_keystore('pop', 'foobar')
 
             assert response == {'message': 'keystore', 'action': 'pop', 'data': 'foobaz', 'identifier': grizzly.scenario.class_name, 'key': 'foobar'}
-            assert grizzly.state.producer.keystore['foobar'] == []
+            with pytest.raises(KeyError):
+                grizzly.state.producer.keystore['foobar']
 
             response = request_keystore('pop', 'foobar')
 
@@ -1173,6 +1174,7 @@ value3,value4
             # // pop -->
 
             # <!-- del
+            grizzly.state.producer.keystore.update({'foobar': 'barfoo'})
             assert 'foobar' in grizzly.state.producer.keystore
 
             response = request_keystore('del', 'foobar', 'dummy')

--- a/tests/unit/test_grizzly/testdata/test_communication.py
+++ b/tests/unit/test_grizzly/testdata/test_communication.py
@@ -7,7 +7,7 @@ from contextlib import suppress
 from datetime import datetime, timedelta, timezone
 from os import environ, sep
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, cast
+from typing import TYPE_CHECKING, Any, Literal, Optional, cast
 from uuid import uuid4
 
 import pytest
@@ -23,6 +23,7 @@ from grizzly.types.locust import Environment, LocalRunner, MasterRunner, Message
 from tests.helpers import ANY, ANYUUID, SOME
 
 if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Callable
     from unittest.mock import MagicMock
 
     from _pytest.logging import LogCaptureFixture

--- a/tests/unit/test_grizzly/users/test_restapi.py
+++ b/tests/unit/test_grizzly/users/test_restapi.py
@@ -5,7 +5,7 @@ import json
 from contextlib import suppress
 from hashlib import sha256
 from time import time
-from typing import TYPE_CHECKING, Any, Callable, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import gevent
 import pytest
@@ -24,6 +24,8 @@ from grizzly_extras.transformer import TransformerContentType
 from tests.helpers import ANY, SOME, create_mocked_fast_response_context_manager
 
 if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Callable
+
     from _pytest.logging import LogCaptureFixture
 
     from tests.fixtures import GrizzlyFixture, MockerFixture

--- a/tests/unit/test_grizzly/users/test_servicebus.py
+++ b/tests/unit/test_grizzly/users/test_servicebus.py
@@ -39,7 +39,7 @@ class TestServiceBusUser:
 
         test_cls.host = 'Endpoint=sb://sb.example.org/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc123def456ghi789='
         user = test_cls(environment=behave_fixture.locust.environment)
-        assert issubclass(user.__class__, (GrizzlyUser, ServiceBusUser))
+        assert issubclass(user.__class__, GrizzlyUser | ServiceBusUser)
 
         user.on_start()
 

--- a/tests/unit/test_grizzly/utils/test___init__.py
+++ b/tests/unit/test_grizzly/utils/test___init__.py
@@ -119,7 +119,7 @@ def test_create_user_class_type(behave_fixture: BehaveFixture) -> None:  # noqa:
     user_class_type_1 = create_user_class_type(scenario)
     user_class_type_1.host = 'http://localhost:8000'
 
-    assert issubclass(user_class_type_1, (RestApiUser, GrizzlyUser))
+    assert issubclass(user_class_type_1, RestApiUser | GrizzlyUser)
     user_class_type_1 = cast(type[RestApiUser], user_class_type_1)
     assert user_class_type_1.__name__ == f'grizzly.users.RestApiUser_{scenario.identifier}'
     assert user_class_type_1.weight == 1
@@ -220,7 +220,7 @@ def test_create_user_class_type(behave_fixture: BehaveFixture) -> None:  # noqa:
     )
     user_class_type_2.host = 'http://localhost:8001'
 
-    assert issubclass(user_class_type_2, (RestApiUser, GrizzlyUser))
+    assert issubclass(user_class_type_2, RestApiUser | GrizzlyUser)
     user_class_type_2 = cast(type[RestApiUser], user_class_type_2)
     assert user_class_type_2.__name__ == f'RestApiUser_{scenario.identifier}'
     assert user_class_type_2.weight == 1
@@ -311,7 +311,7 @@ def test_create_user_class_type(behave_fixture: BehaveFixture) -> None:  # noqa:
     user_class_type_3 = create_user_class_type(scenario, {'test': {'value': 1}})
     user_class_type_3.host = 'http://localhost:8002'
 
-    assert issubclass(user_class_type_3, (RestApiUser, GrizzlyUser))
+    assert issubclass(user_class_type_3, RestApiUser | GrizzlyUser)
     assert user_class_type_3.__name__ == f'RestApiUser_{scenario.identifier}'
     assert user_class_type_3.weight == 1
     assert user_class_type_3.fixed_count == 0
@@ -356,7 +356,7 @@ def test_create_user_class_type(behave_fixture: BehaveFixture) -> None:  # noqa:
     user_class_type_3 = create_user_class_type(scenario, {'test': {'value': 1}}, fixed_count=10)
     user_class_type_3.host = 'http://localhost:8002'
 
-    assert issubclass(user_class_type_3, (RestApiUser, GrizzlyUser))
+    assert issubclass(user_class_type_3, RestApiUser | GrizzlyUser)
     assert user_class_type_3.__name__ == f'RestApiUser_{scenario.identifier}'
     assert user_class_type_3.weight == 1
     assert user_class_type_3.fixed_count == 10
@@ -410,7 +410,7 @@ def test_create_scenario_class_type(behave_fixture: BehaveFixture) -> None:
 
     task_class_type_1 = create_scenario_class_type('grizzly.scenarios.IteratorScenario', scenario)
 
-    assert issubclass(task_class_type_1, (IteratorScenario, TaskSet))
+    assert issubclass(task_class_type_1, IteratorScenario | TaskSet)
     assert task_class_type_1.__name__ == 'IteratorScenario_001'
     assert task_class_type_1.__module__ == 'grizzly.scenarios.iterator'
     assert getattr(task_class_type_1, 'pace_time', '') is None
@@ -423,7 +423,7 @@ def test_create_scenario_class_type(behave_fixture: BehaveFixture) -> None:
     scenario = GrizzlyContextScenario(2, behave=behave_fixture.create_scenario('TestTestTest'), grizzly=behave_fixture.grizzly)
     scenario.pace = '2000'
     task_class_type_2 = create_scenario_class_type('IteratorScenario', scenario)
-    assert issubclass(task_class_type_2, (IteratorScenario, TaskSet))
+    assert issubclass(task_class_type_2, IteratorScenario | TaskSet)
     assert task_class_type_2.__name__ == 'IteratorScenario_002'
     assert task_class_type_2.__module__ == 'grizzly.scenarios.iterator'
     assert getattr(task_class_type_2, 'pace_time', '') == '2000'

--- a/tests/unit/test_grizzly_extras/test_transformer.py
+++ b/tests/unit/test_grizzly_extras/test_transformer.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta, timezone
 from json import dumps as jsondumps
 from json import loads as jsonloads
 from json.decoder import JSONDecodeError
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 import pytest
 from lxml import etree as XML  # noqa: N812
@@ -22,6 +22,8 @@ from grizzly_extras.transformer import (
 from tests.helpers import JSON_EXAMPLE
 
 if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Callable
+
     from pytest_mock import MockerFixture
 
 


### PR DESCRIPTION
needed to get a better constraint for `gevent` dependency.
`gevent>=25.5.1` causes loose "Exception ignored in" thrown around.

also fixes bug where when the last (list) key for a value is popped, the key itself should be removed. this was never done before this fix, as long as there where other keys in the keystore.

as an extra precation, add a noop message handler for `IotHubUser` if the number of fixed users are greater than 1.