### PR TITLE
HttpClientTask: paths to client cert and key should be relative to context root

### DIFF
--- a/grizzly/tasks/clients/http.py
+++ b/grizzly/tasks/clients/http.py
@@ -138,6 +138,9 @@ class HttpClientTask(ClientTask, GrizzlyHttpAuthClient):
             client_key = None
 
         if client_cert is not None and client_key is not None:
+            client_cert = (Path(self._context_root) / client_cert).resolve()
+            client_key = (Path(self._context_root) / client_key).resolve()
+
             if not Path(client_cert).exists() or not Path(client_key).exists():
                 message = f'either {client_cert} or {client_key} does not exist'
                 raise ValueError(message)

--- a/tests/unit/test_grizzly/tasks/clients/test_http.py
+++ b/tests/unit/test_grizzly/tasks/clients/test_http.py
@@ -35,7 +35,7 @@ class TestHttpClientTask:
         grizzly.scenario.variables.update({'test_payload': 'none', 'test_metadata': 'none'})
 
         HttpClientTask.__scenario__ = grizzly.scenario
-        with pytest.raises(ValueError, match='either hello.crt or hello.key does not exist'):
+        with pytest.raises(ValueError, match='either .* or .* does not exist'):
             HttpClientTask(
                 RequestDirection.FROM,
                 'http://example.org | timeout=1800, client_cert=hello.crt, client_key=hello.key',


### PR DESCRIPTION
same as RestApiUser.