### PR TITLE
cleaner logging for testdata and more ambigous keys for keystore errors

### DIFF
--- a/grizzly/scenarios/__init__.py
+++ b/grizzly/scenarios/__init__.py
@@ -88,6 +88,9 @@ class GrizzlyScenario(SequentialTaskSet):
         """When test start the testdata producer should be started, and if the implementing scenario
         has some prefetching todo it must also be one. There might be cases where an on_start method
         needs the first iteration of testdata.
+
+        There should be one `TestdataConsumer` per scenario type, which means that all users on the
+        same worker will share the same instance.
         """
         if self.__class__._consumer is None:
             self.__class__._consumer = TestdataConsumer(

--- a/grizzly/testdata/communication.py
+++ b/grizzly/testdata/communication.py
@@ -330,6 +330,7 @@ class TestdataConsumer:
         self.stopped = False
 
         self.response = {}
+        self.logger = logging.getLogger(f'{scenario.__class__.__name__}/testdata')
         self.logger.debug('started consumer')
 
         self.async_timers = AsyncTimersConsumer(scenario, self.semaphore)
@@ -341,9 +342,6 @@ class TestdataConsumer:
 
         cls._responses[uid].set(response)
 
-    @property
-    def logger(self) -> logging.Logger:
-        return self.scenario.user.logger
 
     @event(events.testdata_request, tags={'type': 'consumer'}, decoder=TestdataDecoder(arg='request'))
     def _testdata_request(self, *, request: dict[str, Any]) -> dict[str, Any] | None:


### PR DESCRIPTION
own identity for TestdataConsumer logger, to avoid confusion, since it's shared between all user instances of the same type running on the same worker.

needed more ambigous keys for better failure summary summarization.